### PR TITLE
Use actual lifetimes instead of 'static for the `acc`, `acc_mut` and `str` functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ emscripten/target
 emscripten/Cargo.lock
 js/livesplit.js
 Cargo.lock
-**.rs.bk
+*.rs.bk

--- a/capi/src/atomic_date_time.rs
+++ b/capi/src/atomic_date_time.rs
@@ -12,15 +12,15 @@ pub unsafe extern "C" fn AtomicDateTime_drop(this: OwnedAtomicDateTime) {
 
 #[no_mangle]
 pub unsafe extern "C" fn AtomicDateTime_is_synchronized(this: *const AtomicDateTime) -> bool {
-    acc(this).synced_with_atomic_clock
+    acc(&this).synced_with_atomic_clock
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn AtomicDateTime_to_rfc2822(this: *const AtomicDateTime) -> *const c_char {
-    output_str(acc(this).time.to_rfc2822())
+    output_str(acc(&this).time.to_rfc2822())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn AtomicDateTime_to_rfc3339(this: *const AtomicDateTime) -> *const c_char {
-    output_str(acc(this).time.to_rfc3339())
+    output_str(acc(&this).time.to_rfc3339())
 }

--- a/capi/src/attempt.rs
+++ b/capi/src/attempt.rs
@@ -8,17 +8,17 @@ pub type OwnedAttempt = *mut Attempt;
 
 #[no_mangle]
 pub unsafe extern "C" fn Attempt_index(this: *const Attempt) -> i32 {
-    acc(this).index()
+    acc(&this).index()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Attempt_time(this: *const Attempt) -> *const Time {
-    output_time(acc(this).time())
+    output_time(acc(&this).time())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Attempt_pause_time(this: *const Attempt) -> *const NullableTimeSpan {
-    if let Some(pause_time) = acc(this).pause_time() {
+    if let Some(pause_time) = acc(&this).pause_time() {
         output_time_span(pause_time)
     } else {
         ptr::null()
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn Attempt_pause_time(this: *const Attempt) -> *const Null
 
 #[no_mangle]
 pub unsafe extern "C" fn Attempt_started(this: *const Attempt) -> NullableOwnedAtomicDateTime {
-    if let Some(date_time) = acc(this).started() {
+    if let Some(date_time) = acc(&this).started() {
         alloc(date_time)
     } else {
         ptr::null_mut()
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn Attempt_started(this: *const Attempt) -> NullableOwnedA
 
 #[no_mangle]
 pub unsafe extern "C" fn Attempt_ended(this: *const Attempt) -> NullableOwnedAtomicDateTime {
-    if let Some(date_time) = acc(this).ended() {
+    if let Some(date_time) = acc(&this).ended() {
         alloc(date_time)
     } else {
         ptr::null_mut()

--- a/capi/src/blank_space_component.rs
+++ b/capi/src/blank_space_component.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn BlankSpaceComponent_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
@@ -38,5 +38,5 @@ pub unsafe extern "C" fn BlankSpaceComponent_state(
     this: *mut BlankSpaceComponent,
     timer: *const Timer,
 ) -> OwnedBlankSpaceComponentState {
-    alloc(acc_mut(this).state(acc(timer)))
+    alloc(acc_mut(&this).state(acc(&timer)))
 }

--- a/capi/src/blank_space_component_state.rs
+++ b/capi/src/blank_space_component_state.rs
@@ -12,5 +12,5 @@ pub unsafe extern "C" fn BlankSpaceComponentState_drop(this: OwnedBlankSpaceComp
 pub unsafe extern "C" fn BlankSpaceComponentState_height(
     this: *const BlankSpaceComponentState,
 ) -> u32 {
-    acc(this).height
+    acc(&this).height
 }

--- a/capi/src/current_comparison_component.rs
+++ b/capi/src/current_comparison_component.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn CurrentComparisonComponent_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
@@ -38,5 +38,5 @@ pub unsafe extern "C" fn CurrentComparisonComponent_state(
     this: *mut CurrentComparisonComponent,
     timer: *const Timer,
 ) -> OwnedCurrentComparisonComponentState {
-    alloc(acc_mut(this).state(acc(timer)))
+    alloc(acc_mut(&this).state(acc(&timer)))
 }

--- a/capi/src/current_comparison_component_state.rs
+++ b/capi/src/current_comparison_component_state.rs
@@ -15,12 +15,12 @@ pub unsafe extern "C" fn CurrentComparisonComponentState_drop(
 pub unsafe extern "C" fn CurrentComparisonComponentState_text(
     this: *const CurrentComparisonComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn CurrentComparisonComponentState_comparison(
     this: *const CurrentComparisonComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).comparison)
+    output_str(&acc(&this).comparison)
 }

--- a/capi/src/current_pace_component.rs
+++ b/capi/src/current_pace_component.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn CurrentPaceComponent_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
@@ -38,5 +38,5 @@ pub unsafe extern "C" fn CurrentPaceComponent_state(
     this: *mut CurrentPaceComponent,
     timer: *const Timer,
 ) -> OwnedCurrentPaceComponentState {
-    alloc(acc_mut(this).state(acc(timer)))
+    alloc(acc_mut(&this).state(acc(&timer)))
 }

--- a/capi/src/current_pace_component_state.rs
+++ b/capi/src/current_pace_component_state.rs
@@ -13,12 +13,12 @@ pub unsafe extern "C" fn CurrentPaceComponentState_drop(this: OwnedCurrentPaceCo
 pub unsafe extern "C" fn CurrentPaceComponentState_text(
     this: *const CurrentPaceComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn CurrentPaceComponentState_time(
     this: *const CurrentPaceComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }

--- a/capi/src/delta_component.rs
+++ b/capi/src/delta_component.rs
@@ -28,8 +28,8 @@ pub unsafe extern "C" fn DeltaComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this)
-            .state(acc(timer), acc(layout_settings))
+        acc_mut(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -41,5 +41,5 @@ pub unsafe extern "C" fn DeltaComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedDeltaComponentState {
-    alloc(acc_mut(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc_mut(&this).state(acc(&timer), acc(&layout_settings)))
 }

--- a/capi/src/delta_component_state.rs
+++ b/capi/src/delta_component_state.rs
@@ -14,19 +14,19 @@ pub unsafe extern "C" fn DeltaComponentState_drop(this: OwnedDeltaComponentState
 pub unsafe extern "C" fn DeltaComponentState_text(
     this: *const DeltaComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn DeltaComponentState_time(
     this: *const DeltaComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn DeltaComponentState_semantic_color(
     this: *const DeltaComponentState,
 ) -> *const c_char {
-    output_str_with(|f| write!(f, "{:?}", acc(this).semantic_color).unwrap())
+    output_str_with(|f| write!(f, "{:?}", acc(&this).semantic_color).unwrap())
 }

--- a/capi/src/detailed_timer_component.rs
+++ b/capi/src/detailed_timer_component.rs
@@ -30,8 +30,8 @@ pub unsafe extern "C" fn DetailedTimerComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this)
-            .state(acc(timer), acc(layout_settings))
+        acc_mut(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -43,5 +43,5 @@ pub unsafe extern "C" fn DetailedTimerComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedDetailedTimerComponentState {
-    alloc(acc_mut(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc_mut(&this).state(acc(&timer), acc(&layout_settings)))
 }

--- a/capi/src/detailed_timer_component_state.rs
+++ b/capi/src/detailed_timer_component_state.rs
@@ -15,14 +15,14 @@ pub unsafe extern "C" fn DetailedTimerComponentState_drop(this: OwnedDetailedTim
 pub unsafe extern "C" fn DetailedTimerComponentState_timer_time(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).timer.time)
+    output_str(&acc(&this).timer.time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn DetailedTimerComponentState_timer_fraction(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).timer.fraction)
+    output_str(&acc(&this).timer.fraction)
 }
 
 #[no_mangle]
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_timer_semantic_color(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
     output_str_with(|f| {
-        write!(f, "{:?}", acc(this).timer.semantic_color).unwrap()
+        write!(f, "{:?}", acc(&this).timer.semantic_color).unwrap()
     })
 }
 
@@ -38,21 +38,21 @@ pub unsafe extern "C" fn DetailedTimerComponentState_timer_semantic_color(
 pub unsafe extern "C" fn DetailedTimerComponentState_segment_timer_time(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).segment_timer.time)
+    output_str(&acc(&this).segment_timer.time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn DetailedTimerComponentState_segment_timer_fraction(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).segment_timer.fraction)
+    output_str(&acc(&this).segment_timer.fraction)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn DetailedTimerComponentState_comparison1_visible(
     this: *const DetailedTimerComponentState,
 ) -> bool {
-    acc(this).comparison1.is_some()
+    acc(&this).comparison1.is_some()
 }
 
 #[no_mangle]
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison1_name(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
     output_str(
-        &acc(this)
+        &acc(&this)
             .comparison1
             .as_ref()
             .expect("Comparison 1 is not visible")
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison1_time(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
     output_str(
-        &acc(this)
+        &acc(&this)
             .comparison1
             .as_ref()
             .expect("Comparison 1 is not visible")
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison1_time(
 pub unsafe extern "C" fn DetailedTimerComponentState_comparison2_visible(
     this: *const DetailedTimerComponentState,
 ) -> bool {
-    acc(this).comparison2.is_some()
+    acc(&this).comparison2.is_some()
 }
 
 #[no_mangle]
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison2_name(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
     output_str(
-        &acc(this)
+        &acc(&this)
             .comparison2
             .as_ref()
             .expect("Comparison 2 is not visible")
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison2_time(
     this: *const DetailedTimerComponentState,
 ) -> *const c_char {
     output_str(
-        &acc(this)
+        &acc(&this)
             .comparison2
             .as_ref()
             .expect("Comparison 2 is not visible")
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_comparison2_time(
 pub unsafe extern "C" fn DetailedTimerComponentState_icon_change(
     this: *const DetailedTimerComponentState,
 ) -> *const Nullablec_char {
-    acc(this)
+    acc(&this)
         .icon_change
         .as_ref()
         .map_or_else(ptr::null, output_str)
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn DetailedTimerComponentState_icon_change(
 pub unsafe extern "C" fn DetailedTimerComponentState_name(
     this: *const DetailedTimerComponentState,
 ) -> *const Nullablec_char {
-    acc(this)
+    acc(&this)
         .segment_name
         .as_ref()
         .map_or_else(ptr::null, output_str)

--- a/capi/src/graph_component.rs
+++ b/capi/src/graph_component.rs
@@ -28,8 +28,8 @@ pub unsafe extern "C" fn GraphComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc(this)
-            .state(acc(timer), acc(layout_settings))
+        acc(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -41,5 +41,5 @@ pub unsafe extern "C" fn GraphComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedGraphComponentState {
-    alloc(acc(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc(&this).state(acc(&timer), acc(&layout_settings)))
 }

--- a/capi/src/graph_component_state.rs
+++ b/capi/src/graph_component_state.rs
@@ -10,7 +10,7 @@ pub unsafe extern "C" fn GraphComponentState_drop(this: OwnedGraphComponentState
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_points_len(this: *const GraphComponentState) -> usize {
-    acc(this).points.len()
+    acc(&this).points.len()
 }
 
 #[no_mangle]
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn GraphComponentState_point_x(
     this: *const GraphComponentState,
     index: usize,
 ) -> f32 {
-    acc(this).points[index].x
+    acc(&this).points[index].x
 }
 
 #[no_mangle]
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn GraphComponentState_point_y(
     this: *const GraphComponentState,
     index: usize,
 ) -> f32 {
-    acc(this).points[index].y
+    acc(&this).points[index].y
 }
 
 #[no_mangle]
@@ -34,14 +34,14 @@ pub unsafe extern "C" fn GraphComponentState_point_is_best_segment(
     this: *const GraphComponentState,
     index: usize,
 ) -> bool {
-    acc(this).points[index].is_best_segment
+    acc(&this).points[index].is_best_segment
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_horizontal_grid_lines_len(
     this: *const GraphComponentState,
 ) -> usize {
-    acc(this).horizontal_grid_lines.len()
+    acc(&this).horizontal_grid_lines.len()
 }
 
 #[no_mangle]
@@ -49,14 +49,14 @@ pub unsafe extern "C" fn GraphComponentState_horizontal_grid_line(
     this: *const GraphComponentState,
     index: usize,
 ) -> f32 {
-    acc(this).horizontal_grid_lines[index]
+    acc(&this).horizontal_grid_lines[index]
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_vertical_grid_lines_len(
     this: *const GraphComponentState,
 ) -> usize {
-    acc(this).vertical_grid_lines.len()
+    acc(&this).vertical_grid_lines.len()
 }
 
 #[no_mangle]
@@ -64,22 +64,22 @@ pub unsafe extern "C" fn GraphComponentState_vertical_grid_line(
     this: *const GraphComponentState,
     index: usize,
 ) -> f32 {
-    acc(this).vertical_grid_lines[index]
+    acc(&this).vertical_grid_lines[index]
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_middle(this: *const GraphComponentState) -> f32 {
-    acc(this).middle
+    acc(&this).middle
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_is_live_delta_active(
     this: *const GraphComponentState,
 ) -> bool {
-    acc(this).is_live_delta_active
+    acc(&this).is_live_delta_active
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GraphComponentState_is_flipped(this: *const GraphComponentState) -> bool {
-    acc(this).is_flipped
+    acc(&this).is_flipped
 }

--- a/capi/src/layout.rs
+++ b/capi/src/layout.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn Layout_drop(this: OwnedLayout) {
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_clone(this: *const Layout) -> OwnedLayout {
-    alloc(acc(this).clone())
+    alloc(acc(&this).clone())
 }
 
 #[no_mangle]
@@ -41,31 +41,31 @@ pub unsafe extern "C" fn Layout_parse_json(settings: Json) -> NullableOwnedLayou
 #[no_mangle]
 pub unsafe extern "C" fn Layout_state_as_json(this: *mut Layout, timer: *const Timer) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_settings_as_json(this: *const Layout) -> Json {
-    output_vec(|o| { acc(this).settings().write_json(o).unwrap(); })
+    output_vec(|o| { acc(&this).settings().write_json(o).unwrap(); })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_push(this: *mut Layout, component: OwnedComponent) {
-    acc_mut(this).push(own(component));
+    acc_mut(&this).push(own(component));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_scroll_up(this: *mut Layout) {
-    acc_mut(this).scroll_up();
+    acc_mut(&this).scroll_up();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_scroll_down(this: *mut Layout) {
-    acc_mut(this).scroll_down();
+    acc_mut(&this).scroll_down();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_remount(this: *mut Layout) {
-    acc_mut(this).remount();
+    acc_mut(&this).remount();
 }

--- a/capi/src/layout.rs
+++ b/capi/src/layout.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn Layout_clone(this: *const Layout) -> OwnedLayout {
 
 #[no_mangle]
 pub unsafe extern "C" fn Layout_parse_json(settings: Json) -> NullableOwnedLayout {
-    let settings = Cursor::new(str(settings).as_bytes());
+    let settings = Cursor::new(str(&settings).as_bytes());
     if let Ok(settings) = LayoutSettings::from_json(settings) {
         alloc(Layout::from_settings(settings))
     } else {

--- a/capi/src/layout_editor.rs
+++ b/capi/src/layout_editor.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn LayoutEditor_close(this: OwnedLayoutEditor) -> OwnedLay
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_state_as_json(this: *const LayoutEditor) -> Json {
-    output_vec(|o| { acc(this).state().write_json(o).unwrap(); })
+    output_vec(|o| { acc(&this).state().write_json(o).unwrap(); })
 }
 
 #[no_mangle]
@@ -31,8 +31,8 @@ pub unsafe extern "C" fn LayoutEditor_layout_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this)
-            .layout_state(acc(timer))
+        acc_mut(&this)
+            .layout_state(acc(&timer))
             .write_json(o)
             .unwrap();
     })
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn LayoutEditor_layout_state_as_json(
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_select(this: *mut LayoutEditor, index: usize) {
-    acc_mut(this).select(index);
+    acc_mut(&this).select(index);
 }
 
 #[no_mangle]
@@ -48,27 +48,27 @@ pub unsafe extern "C" fn LayoutEditor_add_component(
     this: *mut LayoutEditor,
     component: OwnedComponent,
 ) {
-    acc_mut(this).add_component(own(component));
+    acc_mut(&this).add_component(own(component));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_remove_component(this: *mut LayoutEditor) {
-    acc_mut(this).remove_component();
+    acc_mut(&this).remove_component();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_move_component_up(this: *mut LayoutEditor) {
-    acc_mut(this).move_component_up();
+    acc_mut(&this).move_component_up();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_move_component_down(this: *mut LayoutEditor) {
-    acc_mut(this).move_component_down();
+    acc_mut(&this).move_component_down();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn LayoutEditor_move_component(this: *mut LayoutEditor, dst_index: usize) {
-    acc_mut(this).move_component(dst_index);
+    acc_mut(&this).move_component(dst_index);
 }
 
 #[no_mangle]
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn LayoutEditor_set_component_settings_value(
     index: usize,
     value: OwnedSettingValue,
 ) {
-    acc_mut(this).set_component_settings_value(index, own(value));
+    acc_mut(&this).set_component_settings_value(index, own(value));
 }
 
 #[no_mangle]
@@ -86,5 +86,5 @@ pub unsafe extern "C" fn LayoutEditor_set_general_settings_value(
     index: usize,
     value: OwnedSettingValue,
 ) {
-    acc_mut(this).set_general_settings_value(index, own(value));
+    acc_mut(&this).set_general_settings_value(index, own(value));
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -138,10 +138,10 @@ unsafe fn own_drop<T>(data: *mut T) {
     Box::from_raw(data);
 }
 
-unsafe fn acc_mut<T>(data: *mut T) -> &'static mut T {
-    &mut *data
+unsafe fn acc_mut<'a, T>(p: &'a *mut T) -> &mut T {
+    &mut **p
 }
 
-unsafe fn acc<T>(data: *const T) -> &'static T {
-    &*data
+unsafe fn acc<'a, T>(p: &'a *const T) -> &T {
+    &**p
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -122,8 +122,8 @@ where
     })
 }
 
-unsafe fn str(s: *const c_char) -> &'static str {
-    CStr::from_ptr(s as _).to_str().unwrap()
+unsafe fn str<'a>(s: &'a *const c_char) -> &'a str {
+    CStr::from_ptr(*s as _).to_str().unwrap()
 }
 
 fn alloc<T>(data: T) -> *mut T {

--- a/capi/src/possible_time_save_component.rs
+++ b/capi/src/possible_time_save_component.rs
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn PossibleTimeSaveComponent_state_as_json(
     this: *const PossibleTimeSaveComponent,
     timer: *const Timer,
 ) -> Json {
-    output_vec(|o| { acc(this).state(acc(timer)).write_json(o).unwrap(); })
+    output_vec(|o| { acc(&this).state(acc(&timer)).write_json(o).unwrap(); })
 }
 
 #[no_mangle]
@@ -36,5 +36,5 @@ pub unsafe extern "C" fn PossibleTimeSaveComponent_state(
     this: *const PossibleTimeSaveComponent,
     timer: *const Timer,
 ) -> OwnedPossibleTimeSaveComponentState {
-    alloc(acc(this).state(acc(timer)))
+    alloc(acc(&this).state(acc(&timer)))
 }

--- a/capi/src/possible_time_save_component_state.rs
+++ b/capi/src/possible_time_save_component_state.rs
@@ -15,12 +15,12 @@ pub unsafe extern "C" fn PossibleTimeSaveComponentState_drop(
 pub unsafe extern "C" fn PossibleTimeSaveComponentState_text(
     this: *const PossibleTimeSaveComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn PossibleTimeSaveComponentState_time(
     this: *const PossibleTimeSaveComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }

--- a/capi/src/previous_segment_component.rs
+++ b/capi/src/previous_segment_component.rs
@@ -30,8 +30,8 @@ pub unsafe extern "C" fn PreviousSegmentComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc(this)
-            .state(acc(timer), acc(layout_settings))
+        acc(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -43,5 +43,5 @@ pub unsafe extern "C" fn PreviousSegmentComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedPreviousSegmentComponentState {
-    alloc(acc(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc(&this).state(acc(&timer), acc(&layout_settings)))
 }

--- a/capi/src/previous_segment_component_state.rs
+++ b/capi/src/previous_segment_component_state.rs
@@ -16,19 +16,19 @@ pub unsafe extern "C" fn PreviousSegmentComponentState_drop(
 pub unsafe extern "C" fn PreviousSegmentComponentState_text(
     this: *const PreviousSegmentComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn PreviousSegmentComponentState_time(
     this: *const PreviousSegmentComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn PreviousSegmentComponentState_semantic_color(
     this: *const PreviousSegmentComponentState,
 ) -> *const c_char {
-    output_str_with(|f| write!(f, "{:?}", acc(this).semantic_color).unwrap())
+    output_str_with(|f| write!(f, "{:?}", acc(&this).semantic_color).unwrap())
 }

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn Run_game_name(this: *const Run) -> *const c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_game_name(this: *mut Run, game: *const c_char) {
-    acc_mut(&this).set_game_name(str(game));
+    acc_mut(&this).set_game_name(str(&game));
 }
 
 #[no_mangle]
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn Run_category_name(this: *const Run) -> *const c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_category_name(this: *mut Run, category: *const c_char) {
-    acc_mut(&this).set_category_name(str(category));
+    acc_mut(&this).set_category_name(str(&category));
 }
 
 #[no_mangle]

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -33,37 +33,37 @@ pub unsafe extern "C" fn Run_parse(data: *const u8, length: usize) -> NullableOw
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_clone(this: *const Run) -> OwnedRun {
-    alloc(acc(this).clone())
+    alloc(acc(&this).clone())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_push_segment(this: *mut Run, segment: OwnedSegment) {
-    acc_mut(this).push_segment(own(segment));
+    acc_mut(&this).push_segment(own(segment));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_game_name(this: *const Run) -> *const c_char {
-    output_str(acc(this).game_name())
+    output_str(acc(&this).game_name())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_game_name(this: *mut Run, game: *const c_char) {
-    acc_mut(this).set_game_name(str(game));
+    acc_mut(&this).set_game_name(str(game));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_game_icon(this: *const Run) -> *const c_char {
-    output_str(acc(this).game_icon().url())
+    output_str(acc(&this).game_icon().url())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_category_name(this: *const Run) -> *const c_char {
-    output_str(acc(this).category_name())
+    output_str(acc(&this).category_name())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_set_category_name(this: *mut Run, category: *const c_char) {
-    acc_mut(this).set_category_name(str(category));
+    acc_mut(&this).set_category_name(str(category));
 }
 
 #[no_mangle]
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn Run_extended_file_name(
     this: *const Run,
     use_extended_category_name: bool,
 ) -> *const c_char {
-    output_str(acc(this).extended_file_name(use_extended_category_name))
+    output_str(acc(&this).extended_file_name(use_extended_category_name))
 }
 
 #[no_mangle]
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn Run_extended_name(
     this: *const Run,
     use_extended_category_name: bool,
 ) -> *const c_char {
-    output_str(acc(this).extended_name(use_extended_category_name))
+    output_str(acc(&this).extended_name(use_extended_category_name))
 }
 
 #[no_mangle]
@@ -90,38 +90,38 @@ pub unsafe extern "C" fn Run_extended_category_name(
     show_variables: bool,
 ) -> *const c_char {
     output_str(
-        acc(this).extended_category_name(show_region, show_platform, show_variables),
+        acc(&this).extended_category_name(show_region, show_platform, show_variables),
     )
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_attempt_count(this: *const Run) -> u32 {
-    acc(this).attempt_count()
+    acc(&this).attempt_count()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_metadata(this: *const Run) -> *const RunMetadata {
-    acc(this).metadata()
+    acc(&this).metadata()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_offset(this: *const Run) -> *const TimeSpan {
-    output_time_span(acc(this).offset())
+    output_time_span(acc(&this).offset())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_len(this: *const Run) -> usize {
-    acc(this).len()
+    acc(&this).len()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_segment(this: *const Run, index: usize) -> *const Segment {
-    acc(this).segment(index)
+    acc(&this).segment(index)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_attempt_history_len(this: *const Run) -> usize {
-    acc(this).attempt_history().len()
+    acc(&this).attempt_history().len()
 }
 
 #[no_mangle]
@@ -129,10 +129,10 @@ pub unsafe extern "C" fn Run_attempt_history_index(
     this: *const Run,
     index: usize,
 ) -> *const Attempt {
-    &acc(this).attempt_history()[index]
+    &acc(&this).attempt_history()[index]
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Run_save_as_lss(this: *const Run) -> *const c_char {
-    output_vec(|o| { saver::livesplit::save(acc(this), o).unwrap(); })
+    output_vec(|o| { saver::livesplit::save(acc(&this), o).unwrap(); })
 }

--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -232,9 +232,11 @@ pub unsafe extern "C" fn RunEditor_clear_times(this: *mut RunEditor) {
     acc_mut(&this).clear_times();
 }
 
+/// # Safety
+/// `this` must outlive `OwnedSumOfBestCleaner`
 #[no_mangle]
-pub unsafe extern "C" fn RunEditor_clean_sum_of_best(
+pub unsafe extern "C" fn RunEditor_clean_sum_of_best<'a>(
     this: *mut RunEditor,
-) -> OwnedSumOfBestCleaner {
-    alloc(acc_mut(&this).clean_sum_of_best())
+) -> OwnedSumOfBestCleaner<'a> {
+    alloc((&mut *this).clean_sum_of_best())
 }

--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn RunEditor_close(this: OwnedRunEditor) -> OwnedRun {
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_state_as_json(this: *mut RunEditor) -> Json {
-    output_vec(|o| { acc_mut(this).state().write_json(o).unwrap(); })
+    output_vec(|o| { acc_mut(&this).state().write_json(o).unwrap(); })
 }
 
 #[no_mangle]
@@ -30,27 +30,27 @@ pub unsafe extern "C" fn RunEditor_select_timing_method(
     this: *mut RunEditor,
     method: TimingMethod,
 ) {
-    acc_mut(this).select_timing_method(method);
+    acc_mut(&this).select_timing_method(method);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_unselect(this: *mut RunEditor, index: usize) {
-    acc_mut(this).unselect(index);
+    acc_mut(&this).unselect(index);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_select_additionally(this: *mut RunEditor, index: usize) {
-    acc_mut(this).select_additionally(index);
+    acc_mut(&this).select_additionally(index);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_select_only(this: *mut RunEditor, index: usize) {
-    acc_mut(this).select_only(index);
+    acc_mut(&this).select_only(index);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_set_game_name(this: *mut RunEditor, game: *const c_char) {
-    acc_mut(this).set_game_name(str(game));
+    acc_mut(&this).set_game_name(str(game));
 }
 
 #[no_mangle]
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn RunEditor_set_category_name(
     this: *mut RunEditor,
     category: *const c_char,
 ) {
-    acc_mut(this).set_category_name(str(category));
+    acc_mut(&this).set_category_name(str(category));
 }
 
 #[no_mangle]
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn RunEditor_parse_and_set_offset(
     this: *mut RunEditor,
     offset: *const c_char,
 ) -> bool {
-    acc_mut(this).parse_and_set_offset(str(offset)).is_ok()
+    acc_mut(&this).parse_and_set_offset(str(offset)).is_ok()
 }
 
 #[no_mangle]
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn RunEditor_parse_and_set_attempt_count(
     this: *mut RunEditor,
     attempts: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .parse_and_set_attempt_count(str(attempts))
         .is_ok()
 }
@@ -85,37 +85,37 @@ pub unsafe extern "C" fn RunEditor_set_game_icon(
     data: *const u8,
     length: usize,
 ) {
-    acc_mut(this).set_game_icon(slice::from_raw_parts(data, length));
+    acc_mut(&this).set_game_icon(slice::from_raw_parts(data, length));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_remove_game_icon(this: *mut RunEditor) {
-    acc_mut(this).remove_game_icon();
+    acc_mut(&this).remove_game_icon();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_insert_segment_above(this: *mut RunEditor) {
-    acc_mut(this).insert_segment_above();
+    acc_mut(&this).insert_segment_above();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_insert_segment_below(this: *mut RunEditor) {
-    acc_mut(this).insert_segment_below();
+    acc_mut(&this).insert_segment_below();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_remove_segments(this: *mut RunEditor) {
-    acc_mut(this).remove_segments();
+    acc_mut(&this).remove_segments();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_move_segments_up(this: *mut RunEditor) {
-    acc_mut(this).move_segments_up();
+    acc_mut(&this).move_segments_up();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_move_segments_down(this: *mut RunEditor) {
-    acc_mut(this).move_segments_down();
+    acc_mut(&this).move_segments_down();
 }
 
 #[no_mangle]
@@ -124,19 +124,19 @@ pub unsafe extern "C" fn RunEditor_selected_set_icon(
     data: *const u8,
     length: usize,
 ) {
-    acc_mut(this)
+    acc_mut(&this)
         .selected_segment()
         .set_icon(slice::from_raw_parts(data, length));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_selected_remove_icon(this: *mut RunEditor) {
-    acc_mut(this).selected_segment().remove_icon();
+    acc_mut(&this).selected_segment().remove_icon();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_selected_set_name(this: *mut RunEditor, name: *const c_char) {
-    acc_mut(this).selected_segment().set_name(str(name));
+    acc_mut(&this).selected_segment().set_name(str(name));
 }
 
 #[no_mangle]
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_split_time(
     this: *mut RunEditor,
     time: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .selected_segment()
         .parse_and_set_split_time(str(time))
         .is_ok()
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_segment_time(
     this: *mut RunEditor,
     time: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .selected_segment()
         .parse_and_set_segment_time(str(time))
         .is_ok()
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_best_segment_time(
     this: *mut RunEditor,
     time: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .selected_segment()
         .parse_and_set_best_segment_time(str(time))
         .is_ok()
@@ -178,7 +178,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_comparison_time(
     comparison: *const c_char,
     time: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .selected_segment()
         .parse_and_set_comparison_time(str(comparison), str(time))
         .is_ok()
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn RunEditor_add_comparison(
     this: *mut RunEditor,
     comparison: *const c_char,
 ) -> bool {
-    acc_mut(this).add_comparison(str(comparison)).is_ok()
+    acc_mut(&this).add_comparison(str(comparison)).is_ok()
 }
 
 #[no_mangle]
@@ -198,8 +198,8 @@ pub unsafe extern "C" fn RunEditor_import_comparison(
     run: *const Run,
     comparison: *const c_char,
 ) -> bool {
-    acc_mut(this)
-        .import_comparison(acc(run), str(comparison))
+    acc_mut(&this)
+        .import_comparison(acc(&run), str(comparison))
         .is_ok()
 }
 
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn RunEditor_remove_comparison(
     this: *mut RunEditor,
     comparison: *const c_char,
 ) {
-    acc_mut(this).remove_comparison(str(comparison));
+    acc_mut(&this).remove_comparison(str(comparison));
 }
 
 #[no_mangle]
@@ -217,24 +217,24 @@ pub unsafe extern "C" fn RunEditor_rename_comparison(
     old_name: *const c_char,
     new_name: *const c_char,
 ) -> bool {
-    acc_mut(this)
+    acc_mut(&this)
         .rename_comparison(str(old_name), str(new_name))
         .is_ok()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_clear_history(this: *mut RunEditor) {
-    acc_mut(this).clear_history();
+    acc_mut(&this).clear_history();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_clear_times(this: *mut RunEditor) {
-    acc_mut(this).clear_times();
+    acc_mut(&this).clear_times();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_clean_sum_of_best(
     this: *mut RunEditor,
 ) -> OwnedSumOfBestCleaner {
-    alloc(acc_mut(this).clean_sum_of_best())
+    alloc(acc_mut(&this).clean_sum_of_best())
 }

--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn RunEditor_select_only(this: *mut RunEditor, index: usiz
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_set_game_name(this: *mut RunEditor, game: *const c_char) {
-    acc_mut(&this).set_game_name(str(game));
+    acc_mut(&this).set_game_name(str(&game));
 }
 
 #[no_mangle]
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn RunEditor_set_category_name(
     this: *mut RunEditor,
     category: *const c_char,
 ) {
-    acc_mut(&this).set_category_name(str(category));
+    acc_mut(&this).set_category_name(str(&category));
 }
 
 #[no_mangle]
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn RunEditor_parse_and_set_offset(
     this: *mut RunEditor,
     offset: *const c_char,
 ) -> bool {
-    acc_mut(&this).parse_and_set_offset(str(offset)).is_ok()
+    acc_mut(&this).parse_and_set_offset(str(&offset)).is_ok()
 }
 
 #[no_mangle]
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn RunEditor_parse_and_set_attempt_count(
     attempts: *const c_char,
 ) -> bool {
     acc_mut(&this)
-        .parse_and_set_attempt_count(str(attempts))
+        .parse_and_set_attempt_count(str(&attempts))
         .is_ok()
 }
 
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn RunEditor_selected_remove_icon(this: *mut RunEditor) {
 
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_selected_set_name(this: *mut RunEditor, name: *const c_char) {
-    acc_mut(&this).selected_segment().set_name(str(name));
+    acc_mut(&this).selected_segment().set_name(str(&name));
 }
 
 #[no_mangle]
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_split_time(
 ) -> bool {
     acc_mut(&this)
         .selected_segment()
-        .parse_and_set_split_time(str(time))
+        .parse_and_set_split_time(str(&time))
         .is_ok()
 }
 
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_segment_time(
 ) -> bool {
     acc_mut(&this)
         .selected_segment()
-        .parse_and_set_segment_time(str(time))
+        .parse_and_set_segment_time(str(&time))
         .is_ok()
 }
 
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_best_segment_time(
 ) -> bool {
     acc_mut(&this)
         .selected_segment()
-        .parse_and_set_best_segment_time(str(time))
+        .parse_and_set_best_segment_time(str(&time))
         .is_ok()
 }
 
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn RunEditor_selected_parse_and_set_comparison_time(
 ) -> bool {
     acc_mut(&this)
         .selected_segment()
-        .parse_and_set_comparison_time(str(comparison), str(time))
+        .parse_and_set_comparison_time(str(&comparison), str(&time))
         .is_ok()
 }
 
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn RunEditor_add_comparison(
     this: *mut RunEditor,
     comparison: *const c_char,
 ) -> bool {
-    acc_mut(&this).add_comparison(str(comparison)).is_ok()
+    acc_mut(&this).add_comparison(str(&comparison)).is_ok()
 }
 
 #[no_mangle]
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn RunEditor_import_comparison(
     comparison: *const c_char,
 ) -> bool {
     acc_mut(&this)
-        .import_comparison(acc(&run), str(comparison))
+        .import_comparison(acc(&run), str(&comparison))
         .is_ok()
 }
 
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn RunEditor_remove_comparison(
     this: *mut RunEditor,
     comparison: *const c_char,
 ) {
-    acc_mut(&this).remove_comparison(str(comparison));
+    acc_mut(&this).remove_comparison(str(&comparison));
 }
 
 #[no_mangle]
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn RunEditor_rename_comparison(
     new_name: *const c_char,
 ) -> bool {
     acc_mut(&this)
-        .rename_comparison(str(old_name), str(new_name))
+        .rename_comparison(str(&old_name), str(&new_name))
         .is_ok()
 }
 

--- a/capi/src/run_metadata.rs
+++ b/capi/src/run_metadata.rs
@@ -25,9 +25,11 @@ pub unsafe extern "C" fn RunMetadata_region_name(this: *const RunMetadata) -> *c
     output_str(acc(&this).region_name())
 }
 
+/// # Safety
+/// `this` must outlive `OwnedRunMetadataVariablesIter`
 #[no_mangle]
-pub unsafe extern "C" fn RunMetadata_variables(
+pub unsafe extern "C" fn RunMetadata_variables<'a>(
     this: *const RunMetadata,
-) -> OwnedRunMetadataVariablesIter {
-    alloc(acc(&this).variables())
+) -> OwnedRunMetadataVariablesIter<'a> {
+    alloc((&*this).variables())
 }

--- a/capi/src/run_metadata.rs
+++ b/capi/src/run_metadata.rs
@@ -7,27 +7,27 @@ pub type OwnedRunMetadata = *mut RunMetadata;
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_run_id(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).run_id())
+    output_str(acc(&this).run_id())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_platform_name(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).platform_name())
+    output_str(acc(&this).platform_name())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_uses_emulator(this: *const RunMetadata) -> bool {
-    acc(this).uses_emulator()
+    acc(&this).uses_emulator()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_region_name(this: *const RunMetadata) -> *const c_char {
-    output_str(acc(this).region_name())
+    output_str(acc(&this).region_name())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadata_variables(
     this: *const RunMetadata,
 ) -> OwnedRunMetadataVariablesIter {
-    alloc(acc(this).variables())
+    alloc(acc(&this).variables())
 }

--- a/capi/src/run_metadata_variable.rs
+++ b/capi/src/run_metadata_variable.rs
@@ -14,12 +14,12 @@ pub unsafe extern "C" fn RunMetadataVariable_drop(this: OwnedRunMetadataVariable
 pub unsafe extern "C" fn RunMetadataVariable_name(
     this: *const RunMetadataVariable,
 ) -> *const c_char {
-    output_str(acc(acc(this).0))
+    output_str(acc(&acc(&this).0))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadataVariable_value(
     this: *const RunMetadataVariable,
 ) -> *const c_char {
-    output_str(acc(acc(this).1))
+    output_str(acc(&acc(&this).1))
 }

--- a/capi/src/run_metadata_variables_iter.rs
+++ b/capi/src/run_metadata_variables_iter.rs
@@ -3,8 +3,8 @@ use std::ptr;
 use livesplit_core::ordermap;
 use run_metadata_variable::{NullableRunMetadataVariable, RunMetadataVariable};
 
-pub type RunMetadataVariablesIter = ordermap::Iter<'static, String, String>;
-pub type OwnedRunMetadataVariablesIter = *mut RunMetadataVariablesIter;
+pub type RunMetadataVariablesIter<'a> = ordermap::Iter<'a, String, String>;
+pub type OwnedRunMetadataVariablesIter<'a> = *mut RunMetadataVariablesIter<'a>;
 
 #[no_mangle]
 pub unsafe extern "C" fn RunMetadataVariablesIter_drop(this: OwnedRunMetadataVariablesIter) {

--- a/capi/src/run_metadata_variables_iter.rs
+++ b/capi/src/run_metadata_variables_iter.rs
@@ -15,7 +15,7 @@ pub unsafe extern "C" fn RunMetadataVariablesIter_drop(this: OwnedRunMetadataVar
 pub unsafe extern "C" fn RunMetadataVariablesIter_next(
     this: *mut RunMetadataVariablesIter,
 ) -> *const NullableRunMetadataVariable {
-    if let Some((name, value)) = acc_mut(this).next() {
+    if let Some((name, value)) = acc_mut(&this).next() {
         RUN_METADATA_VARIABLE.with(|output| {
             output.set((name, value));
             output.as_ptr() as *const RunMetadataVariable

--- a/capi/src/segment.rs
+++ b/capi/src/segment.rs
@@ -6,7 +6,7 @@ pub type OwnedSegment = *mut Segment;
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_new(name: *const c_char) -> OwnedSegment {
-    alloc(Segment::new(str(name)))
+    alloc(Segment::new(str(&name)))
 }
 
 #[no_mangle]
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn Segment_comparison(
     this: *const Segment,
     comparison: *const c_char,
 ) -> *const Time {
-    output_time(acc(&this).comparison(str(comparison)))
+    output_time(acc(&this).comparison(str(&comparison)))
 }
 
 #[no_mangle]

--- a/capi/src/segment.rs
+++ b/capi/src/segment.rs
@@ -16,12 +16,12 @@ pub unsafe extern "C" fn Segment_drop(this: OwnedSegment) {
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_name(this: *const Segment) -> *const c_char {
-    output_str(acc(this).name())
+    output_str(acc(&this).name())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_icon(this: *const Segment) -> *const c_char {
-    output_str(acc(this).icon().url())
+    output_str(acc(&this).icon().url())
 }
 
 #[no_mangle]
@@ -29,20 +29,20 @@ pub unsafe extern "C" fn Segment_comparison(
     this: *const Segment,
     comparison: *const c_char,
 ) -> *const Time {
-    output_time(acc(this).comparison(str(comparison)))
+    output_time(acc(&this).comparison(str(comparison)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_personal_best_split_time(this: *const Segment) -> *const Time {
-    output_time(acc(this).personal_best_split_time())
+    output_time(acc(&this).personal_best_split_time())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_best_segment_time(this: *const Segment) -> *const Time {
-    output_time(acc(this).best_segment_time())
+    output_time(acc(&this).best_segment_time())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Segment_segment_history(this: *const Segment) -> *const SegmentHistory {
-    acc(this).segment_history()
+    acc(&this).segment_history()
 }

--- a/capi/src/segment_history.rs
+++ b/capi/src/segment_history.rs
@@ -8,5 +8,5 @@ pub type OwnedSegmentHistory = *mut SegmentHistory;
 pub unsafe extern "C" fn SegmentHistory_iter(
     this: *const SegmentHistory,
 ) -> OwnedSegmentHistoryIter {
-    alloc(acc(this).iter())
+    alloc(acc(&this).iter())
 }

--- a/capi/src/segment_history.rs
+++ b/capi/src/segment_history.rs
@@ -1,12 +1,14 @@
 use livesplit_core::SegmentHistory;
-use super::{acc, alloc};
+use super::alloc;
 use segment_history_iter::OwnedSegmentHistoryIter;
 
 pub type OwnedSegmentHistory = *mut SegmentHistory;
 
+/// # Safety
+/// `this` must outlive `OwnedSegmentHistoryIter`
 #[no_mangle]
-pub unsafe extern "C" fn SegmentHistory_iter(
+pub unsafe extern "C" fn SegmentHistory_iter<'a>(
     this: *const SegmentHistory,
-) -> OwnedSegmentHistoryIter {
-    alloc(acc(&this).iter())
+) -> OwnedSegmentHistoryIter<'a> {
+    alloc((&*this).iter())
 }

--- a/capi/src/segment_history_element.rs
+++ b/capi/src/segment_history_element.rs
@@ -7,12 +7,12 @@ pub type OwnedSegmentHistoryElement = *mut SegmentHistoryElement;
 
 #[no_mangle]
 pub unsafe extern "C" fn SegmentHistoryElement_index(this: *const SegmentHistoryElement) -> i32 {
-    acc(this).0
+    acc(&this).0
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SegmentHistoryElement_time(
     this: *const SegmentHistoryElement,
 ) -> *const Time {
-    output_time(acc(this).1)
+    output_time(acc(&this).1)
 }

--- a/capi/src/segment_history_iter.rs
+++ b/capi/src/segment_history_iter.rs
@@ -15,7 +15,7 @@ pub unsafe extern "C" fn SegmentHistoryIter_drop(this: OwnedSegmentHistoryIter) 
 pub unsafe extern "C" fn SegmentHistoryIter_next(
     this: *mut SegmentHistoryIter,
 ) -> *const NullableSegmentHistoryElement {
-    if let Some(&element) = acc_mut(this).next() {
+    if let Some(&element) = acc_mut(&this).next() {
         SEGMENT_HISTORY_ELEMENT.with(|output| {
             output.set(element);
             output.as_ptr() as *const SegmentHistoryElement

--- a/capi/src/segment_history_iter.rs
+++ b/capi/src/segment_history_iter.rs
@@ -3,8 +3,8 @@ use super::{acc_mut, own_drop, SEGMENT_HISTORY_ELEMENT};
 use std::{ptr, slice};
 use segment_history_element::{NullableSegmentHistoryElement, SegmentHistoryElement};
 
-pub type SegmentHistoryIter = slice::Iter<'static, (i32, Time)>;
-pub type OwnedSegmentHistoryIter = *mut SegmentHistoryIter;
+pub type SegmentHistoryIter<'a> = slice::Iter<'a, (i32, Time)>;
+pub type OwnedSegmentHistoryIter<'a> = *mut SegmentHistoryIter<'a>;
 
 #[no_mangle]
 pub unsafe extern "C" fn SegmentHistoryIter_drop(this: OwnedSegmentHistoryIter) {

--- a/capi/src/setting_value.rs
+++ b/capi/src/setting_value.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn SettingValue_from_int(value: i64) -> OwnedSettingValue 
 
 #[no_mangle]
 pub unsafe extern "C" fn SettingValue_from_string(value: *const c_char) -> OwnedSettingValue {
-    alloc(str(value).to_string().into())
+    alloc(str(&value).to_string().into())
 }
 
 #[no_mangle]
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn SettingValue_from_optional_string(
     let value = if value.is_null() {
         None::<String>.into()
     } else {
-        Some(str(value).to_string()).into()
+        Some(str(&value).to_string()).into()
     };
     alloc(value)
 }
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn SettingValue_from_float(value: f64) -> OwnedSettingValu
 pub unsafe extern "C" fn SettingValue_from_accuracy(
     value: *const c_char,
 ) -> NullableOwnedSettingValue {
-    let value = str(value);
+    let value = str(&value);
     let value = match value {
         "Seconds" => Accuracy::Seconds,
         "Tenths" => Accuracy::Tenths,
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn SettingValue_from_accuracy(
 pub unsafe extern "C" fn SettingValue_from_digits_format(
     value: *const c_char,
 ) -> NullableOwnedSettingValue {
-    let value = str(value);
+    let value = str(&value);
     let value = match value {
         "SingleDigitSeconds" => DigitsFormat::SingleDigitSeconds,
         "DoubleDigitSeconds" => DigitsFormat::DoubleDigitSeconds,
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn SettingValue_from_optional_timing_method(
     if value.is_null() {
         alloc(None::<TimingMethod>.into())
     } else {
-        let value = str(value);
+        let value = str(&value);
         let value = match value {
             "RealTime" => TimingMethod::RealTime,
             "GameTime" => TimingMethod::GameTime,

--- a/capi/src/shared_timer.rs
+++ b/capi/src/shared_timer.rs
@@ -8,7 +8,7 @@ pub type OwnedSharedTimer = *mut SharedTimer;
 
 #[no_mangle]
 pub unsafe extern "C" fn SharedTimer_share(this: *const SharedTimer) -> OwnedSharedTimer {
-    alloc(acc(this).clone())
+    alloc(acc(&this).clone())
 }
 
 #[no_mangle]
@@ -18,15 +18,15 @@ pub unsafe extern "C" fn SharedTimer_drop(this: OwnedSharedTimer) {
 
 #[no_mangle]
 pub unsafe extern "C" fn SharedTimer_read(this: *const SharedTimer) -> OwnedTimerReadLock {
-    alloc(acc(this).read())
+    alloc(acc(&this).read())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SharedTimer_write(this: *const SharedTimer) -> OwnedTimerWriteLock {
-    alloc(acc(this).write())
+    alloc(acc(&this).write())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SharedTimer_replace_inner(this: *const SharedTimer, timer: OwnedTimer) {
-    *acc(this).write() = own(timer);
+    *acc(&this).write() = own(timer);
 }

--- a/capi/src/shared_timer.rs
+++ b/capi/src/shared_timer.rs
@@ -16,14 +16,18 @@ pub unsafe extern "C" fn SharedTimer_drop(this: OwnedSharedTimer) {
     own_drop(this);
 }
 
+/// # Safety
+/// `this` must outlive `OwnedTimerReadLock`
 #[no_mangle]
-pub unsafe extern "C" fn SharedTimer_read(this: *const SharedTimer) -> OwnedTimerReadLock {
-    alloc(acc(&this).read())
+pub unsafe extern "C" fn SharedTimer_read<'a>(this: *const SharedTimer) -> OwnedTimerReadLock<'a> {
+    alloc((&*this).read())
 }
 
+/// # Safety
+/// `this` must outlive `OwnedTimerWriteLock`
 #[no_mangle]
-pub unsafe extern "C" fn SharedTimer_write(this: *const SharedTimer) -> OwnedTimerWriteLock {
-    alloc(acc(&this).write())
+pub unsafe extern "C" fn SharedTimer_write<'a>(this: *const SharedTimer) -> OwnedTimerWriteLock<'a> {
+    alloc((&*this).write())
 }
 
 #[no_mangle]

--- a/capi/src/splits_component.rs
+++ b/capi/src/splits_component.rs
@@ -30,8 +30,8 @@ pub unsafe extern "C" fn SplitsComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this)
-            .state(acc(timer), acc(layout_settings))
+        acc_mut(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -43,18 +43,18 @@ pub unsafe extern "C" fn SplitsComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedSplitsComponentState {
-    alloc(acc_mut(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc_mut(&this).state(acc(&timer), acc(&layout_settings)))
 }
 
 
 #[no_mangle]
 pub unsafe extern "C" fn SplitsComponent_scroll_up(this: *mut SplitsComponent) {
-    acc_mut(this).scroll_up();
+    acc_mut(&this).scroll_up();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SplitsComponent_scroll_down(this: *mut SplitsComponent) {
-    acc_mut(this).scroll_down();
+    acc_mut(&this).scroll_down();
 }
 
 #[no_mangle]
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn SplitsComponent_set_visual_split_count(
     this: *mut SplitsComponent,
     count: usize,
 ) {
-    acc_mut(this).settings_mut().visual_split_count = count;
+    acc_mut(&this).settings_mut().visual_split_count = count;
 }
 
 #[no_mangle]
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn SplitsComponent_set_split_preview_count(
     this: *mut SplitsComponent,
     count: usize,
 ) {
-    acc_mut(this).settings_mut().split_preview_count = count;
+    acc_mut(&this).settings_mut().split_preview_count = count;
 }
 
 #[no_mangle]
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn SplitsComponent_set_always_show_last_split(
     this: *mut SplitsComponent,
     always_show_last_split: bool,
 ) {
-    acc_mut(this).settings_mut().always_show_last_split = always_show_last_split;
+    acc_mut(&this).settings_mut().always_show_last_split = always_show_last_split;
 }
 
 #[no_mangle]
@@ -86,5 +86,5 @@ pub unsafe extern "C" fn SplitsComponent_set_separator_last_split(
     this: *mut SplitsComponent,
     separator_last_split: bool,
 ) {
-    acc_mut(this).settings_mut().separator_last_split = separator_last_split;
+    acc_mut(&this).settings_mut().separator_last_split = separator_last_split;
 }

--- a/capi/src/splits_component_state.rs
+++ b/capi/src/splits_component_state.rs
@@ -15,12 +15,12 @@ pub unsafe extern "C" fn SplitsComponentState_drop(this: OwnedSplitsComponentSta
 pub unsafe extern "C" fn SplitsComponentState_final_separator_shown(
     this: *const SplitsComponentState,
 ) -> bool {
-    acc(this).show_final_separator
+    acc(&this).show_final_separator
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SplitsComponentState_len(this: *const SplitsComponentState) -> usize {
-    acc(this).splits.len()
+    acc(&this).splits.len()
 }
 
 #[no_mangle]
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn SplitsComponentState_icon_change(
     this: *const SplitsComponentState,
     index: usize,
 ) -> *const Nullablec_char {
-    acc(this).splits[index]
+    acc(&this).splits[index]
         .icon_change
         .as_ref()
         .map_or_else(ptr::null, output_str)
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn SplitsComponentState_name(
     this: *const SplitsComponentState,
     index: usize,
 ) -> *const c_char {
-    output_str(&acc(this).splits[index].name)
+    output_str(&acc(&this).splits[index].name)
 }
 
 #[no_mangle]
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn SplitsComponentState_delta(
     this: *const SplitsComponentState,
     index: usize,
 ) -> *const c_char {
-    output_str(&acc(this).splits[index].delta)
+    output_str(&acc(&this).splits[index].delta)
 }
 
 #[no_mangle]
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn SplitsComponentState_time(
     this: *const SplitsComponentState,
     index: usize,
 ) -> *const c_char {
-    output_str(&acc(this).splits[index].time)
+    output_str(&acc(&this).splits[index].time)
 }
 
 #[no_mangle]
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn SplitsComponentState_semantic_color(
     index: usize,
 ) -> *const c_char {
     output_str_with(|f| {
-        write!(f, "{:?}", acc(this).splits[index].semantic_color).unwrap()
+        write!(f, "{:?}", acc(&this).splits[index].semantic_color).unwrap()
     })
 }
 
@@ -73,5 +73,5 @@ pub unsafe extern "C" fn SplitsComponentState_is_current_split(
     this: *const SplitsComponentState,
     index: usize,
 ) -> bool {
-    acc(this).splits[index].is_current_split
+    acc(&this).splits[index].is_current_split
 }

--- a/capi/src/sum_of_best_cleaner.rs
+++ b/capi/src/sum_of_best_cleaner.rs
@@ -4,28 +4,30 @@ use libc::c_char;
 use std::fmt::Write;
 use std::ptr;
 
-pub type OwnedSumOfBestCleaner = *mut SumOfBestCleaner<'static>;
-pub type OwnedPotentialCleanUp = *mut PotentialCleanUp<'static>;
-pub type NullableOwnedPotentialCleanUp = OwnedPotentialCleanUp;
+pub type OwnedSumOfBestCleaner<'a> = *mut SumOfBestCleaner<'a>;
+pub type OwnedPotentialCleanUp<'a> = *mut PotentialCleanUp<'a>;
+pub type NullableOwnedPotentialCleanUp<'a> = OwnedPotentialCleanUp<'a>;
 
 #[no_mangle]
 pub unsafe extern "C" fn SumOfBestCleaner_drop(this: OwnedSumOfBestCleaner) {
     own_drop(this);
 }
 
+/// # Safety
+/// `this` must outlive `NullableOwnedPotentialCleanUp`
 #[no_mangle]
-pub unsafe extern "C" fn SumOfBestCleaner_next_potential_clean_up(
-    this: *mut SumOfBestCleaner<'static>,
-) -> NullableOwnedPotentialCleanUp {
-    acc_mut(&this)
+pub unsafe extern "C" fn SumOfBestCleaner_next_potential_clean_up<'a>(
+    this: *mut SumOfBestCleaner<'a>,
+) -> NullableOwnedPotentialCleanUp<'a> {
+    (&mut *this)
         .next_potential_clean_up()
         .map_or_else(ptr::null_mut, alloc)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SumOfBestCleaner_apply(
-    this: *mut SumOfBestCleaner<'static>,
-    clean_up: OwnedPotentialCleanUp,
+pub unsafe extern "C" fn SumOfBestCleaner_apply<'a>(
+    this: *mut SumOfBestCleaner<'a>,
+    clean_up: OwnedPotentialCleanUp<'a>,
 ) {
     acc_mut(&this).apply(own(clean_up).into());
 }
@@ -36,8 +38,8 @@ pub unsafe extern "C" fn PotentialCleanUp_drop(this: OwnedPotentialCleanUp) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn PotentialCleanUp_message(
-    this: *const PotentialCleanUp<'static>,
+pub unsafe extern "C" fn PotentialCleanUp_message<'a>(
+    this: *const PotentialCleanUp<'a>,
 ) -> *const c_char {
     output_str_with(|s| write!(s, "{}", acc(&this)).unwrap())
 }

--- a/capi/src/sum_of_best_cleaner.rs
+++ b/capi/src/sum_of_best_cleaner.rs
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn SumOfBestCleaner_drop(this: OwnedSumOfBestCleaner) {
 pub unsafe extern "C" fn SumOfBestCleaner_next_potential_clean_up(
     this: *mut SumOfBestCleaner<'static>,
 ) -> NullableOwnedPotentialCleanUp {
-    acc_mut(this)
+    acc_mut(&this)
         .next_potential_clean_up()
         .map_or_else(ptr::null_mut, alloc)
 }
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn SumOfBestCleaner_apply(
     this: *mut SumOfBestCleaner<'static>,
     clean_up: OwnedPotentialCleanUp,
 ) {
-    acc_mut(this).apply(own(clean_up).into());
+    acc_mut(&this).apply(own(clean_up).into());
 }
 
 #[no_mangle]
@@ -39,5 +39,5 @@ pub unsafe extern "C" fn PotentialCleanUp_drop(this: OwnedPotentialCleanUp) {
 pub unsafe extern "C" fn PotentialCleanUp_message(
     this: *const PotentialCleanUp<'static>,
 ) -> *const c_char {
-    output_str_with(|s| write!(s, "{}", acc(this)).unwrap())
+    output_str_with(|s| write!(s, "{}", acc(&this)).unwrap())
 }

--- a/capi/src/sum_of_best_component.rs
+++ b/capi/src/sum_of_best_component.rs
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn SumOfBestComponent_state_as_json(
     this: *const SumOfBestComponent,
     timer: *const Timer,
 ) -> Json {
-    output_vec(|o| { acc(this).state(acc(timer)).write_json(o).unwrap(); })
+    output_vec(|o| { acc(&this).state(acc(&timer)).write_json(o).unwrap(); })
 }
 
 #[no_mangle]
@@ -36,5 +36,5 @@ pub unsafe extern "C" fn SumOfBestComponent_state(
     this: *const SumOfBestComponent,
     timer: *const Timer,
 ) -> OwnedSumOfBestComponentState {
-    alloc(acc(this).state(acc(timer)))
+    alloc(acc(&this).state(acc(&timer)))
 }

--- a/capi/src/sum_of_best_component_state.rs
+++ b/capi/src/sum_of_best_component_state.rs
@@ -13,12 +13,12 @@ pub unsafe extern "C" fn SumOfBestComponentState_drop(this: OwnedSumOfBestCompon
 pub unsafe extern "C" fn SumOfBestComponentState_text(
     this: *const SumOfBestComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SumOfBestComponentState_time(
     this: *const SumOfBestComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }

--- a/capi/src/text_component.rs
+++ b/capi/src/text_component.rs
@@ -28,17 +28,17 @@ pub unsafe extern "C" fn TextComponent_state_as_json(this: *const TextComponent)
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_center(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(&this).settings_mut().text.set_center(str(text));
+    acc_mut(&this).settings_mut().text.set_center(str(&text));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_left(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(&this).settings_mut().text.set_left(str(text));
+    acc_mut(&this).settings_mut().text.set_left(str(&text));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_right(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(&this).settings_mut().text.set_right(str(text));
+    acc_mut(&this).settings_mut().text.set_right(str(&text));
 }
 
 #[no_mangle]

--- a/capi/src/text_component.rs
+++ b/capi/src/text_component.rs
@@ -23,27 +23,27 @@ pub unsafe extern "C" fn TextComponent_into_generic(this: OwnedTextComponent) ->
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_state_as_json(this: *const TextComponent) -> Json {
-    output_vec(|o| { acc(this).state().write_json(o).unwrap(); })
+    output_vec(|o| { acc(&this).state().write_json(o).unwrap(); })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_center(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(this).settings_mut().text.set_center(str(text));
+    acc_mut(&this).settings_mut().text.set_center(str(text));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_left(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(this).settings_mut().text.set_left(str(text));
+    acc_mut(&this).settings_mut().text.set_left(str(text));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_set_right(this: *mut TextComponent, text: *const c_char) {
-    acc_mut(this).settings_mut().text.set_right(str(text));
+    acc_mut(&this).settings_mut().text.set_right(str(text));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponent_state(
     this: *const TextComponent,
 ) -> OwnedTextComponentState {
-    alloc(acc(this).state())
+    alloc(acc(&this).state())
 }

--- a/capi/src/text_component_state.rs
+++ b/capi/src/text_component_state.rs
@@ -12,7 +12,7 @@ pub unsafe extern "C" fn TextComponentState_drop(this: OwnedTextComponentState) 
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponentState_left(this: *const TextComponentState) -> *const c_char {
-    if let &TextComponentState(Text::Split(ref left, _)) = acc(this) {
+    if let &TextComponentState(Text::Split(ref left, _)) = acc(&this) {
         output_str(left)
     } else {
         output_str("")
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn TextComponentState_left(this: *const TextComponentState
 pub unsafe extern "C" fn TextComponentState_right(
     this: *const TextComponentState,
 ) -> *const c_char {
-    if let &TextComponentState(Text::Split(_, ref right)) = acc(this) {
+    if let &TextComponentState(Text::Split(_, ref right)) = acc(&this) {
         output_str(right)
     } else {
         output_str("")
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn TextComponentState_right(
 pub unsafe extern "C" fn TextComponentState_center(
     this: *const TextComponentState,
 ) -> *const c_char {
-    if let &TextComponentState(Text::Center(ref center)) = acc(this) {
+    if let &TextComponentState(Text::Center(ref center)) = acc(&this) {
         output_str(center)
     } else {
         output_str("")
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn TextComponentState_center(
 
 #[no_mangle]
 pub unsafe extern "C" fn TextComponentState_is_split(this: *const TextComponentState) -> bool {
-    if let &TextComponentState(Text::Split(_, _)) = acc(this) {
+    if let &TextComponentState(Text::Split(_, _)) = acc(&this) {
         true
     } else {
         false

--- a/capi/src/time.rs
+++ b/capi/src/time.rs
@@ -7,7 +7,7 @@ pub type OwnedTime = *mut Time;
 
 #[no_mangle]
 pub unsafe extern "C" fn Time_clone(this: *const Time) -> OwnedTime {
-    alloc(*acc(this))
+    alloc(*acc(&this))
 }
 
 #[no_mangle]
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn Time_drop(this: OwnedTime) {
 
 #[no_mangle]
 pub unsafe extern "C" fn Time_real_time(this: *const Time) -> *const NullableTimeSpan {
-    acc(this)
+    acc(&this)
         .real_time
         .as_ref()
         .map(|t| t as *const _)
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn Time_real_time(this: *const Time) -> *const NullableTim
 
 #[no_mangle]
 pub unsafe extern "C" fn Time_game_time(this: *const Time) -> *const NullableTimeSpan {
-    acc(this)
+    acc(&this)
         .game_time
         .as_ref()
         .map(|t| t as *const _)
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn Time_index(
     this: *const Time,
     timing_method: TimingMethod,
 ) -> *const NullableTimeSpan {
-    acc(this)[timing_method]
+    acc(&this)[timing_method]
         .as_ref()
         .map(|t| t as *const _)
         .unwrap_or_else(ptr::null)

--- a/capi/src/time_span.rs
+++ b/capi/src/time_span.rs
@@ -6,7 +6,7 @@ pub type OwnedTimeSpan = *mut TimeSpan;
 
 #[no_mangle]
 pub unsafe extern "C" fn TimeSpan_clone(this: *const TimeSpan) -> OwnedTimeSpan {
-    alloc(*acc(this))
+    alloc(*acc(&this))
 }
 
 #[no_mangle]
@@ -21,5 +21,5 @@ pub unsafe extern "C" fn TimeSpan_from_seconds(seconds: f64) -> OwnedTimeSpan {
 
 #[no_mangle]
 pub unsafe extern "C" fn TimeSpan_total_seconds(this: *const TimeSpan) -> f64 {
-    acc(this).total_seconds()
+    acc(&this).total_seconds()
 }

--- a/capi/src/timer.rs
+++ b/capi/src/timer.rs
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn Timer_replace_run(
 ) -> bool {
     // This working correctly relies on panic = "abort",
     // as a panic would leave the run in an uninitialized state.
-    let result = acc_mut(this).replace_run(ptr::read(run), update_splits);
+    let result = acc_mut(&this).replace_run(ptr::read(run), update_splits);
     let was_successful = result.is_ok();
     let result = match result {
         Ok(r) | Err(r) => r,
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn Timer_replace_run(
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_set_run(this: *mut Timer, run: OwnedRun) -> NullableOwnedRun {
-    acc_mut(this)
+    acc_mut(&this)
         .set_run(own(run))
         .err()
         .map_or_else(ptr::null_mut, alloc)
@@ -50,140 +50,140 @@ pub unsafe extern "C" fn Timer_set_run(this: *mut Timer, run: OwnedRun) -> Nulla
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_start(this: *mut Timer) {
-    acc_mut(this).start();
+    acc_mut(&this).start();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_split(this: *mut Timer) {
-    acc_mut(this).split();
+    acc_mut(&this).split();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_split_or_start(this: *mut Timer) {
-    acc_mut(this).split_or_start();
+    acc_mut(&this).split_or_start();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_skip_split(this: *mut Timer) {
-    acc_mut(this).skip_split();
+    acc_mut(&this).skip_split();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_undo_split(this: *mut Timer) {
-    acc_mut(this).undo_split();
+    acc_mut(&this).undo_split();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_reset(this: *mut Timer, update_splits: bool) {
-    acc_mut(this).reset(update_splits);
+    acc_mut(&this).reset(update_splits);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_pause(this: *mut Timer) {
-    acc_mut(this).pause();
+    acc_mut(&this).pause();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_resume(this: *mut Timer) {
-    acc_mut(this).resume();
+    acc_mut(&this).resume();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_toggle_pause(this: *mut Timer) {
-    acc_mut(this).toggle_pause();
+    acc_mut(&this).toggle_pause();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_toggle_pause_or_start(this: *mut Timer) {
-    acc_mut(this).toggle_pause_or_start();
+    acc_mut(&this).toggle_pause_or_start();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_undo_all_pauses(this: *mut Timer) {
-    acc_mut(this).undo_all_pauses();
+    acc_mut(&this).undo_all_pauses();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_current_timing_method(this: *const Timer) -> TimingMethod {
-    acc(this).current_timing_method()
+    acc(&this).current_timing_method()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_set_current_timing_method(this: *mut Timer, method: TimingMethod) {
-    acc_mut(this).set_current_timing_method(method);
+    acc_mut(&this).set_current_timing_method(method);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_current_comparison(this: *const Timer) -> *const c_char {
-    output_str(acc(this).current_comparison())
+    output_str(acc(&this).current_comparison())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_switch_to_next_comparison(this: *mut Timer) {
-    acc_mut(this).switch_to_next_comparison();
+    acc_mut(&this).switch_to_next_comparison();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_switch_to_previous_comparison(this: *mut Timer) {
-    acc_mut(this).switch_to_previous_comparison();
+    acc_mut(&this).switch_to_previous_comparison();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_is_game_time_initialized(this: *const Timer) -> bool {
-    acc(this).is_game_time_initialized()
+    acc(&this).is_game_time_initialized()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_initialize_game_time(this: *mut Timer) {
-    acc_mut(this).initialize_game_time();
+    acc_mut(&this).initialize_game_time();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_uninitialize_game_time(this: *mut Timer) {
-    acc_mut(this).uninitialize_game_time();
+    acc_mut(&this).uninitialize_game_time();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_is_game_time_paused(this: *const Timer) -> bool {
-    acc(this).is_game_time_paused()
+    acc(&this).is_game_time_paused()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_pause_game_time(this: *mut Timer) {
-    acc_mut(this).pause_game_time();
+    acc_mut(&this).pause_game_time();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_unpause_game_time(this: *mut Timer) {
-    acc_mut(this).unpause_game_time();
+    acc_mut(&this).unpause_game_time();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_set_game_time(this: *mut Timer, time: *const TimeSpan) {
-    acc_mut(this).set_game_time(*acc(time));
+    acc_mut(&this).set_game_time(*acc(&time));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_loading_times(this: *const Timer) -> *const TimeSpan {
-    output_time_span(acc(this).loading_times())
+    output_time_span(acc(&this).loading_times())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_set_loading_times(this: *mut Timer, time: *const TimeSpan) {
-    acc_mut(this).set_loading_times(*acc(time));
+    acc_mut(&this).set_loading_times(*acc(&time));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_current_phase(this: *const Timer) -> TimerPhase {
-    acc(this).current_phase()
+    acc(&this).current_phase()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_get_run(this: *const Timer) -> *const Run {
-    acc(this).run()
+    acc(&this).run()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Timer_print_debug(this: *const Timer) {
-    println!("{:#?}", acc(this));
+    println!("{:#?}", acc(&this));
 }

--- a/capi/src/timer_component.rs
+++ b/capi/src/timer_component.rs
@@ -28,8 +28,8 @@ pub unsafe extern "C" fn TimerComponent_state_as_json(
     layout_settings: *const GeneralLayoutSettings,
 ) -> Json {
     output_vec(|o| {
-        acc(this)
-            .state(acc(timer), acc(layout_settings))
+        acc(&this)
+            .state(acc(&timer), acc(&layout_settings))
             .write_json(o)
             .unwrap();
     })
@@ -41,5 +41,5 @@ pub unsafe extern "C" fn TimerComponent_state(
     timer: *const Timer,
     layout_settings: *const GeneralLayoutSettings,
 ) -> OwnedTimerComponentState {
-    alloc(acc(this).state(acc(timer), acc(layout_settings)))
+    alloc(acc(&this).state(acc(&timer), acc(&layout_settings)))
 }

--- a/capi/src/timer_component_state.rs
+++ b/capi/src/timer_component_state.rs
@@ -14,19 +14,19 @@ pub unsafe extern "C" fn TimerComponentState_drop(this: OwnedTimerComponentState
 pub unsafe extern "C" fn TimerComponentState_time(
     this: *const TimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerComponentState_fraction(
     this: *const TimerComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).fraction)
+    output_str(&acc(&this).fraction)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerComponentState_semantic_color(
     this: *const TimerComponentState,
 ) -> *const c_char {
-    output_str_with(|f| write!(f, "{:?}", acc(this).semantic_color).unwrap())
+    output_str_with(|f| write!(f, "{:?}", acc(&this).semantic_color).unwrap())
 }

--- a/capi/src/timer_read_lock.rs
+++ b/capi/src/timer_read_lock.rs
@@ -13,5 +13,5 @@ pub unsafe extern "C" fn TimerReadLock_drop(this: OwnedTimerReadLock) {
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerReadLock_timer(this: *const TimerReadLock) -> *const Timer {
-    acc(this).deref()
+    acc(&this).deref()
 }

--- a/capi/src/timer_read_lock.rs
+++ b/capi/src/timer_read_lock.rs
@@ -3,8 +3,8 @@ use super::{acc, own_drop};
 use livesplit_core::parking_lot::RwLockReadGuard;
 use std::ops::Deref;
 
-pub type TimerReadLock = RwLockReadGuard<'static, Timer>;
-pub type OwnedTimerReadLock = *mut TimerReadLock;
+pub type TimerReadLock<'a> = RwLockReadGuard<'a, Timer>;
+pub type OwnedTimerReadLock<'a> = *mut TimerReadLock<'a>;
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerReadLock_drop(this: OwnedTimerReadLock) {

--- a/capi/src/timer_write_lock.rs
+++ b/capi/src/timer_write_lock.rs
@@ -3,8 +3,8 @@ use super::{acc_mut, own_drop};
 use livesplit_core::parking_lot::RwLockWriteGuard;
 use std::ops::DerefMut;
 
-pub type TimerWriteLock = RwLockWriteGuard<'static, Timer>;
-pub type OwnedTimerWriteLock = *mut TimerWriteLock;
+pub type TimerWriteLock<'a> = RwLockWriteGuard<'a, Timer>;
+pub type OwnedTimerWriteLock<'a> = *mut TimerWriteLock<'a>;
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerWriteLock_drop(this: OwnedTimerWriteLock) {

--- a/capi/src/timer_write_lock.rs
+++ b/capi/src/timer_write_lock.rs
@@ -13,5 +13,5 @@ pub unsafe extern "C" fn TimerWriteLock_drop(this: OwnedTimerWriteLock) {
 
 #[no_mangle]
 pub unsafe extern "C" fn TimerWriteLock_timer(this: *mut TimerWriteLock) -> *mut Timer {
-    acc_mut(this).deref_mut()
+    acc_mut(&this).deref_mut()
 }

--- a/capi/src/title_component.rs
+++ b/capi/src/title_component.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn TitleComponent_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
@@ -36,5 +36,5 @@ pub unsafe extern "C" fn TitleComponent_state(
     this: *mut TitleComponent,
     timer: *const Timer,
 ) -> OwnedTitleComponentState {
-    alloc(acc_mut(this).state(acc(timer)))
+    alloc(acc_mut(&this).state(acc(&timer)))
 }

--- a/capi/src/title_component_state.rs
+++ b/capi/src/title_component_state.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn TitleComponentState_drop(this: OwnedTitleComponentState
 pub unsafe extern "C" fn TitleComponentState_icon_change(
     this: *const TitleComponentState,
 ) -> *const Nullablec_char {
-    acc(this)
+    acc(&this)
         .icon_change
         .as_ref()
         .map_or_else(ptr::null, output_str)
@@ -24,43 +24,43 @@ pub unsafe extern "C" fn TitleComponentState_icon_change(
 pub unsafe extern "C" fn TitleComponentState_line1(
     this: *const TitleComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).line1)
+    output_str(&acc(&this).line1)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_line2(
     this: *const TitleComponentState,
 ) -> *const Nullablec_char {
-    acc(this).line2.as_ref().map_or_else(ptr::null, output_str)
+    acc(&this).line2.as_ref().map_or_else(ptr::null, output_str)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_is_centered(this: *const TitleComponentState) -> bool {
-    acc(this).is_centered
+    acc(&this).is_centered
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_shows_finished_runs(
     this: *const TitleComponentState,
 ) -> bool {
-    acc(this).finished_runs.is_some()
+    acc(&this).finished_runs.is_some()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_finished_runs(
     this: *const TitleComponentState,
 ) -> u32 {
-    acc(this).finished_runs.unwrap_or_default()
+    acc(&this).finished_runs.unwrap_or_default()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_shows_attempts(
     this: *const TitleComponentState,
 ) -> bool {
-    acc(this).attempts.is_some()
+    acc(&this).attempts.is_some()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TitleComponentState_attempts(this: *const TitleComponentState) -> u32 {
-    acc(this).attempts.unwrap_or_default()
+    acc(&this).attempts.unwrap_or_default()
 }

--- a/capi/src/total_playtime_component.rs
+++ b/capi/src/total_playtime_component.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn TotalPlaytimeComponent_state_as_json(
     timer: *const Timer,
 ) -> Json {
     output_vec(|o| {
-        acc_mut(this).state(acc(timer)).write_json(o).unwrap();
+        acc_mut(&this).state(acc(&timer)).write_json(o).unwrap();
     })
 }
 
@@ -38,5 +38,5 @@ pub unsafe extern "C" fn TotalPlaytimeComponent_state(
     this: *mut TotalPlaytimeComponent,
     timer: *const Timer,
 ) -> OwnedTotalPlaytimeComponentState {
-    alloc(acc_mut(this).state(acc(timer)))
+    alloc(acc_mut(&this).state(acc(&timer)))
 }

--- a/capi/src/total_playtime_component_state.rs
+++ b/capi/src/total_playtime_component_state.rs
@@ -13,12 +13,12 @@ pub unsafe extern "C" fn TotalPlaytimeComponentState_drop(this: OwnedTotalPlayti
 pub unsafe extern "C" fn TotalPlaytimeComponentState_text(
     this: *const TotalPlaytimeComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).text)
+    output_str(&acc(&this).text)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn TotalPlaytimeComponentState_time(
     this: *const TotalPlaytimeComponentState,
 ) -> *const c_char {
-    output_str(&acc(this).time)
+    output_str(&acc(&this).time)
 }


### PR DESCRIPTION
The current capi has convenience functions for converting raw pointers into references or `str`s, however it gives them `'static` lifetimes which is quite unsafe as it practically disables many lifetime checks that would normally happen with the those references. This PR remedies this issue.

The main changes are in `capi/src/lib.rs` and the rest of the changes are just propagating those changes.

There are a few corner cases that these enhanced functions can't handle, particularly certain iterators such as `OwnedRunMetadataVariablesIter`, since raw pointers can't have lifetime information, however because of the enhanced functions we can easily see these situations and document their lifetime dependence, as I have done in those cases.