### PR TITLE
Resume Run Functionality

### DIFF
--- a/capi/bind_gen/src/typescript.rs
+++ b/capi/bind_gen/src/typescript.rs
@@ -243,6 +243,7 @@ export interface RunEditorStateJson {
     icon_change: string | null,
     game: string,
     category: string,
+    stop_time: string,
     offset: string,
     attempts: number,
     timing_method: TimingMethodJson,

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -180,6 +180,11 @@ pub unsafe extern "C" fn Run_metadata(this: *const Run) -> *const RunMetadata {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Run_stop_time(this: *const Run) -> *const TimeSpan {
+    output_time_span(acc(this).stop_time())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn Run_offset(this: *const Run) -> *const TimeSpan {
     output_time_span(acc(this).offset())
 }

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -129,6 +129,17 @@ impl Editor {
         self.run.set_category_name(name);
         self.raise_run_edited();
     }
+	
+	pub fn stop_time(&self) -> TimeSpan {
+		self.run.stop_time()
+	}
+	
+	pub fn set_stop_time(&mut self, stop_time: TimeSpan) {
+		self.run.set_stop_time(stop_time);
+		self.raise_run_edited();
+	}
+	
+
 
     pub fn offset(&self) -> TimeSpan {
         self.run.offset()

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -10,6 +10,7 @@ pub struct State {
     pub icon_change: Option<String>,
     pub game: String,
     pub category: String,
+    pub stop_time: String,
     pub offset: String,
     pub attempts: u32,
     pub timing_method: TimingMethod,
@@ -62,6 +63,7 @@ impl Editor {
             .map(str::to_owned);
         let game = self.game_name().to_string();
         let category = self.category_name().to_string();
+	let stop_time = formatter.format(self.stop_time()).to_string();
         let offset = formatter.format(self.offset()).to_string();
         let attempts = self.attempt_count();
         let timing_method = self.selected_timing_method();
@@ -122,6 +124,7 @@ impl Editor {
             icon_change: icon_change,
             game: game,
             category: category,
+            stop_time: stop_time,
             offset: offset,
             attempts: attempts,
             timing_method: timing_method,

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -384,11 +384,14 @@ pub fn parse<R: BufRead>(source: R, path: Option<PathBuf>) -> Result<Run> {
             } else if tag.name() == b"CategoryName" {
                 required_flags |= 1 << 2;
                 text(reader, tag.into_buf(), |t| run.set_category_name(t))
+			} else if tag.name() == b"StopTime" {
+				required_flags |= 1 << 3;
+				time_span(reader, tag.into_buf(), |t| run.set_stop_time(t))
             } else if tag.name() == b"Offset" {
-                required_flags |= 1 << 3;
+                required_flags |= 1 << 4;
                 time_span(reader, tag.into_buf(), |t| run.set_offset(t))
             } else if tag.name() == b"AttemptCount" {
-                required_flags |= 1 << 4;
+                required_flags |= 1 << 5;
                 text_parsed(reader, tag.into_buf(), |t| run.set_attempt_count(t))
             } else if tag.name() == b"AttemptHistory" {
                 parse_attempt_history(version, reader, tag.into_buf(), &mut run)

--- a/src/run/parser/wsplit.rs
+++ b/src/run/parser/wsplit.rs
@@ -37,6 +37,11 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
                 run.set_category_name(&line["Title=".len()..]);
             } else if line.starts_with("Attempts=") {
                 run.set_attempt_count(line["Attempts=".len()..].parse()?);
+	    } else if line.starts_with("StopTime=") {
+	    	let stop_time = &line["StopTime=".len()..];
+		if !stop_time.is_empty() {
+		    run.set_stop_time(TimeSpan::from_milliseconds(-stop_time.parse::<f64>()?));
+		}
             } else if line.starts_with("Offset=") {
                 let offset = &line["Offset=".len()..];
                 if !offset.is_empty() {

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -11,6 +11,7 @@ pub struct Run {
     game_icon: Image,
     game_name: String,
     category_name: String,
+    stop_time: TimeSpan,
     offset: TimeSpan,
     attempt_count: u32,
     attempt_history: Vec<Attempt>,
@@ -42,6 +43,7 @@ impl Run {
             game_icon: Image::default(),
             game_name: String::new(),
             category_name: String::new(),
+	    stop_time: TimeSpan::zero(),
             offset: TimeSpan::zero(),
             attempt_count: 0,
             attempt_history: Vec::new(),
@@ -99,6 +101,11 @@ impl Run {
     }
 
     #[inline]
+    pub fn set_stop_time(&mut self, stop_time: TimeSpan) {
+	self.stop_time = stop_time;
+    }
+
+    #[inline]
     pub fn set_offset(&mut self, offset: TimeSpan) {
         self.offset = offset;
     }
@@ -121,6 +128,11 @@ impl Run {
     #[inline]
     pub fn metadata_mut(&mut self) -> &mut RunMetadata {
         &mut self.metadata
+    }
+
+    #[inline]
+    pub fn stop_time(&self) -> TimeSpan {
+	self.stop_time
     }
 
     #[inline]

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -243,6 +243,7 @@ pub fn save<W: Write>(run: &Run, writer: W) -> Result<()> {
     )?;
     write_end(writer, b"Metadata")?;
 
+    time_span(writer, new_tag(b"StopTime"), run.stop_time(), buf)?;
     time_span(writer, new_tag(b"Offset"), run.offset(), buf)?;
     write_display(writer, new_tag(b"AttemptCount"), run.attempt_count(), buf)?;
 


### PR DESCRIPTION
In order to accommodate the new Resume Run Functionality within LiveSplit, I needed to enhance LiveSplit-Core to look for and handle StopTime. StopTime is the time the timer was stopped at during a run. 