### PR TITLE
Python bindings: Automatically convert C strings to and from str type

### DIFF
--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -162,6 +162,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
                 "self.ptr".to_string()
             } else if typ.is_custom {
                 format!("{}.ptr", name)
+            } else if typ.name == "c_char" {
+                format!("{}.encode()", name)
             } else {
                 name.to_string()
             }
@@ -170,8 +172,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
 
     write!(writer, ")")?;
 
-    if has_return_type && function.output.is_custom {
-        write!(writer, r#")"#)?;
+    if has_return_type {
+        if function.output.is_custom {
+            write!(writer, r#")"#)?;
+        } else if function.output.name == "c_char" {
+            write!(writer, r#".decode()"#)?;
+        }
     }
 
     for &(ref name, ref typ) in function.inputs.iter() {


### PR DESCRIPTION
Currently, python function bindings taking or returning strings use a byte object `bytes` instead of string representation `str`. This is very unintuitive, leading to confusion when, for example, passing a string literal results in a `ctypes.ArgumentError`. Working around the issue forces relatively ugly code like this:
```python
run.set_game_name(b"Celeste")
run.set_category_name(b"Any%")
...
print(run.game_name.decode())
print(run.category_name.decode())
```
This fork cleans up API usage by running `str.encode` on every string argument and `bytes.decode` on every string return value.