### PR TITLE
Implement Columns for the Splits Component

### DIFF
--- a/src/comparison/average_segments.rs
+++ b/src/comparison/average_segments.rs
@@ -25,11 +25,11 @@ const WEIGHT: f64 = 0.75;
 fn generate(segments: &mut [Segment], method: TimingMethod) {
     let mut accumulated = Some(TimeSpan::zero());
 
-    // TODO This may actually be possible to be fixed with a window like
+    // TODO: This may actually be possible to be fixed with a window like
     // iterator.
     #[allow(needless_range_loop)]
     for i in 0..segments.len() {
-        // TODO Borrowcheck. if accumulated.is_some() is only necessary because
+        // TODO: Borrowcheck. if accumulated.is_some() is only necessary because
         // we can't assign to the outer variable otherwise.
         if accumulated.is_some() {
             let (mut total_weights, mut total_time) = (0.0, 0.0);

--- a/src/comparison/median_segments.rs
+++ b/src/comparison/median_segments.rs
@@ -25,11 +25,11 @@ const WEIGHT: f64 = 0.75;
 fn generate(segments: &mut [Segment], medians: &mut Vec<(f64, f64)>, method: TimingMethod) {
     let mut accumulated = Some(TimeSpan::zero());
 
-    // TODO This may actually be possible to be fixed with a window like
+    // TODO: This may actually be possible to be fixed with a window like
     // iterator.
     #[allow(needless_range_loop)]
     for i in 0..segments.len() {
-        // TODO Borrowcheck. if accumulated.is_some() is only necessary because
+        // TODO: Borrowcheck. if accumulated.is_some() is only necessary because
         // we can't assign to the outer variable otherwise.
         if accumulated.is_some() {
             medians.clear();

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -375,7 +375,10 @@ impl Component {
         if !draw_info.deltas.is_empty() {
             let mut height_one = if total_delta != TimeSpan::zero() {
                 (-draw_info.max_delta.total_milliseconds() / total_delta.total_milliseconds())
-                    as f32 * (graph_height - graph_edge) * 2.0 + graph_edge
+                    as f32
+                    * (graph_height - graph_edge)
+                    * 2.0
+                    + graph_edge
             } else {
                 graph_height
             };
@@ -448,7 +451,9 @@ impl Component {
             *height_one = (delta.total_milliseconds() as f32
                 - draw_info.max_delta.total_milliseconds() as f32)
                 / total_delta.total_milliseconds() as f32
-                * (graph_height - graph_edge) * 2.0 + graph_edge;
+                * (graph_height - graph_edge)
+                * 2.0
+                + graph_edge;
         } else {
             *height_one = graph_height;
         }
@@ -490,7 +495,9 @@ impl Component {
             *height_two = (delta.total_milliseconds() as f32
                 - draw_info.max_delta.total_milliseconds() as f32)
                 / total_delta.total_milliseconds() as f32
-                * (graph_height - graph_edge) * 2.0 + graph_edge;
+                * (graph_height - graph_edge)
+                * 2.0
+                + graph_edge;
         } else {
             *height_two = graph_height;
         }
@@ -578,7 +585,7 @@ impl Component {
         draw_info: &DrawInfo,
     ) -> (f32, f32, f32) {
         let mut graph_edge = 0.0;
-        let graph_height = HEIGHT / 2.0; // TODO Make const
+        let graph_height = HEIGHT / 2.0; // TODO: Make const
         let middle = if total_delta != TimeSpan::zero() {
             graph_edge = GRAPH_EDGE_VALUE
                 / (-total_delta.total_milliseconds() as f32 + 2.0 * GRAPH_EDGE_VALUE)
@@ -586,7 +593,9 @@ impl Component {
             graph_edge += GRAPH_EDGE_MIN;
             (-(draw_info.max_delta.total_milliseconds() as f32
                 / total_delta.total_milliseconds() as f32))
-                * (graph_height - graph_edge) * 2.0 + graph_edge
+                * (graph_height - graph_edge)
+                * 2.0
+                + graph_edge
         } else {
             graph_height
         };
@@ -642,7 +651,7 @@ impl Component {
                 let timing_method = timer.current_timing_method();
                 let mut best_segment =
                     analysis::check_live_delta(timer, true, comparison, timing_method);
-                // TODO Try if let instead of checking current phase up there,
+                // TODO: Try if let instead of checking current phase up there,
                 // so we can skip this unwrap
                 let current_split =
                     timer.current_split().unwrap().comparison(comparison)[timing_method];

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -94,7 +94,7 @@ impl HotkeySystem {
         })
     }
 
-    // TODO Ignore errors in a lot of situations
+    // TODO: Ignore errors in a lot of situations
     //
     // If unregister works and register fails for example, you won't be able to
     // register again, as unregistering will fail forever. Also in initial start

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -417,7 +417,7 @@ impl Editor {
 
         let max_index = self.run.max_attempt_history_index().unwrap_or(0);
         let min_index = self.run.min_segment_history_index();
-        for x in min_index..max_index + 1 {
+        for x in min_index..=max_index {
             segment.segment_history_mut().insert(x, Default::default());
         }
         self.run.segments_mut().insert(active_segment, segment);
@@ -442,7 +442,7 @@ impl Editor {
 
         let max_index = self.run.max_attempt_history_index().unwrap_or(0);
         let min_index = self.run.min_segment_history_index();
-        for x in min_index..max_index + 1 {
+        for x in min_index..=max_index {
             segment.segment_history_mut().insert(x, Default::default());
         }
         self.run.segments_mut().insert(next_segment, segment);
@@ -467,7 +467,7 @@ impl Editor {
 
         let max_index = self.run.max_attempt_history_index().unwrap_or(0);
         let min_index = self.run.min_segment_history_index();
-        for run_index in min_index..max_index + 1 {
+        for run_index in min_index..=max_index {
             // If a history element isn't there in the segment that's deleted
             // remove it from the next segment's history as well
             if let Some(segment_history_element) =
@@ -577,7 +577,7 @@ impl Editor {
         let first = &mut a[0];
         let second = &mut b[0];
 
-        for run_index in min_index..max_index + 1 {
+        for run_index in min_index..=max_index {
             // Remove both segment history elements if one of them has a None
             // time and the other has has a non None time
             let first_history = first.segment_history().get(run_index);
@@ -687,13 +687,13 @@ impl Editor {
     ) -> ComparisonResult<()> {
         let comparison = comparison.into();
         self.run.add_custom_comparison(comparison.as_str())?;
-        // TODO Borrowcheck (remaining_segments isn't used after this block
+        // TODO: Borrowcheck (remaining_segments isn't used after this block
         // anymore. NLL should fix this)
         {
             let mut remaining_segments = self.run.segments_mut().as_mut_slice();
 
             for segment in run.segments().iter().take(run.len().saturating_sub(1)) {
-                // TODO Borrowcheck (new_start is only necessary because the
+                // TODO: Borrowcheck (new_start is only necessary because the
                 // remaining_segments reassignment doesn't work inside this
                 // if)
                 let new_start = if let Some((segment_index, my_segment)) = remaining_segments
@@ -706,7 +706,7 @@ impl Editor {
                 } else {
                     0
                 };
-                // TODO Borrowcheck (get rid of the move block around
+                // TODO: Borrowcheck (get rid of the move block around
                 // remaining_segments)
                 remaining_segments = &mut { remaining_segments }[new_start..];
             }
@@ -781,7 +781,7 @@ impl Editor {
     /// one of the indices is invalid. The indices are based on the
     /// `comparison_names` field of the Run Editor's `State`.
     pub fn move_comparison(&mut self, src_index: usize, dst_index: usize) -> Result<(), ()> {
-        // TODO Borrowcheck (comparisons isn't used after this block anymore. NLL
+        // TODO: Borrowcheck (comparisons isn't used after this block anymore. NLL
         // should fix this)
         {
             let comparisons = self.run.custom_comparisons_mut();
@@ -795,11 +795,11 @@ impl Editor {
 
             if src_index > dst_index {
                 rotate_left(
-                    &mut comparisons[dst_index..src_index + 1],
+                    &mut comparisons[dst_index..=src_index],
                     src_index - dst_index,
                 );
             } else {
-                rotate_left(&mut comparisons[src_index..dst_index + 1], 1);
+                rotate_left(&mut comparisons[src_index..=dst_index], 1);
             }
         }
         self.raise_run_edited();

--- a/src/run/editor/tests/mark_as_modified.rs
+++ b/src/run/editor/tests/mark_as_modified.rs
@@ -307,4 +307,4 @@ fn not_when_cleaning_sum_of_best_without_applying_a_fix() {
     assert!(!editor.run().has_been_modified());
 }
 
-// TODO Cleaning Sum of Best
+// TODO: Cleaning Sum of Best

--- a/src/run/parser/face_split.rs
+++ b/src/run/parser/face_split.rs
@@ -69,9 +69,9 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     let mut lines = source.lines();
 
     run.set_category_name(lines.next().ok_or(Error::ExpectedTitle)??);
-    lines.next(); // TODO Store Goal
+    lines.next(); // TODO: Store Goal
     run.set_attempt_count(lines.next().ok_or(Error::ExpectedAttemptCount)??.parse()?);
-    lines.next(); // TODO Store runs completed somehow
+    lines.next(); // TODO: Store runs completed somehow
 
     for line in lines {
         let line = line?;

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -1,4 +1,4 @@
-use super::{Accuracy, TimeFormatter, DASH};
+use super::{Accuracy, TimeFormatter, DASH, MINUS};
 use std::fmt::{Display, Formatter, Result};
 use TimeSpan;
 
@@ -10,8 +10,7 @@ pub struct Inner {
 /// The Regular Time Formatter formats Time Spans to always show the minutes and
 /// is configurable by how many digits of the fractional part are shown. By
 /// default no fractional part is shown. This Time Formatter is most suitable
-/// for visualizing split times. You may not use this Time Formatter with
-/// negative times.
+/// for visualizing split times.
 ///
 /// # Example Formatting
 ///
@@ -22,6 +21,7 @@ pub struct Inner {
 /// * Seconds with Hundredths `0:23.12`
 /// * Minutes with Hundredths `12:34.98`
 /// * Hours with Hundredths `12:34:56.12`
+/// * Negative Times `−0:23`
 pub struct Regular {
     accuracy: Accuracy,
 }
@@ -65,7 +65,11 @@ impl<'a> TimeFormatter<'a> for Regular {
 impl Display for Inner {
     fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
-            let total_seconds = time.total_seconds();
+            let mut total_seconds = time.total_seconds();
+            if total_seconds < 0.0 {
+                total_seconds *= -1.0;
+                write!(f, "{}", MINUS)?;
+            }
             let seconds = total_seconds % 60.0;
             let total_minutes = (total_seconds / 60.0) as u64;
             let minutes = total_minutes % 60;

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -246,7 +246,7 @@ impl Timer {
             self.deinitialize_game_time();
             self.run.start_next_run();
 
-            // TODO OnStart
+            // TODO: OnStart
         }
     }
 
@@ -254,10 +254,9 @@ impl Timer {
     /// current split. The attempt ends if the last split time is stored.
     pub fn split(&mut self) {
         let current_time = self.current_time();
-        if self.phase == Running
-            && current_time
-                .real_time
-                .map_or(false, |t| t >= TimeSpan::zero())
+        if self.phase == Running && current_time
+            .real_time
+            .map_or(false, |t| t >= TimeSpan::zero())
         {
             self.current_split_mut()
                 .unwrap()
@@ -269,7 +268,7 @@ impl Timer {
             }
             self.run.mark_as_modified();
 
-            // TODO OnSplit
+            // TODO: OnSplit
         }
     }
 
@@ -293,7 +292,7 @@ impl Timer {
             self.current_split_index = self.current_split_index.map(|i| i + 1);
             self.run.mark_as_modified();
 
-            // TODO OnSkipSplit
+            // TODO: OnSkipSplit
         }
     }
 
@@ -309,7 +308,7 @@ impl Timer {
             self.current_split_mut().unwrap().clear_split_time();
             self.run.mark_as_modified();
 
-            // TODO OnUndoSplit
+            // TODO: OnUndoSplit
         }
     }
 
@@ -359,7 +358,7 @@ impl Timer {
             segment.clear_split_time();
         }
 
-        // TODO OnReset
+        // TODO: OnReset
 
         self.run.fix_splits();
         self.run.regenerate_comparisons();
@@ -371,7 +370,7 @@ impl Timer {
             self.time_paused_at = self.current_time().real_time.unwrap();
             self.phase = Paused;
 
-            // TODO OnPause
+            // TODO: OnPause
         }
     }
 
@@ -381,7 +380,7 @@ impl Timer {
             self.adjusted_start_time = TimeStamp::now() - self.time_paused_at;
             self.phase = Running;
 
-            // TODO OnResume
+            // TODO: OnResume
         }
     }
 
@@ -421,7 +420,8 @@ impl Timer {
             Ended => {
                 let pause_time = Some(self.get_pause_time().unwrap_or_default());
 
-                let split_time = self.run
+                let split_time = self
+                    .run
                     .segments_mut()
                     .iter_mut()
                     .last()
@@ -437,7 +437,7 @@ impl Timer {
 
         self.adjusted_start_time = self.start_time_with_offset;
 
-        // TODO OnUndoAllPauses
+        // TODO: OnUndoAllPauses
     }
 
     /// Switches the current comparison to the next comparison in the list.
@@ -450,7 +450,7 @@ impl Timer {
         let index = (index + 1) % len;
         self.current_comparison = self.run.comparisons().nth(index).unwrap().to_owned();
 
-        // TODO OnNextComparison
+        // TODO: OnNextComparison
     }
 
     /// Switches the current comparison to the previous comparison in the list.
@@ -463,7 +463,7 @@ impl Timer {
         let index = (index + len - 1) % len;
         self.current_comparison = self.run.comparisons().nth(index).unwrap().to_owned();
 
-        // TODO OnPreviousComparison
+        // TODO: OnPreviousComparison
     }
 
     /// Returns the total duration of the current attempt. This is not affected


### PR DESCRIPTION
This implements initial support for columns for the splits component. The columns differ a bit from the original LiveSplit in that they don't have a single type. Instead they define a value they start out with and
a value they get updated with. This allows for some interesting combinations that were not possible before.