### PR TITLE
Implement Horizontal Layouts

### DIFF
--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -95,8 +95,8 @@ export enum TimerPhase {
 export interface BlankSpaceComponentStateJson {
     /** The background shown behind the component. */
     background: Gradient,
-    /** The height of the component. */
-    height: number,
+    /** The size of the component. */
+    size: number,
 }
 
 /** The state object describes the information to visualize for this component. */
@@ -665,7 +665,11 @@ export type SettingsDescriptionValueJson =
     { ColumnUpdateWith: ColumnUpdateWith } |
     { ColumnUpdateTrigger: ColumnUpdateTrigger } |
     { Hotkey: string } |
+    { LayoutDirection: LayoutDirection } |
     { CustomCombobox: CustomCombobox };
+
+/** Describes the direction the components of a layout are laid out in. */
+export type LayoutDirection = "Vertical" | "Horizontal";
 
 /**
  * A custom Combobox containing its current value and a list of possible

--- a/capi/src/blank_space_component_state.rs
+++ b/capi/src/blank_space_component_state.rs
@@ -11,8 +11,8 @@ pub extern "C" fn BlankSpaceComponentState_drop(this: OwnedBlankSpaceComponentSt
     drop(this);
 }
 
-/// The height of the component.
+/// The size of the component.
 #[no_mangle]
-pub extern "C" fn BlankSpaceComponentState_height(this: &BlankSpaceComponentState) -> u32 {
-    this.height
+pub extern "C" fn BlankSpaceComponentState_size(this: &BlankSpaceComponentState) -> u32 {
+    this.size
 }

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -23,15 +23,15 @@ pub struct Component {
 pub struct Settings {
     /// The background shown behind the component.
     pub background: Gradient,
-    /// The height of the component.
-    pub height: u32,
+    /// The size of the component.
+    pub size: u32,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
             background: Gradient::Transparent,
-            height: 24,
+            size: 24,
         }
     }
 }
@@ -41,8 +41,8 @@ impl Default for Settings {
 pub struct State {
     /// The background shown behind the component.
     pub background: Gradient,
-    /// The height of the component.
-    pub height: u32,
+    /// The size of the component.
+    pub size: u32,
 }
 
 impl State {
@@ -85,7 +85,7 @@ impl Component {
     pub fn state(&self, _timer: &Timer) -> State {
         State {
             background: self.settings.background,
-            height: self.settings.height,
+            size: self.settings.size,
         }
     }
 
@@ -94,7 +94,7 @@ impl Component {
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
             Field::new("Background".into(), self.settings.background.into()),
-            Field::new("Height".into(), u64::from(self.settings.height).into()),
+            Field::new("Size".into(), u64::from(self.settings.size).into()),
         ])
     }
 
@@ -108,7 +108,7 @@ impl Component {
     pub fn set_value(&mut self, index: usize, value: Value) {
         match index {
             0 => self.settings.background = value.into(),
-            1 => self.settings.height = value.into_uint().unwrap() as _,
+            1 => self.settings.size = value.into_uint().unwrap() as _,
             _ => panic!("Unsupported Setting Index"),
         }
     }

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -1,9 +1,12 @@
+use super::LayoutDirection;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 
 /// The general settings of the layout that apply to all components.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GeneralSettings {
+    /// The direction which the components are laid out in.
+    pub direction: LayoutDirection,
     /// The background to show behind the layout.
     pub background: Gradient,
     /// The color to use for when the runner achieved a best segment.
@@ -37,6 +40,7 @@ pub struct GeneralSettings {
 impl Default for GeneralSettings {
     fn default() -> Self {
         Self {
+            direction: LayoutDirection::Vertical,
             background: Gradient::Plain(Color::hsla(0.0, 0.0, 0.06, 1.0)),
             best_segment_color: Color::hsla(50.0, 1.0, 0.5, 1.0),
             ahead_gaining_time_color: Color::hsla(136.0, 1.0, 0.4, 1.0),
@@ -58,6 +62,7 @@ impl GeneralSettings {
     /// layout and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
+            Field::new("Layout Direction".into(), self.direction.into()),
             Field::new("Background".into(), self.background.into()),
             Field::new("Best Segment".into(), self.best_segment_color.into()),
             Field::new(
@@ -94,18 +99,19 @@ impl GeneralSettings {
     /// the setting provided is out of bounds.
     pub fn set_value(&mut self, index: usize, value: Value) {
         match index {
-            0 => self.background = value.into(),
-            1 => self.best_segment_color = value.into(),
-            2 => self.ahead_gaining_time_color = value.into(),
-            3 => self.ahead_losing_time_color = value.into(),
-            4 => self.behind_gaining_time_color = value.into(),
-            5 => self.behind_losing_time_color = value.into(),
-            6 => self.not_running_color = value.into(),
-            7 => self.personal_best_color = value.into(),
-            8 => self.paused_color = value.into(),
-            9 => self.thin_separators_color = value.into(),
-            10 => self.separators_color = value.into(),
-            11 => self.text_color = value.into(),
+            0 => self.direction = value.into(),
+            1 => self.background = value.into(),
+            2 => self.best_segment_color = value.into(),
+            3 => self.ahead_gaining_time_color = value.into(),
+            4 => self.ahead_losing_time_color = value.into(),
+            5 => self.behind_gaining_time_color = value.into(),
+            6 => self.behind_losing_time_color = value.into(),
+            7 => self.not_running_color = value.into(),
+            8 => self.personal_best_color = value.into(),
+            9 => self.paused_color = value.into(),
+            10 => self.thin_separators_color = value.into(),
+            11 => self.separators_color = value.into(),
+            12 => self.text_color = value.into(),
             _ => panic!("Unsupported Setting Index"),
         }
     }

--- a/src/layout/layout_direction.rs
+++ b/src/layout/layout_direction.rs
@@ -1,0 +1,8 @@
+/// Describes the direction the components of a layout are laid out in.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LayoutDirection {
+    /// The components are placed on top of each other vertically.
+    Vertical,
+    /// The components are placed next to each other horizontally.
+    Horizontal,
+}

--- a/src/layout/layout_state.rs
+++ b/src/layout/layout_state.rs
@@ -1,4 +1,4 @@
-use super::ComponentState;
+use super::{ComponentState, LayoutDirection};
 use crate::settings::{Color, Gradient};
 use serde_json::{to_writer, Result};
 use std::io::Write;
@@ -8,6 +8,8 @@ use std::io::Write;
 pub struct LayoutState {
     /// The state objects for all of the components in the layout.
     pub components: Vec<ComponentState>,
+    /// The direction which the components are laid out in.
+    pub direction: LayoutDirection,
     /// The background to show behind the layout.
     pub background: Gradient,
     /// The color of thin separators.

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -7,6 +7,7 @@ mod component_settings;
 mod component_state;
 pub mod editor;
 mod general_settings;
+mod layout_direction;
 mod layout_settings;
 mod layout_state;
 pub mod parser;
@@ -16,6 +17,7 @@ pub use self::component_settings::ComponentSettings;
 pub use self::component_state::ComponentState;
 pub use self::editor::Editor;
 pub use self::general_settings::GeneralSettings;
+pub use self::layout_direction::LayoutDirection;
 pub use self::layout_settings::LayoutSettings;
 pub use self::layout_state::LayoutState;
 
@@ -92,17 +94,18 @@ impl Layout {
                 .iter_mut()
                 .map(|c| c.state(timer, settings))
                 .collect(),
-            background: self.settings.background,
-            thin_separators_color: self.settings.thin_separators_color,
-            separators_color: self.settings.separators_color,
-            text_color: self.settings.text_color,
+            background: settings.background,
+            thin_separators_color: settings.thin_separators_color,
+            separators_color: settings.separators_color,
+            text_color: settings.text_color,
+            direction: settings.direction,
         }
     }
 
     /// Accesses the settings of the layout.
     pub fn settings(&self) -> LayoutSettings {
         LayoutSettings {
-            components: self.components.iter().map(|c| c.settings()).collect(),
+            components: self.components.iter().map(Component::settings).collect(),
             general: self.settings.clone(),
         }
     }

--- a/src/layout/parser/blank_space.rs
+++ b/src/layout/parser/blank_space.rs
@@ -19,7 +19,7 @@ where
     parse_children::<_, _, Error>(reader, buf, |reader, tag| {
         if let Some(tag) = background_builder.parse_background(reader, tag)? {
             if tag.name() == b"SpaceHeight" {
-                text_parsed(reader, tag.into_buf(), |h| settings.height = h)
+                text_parsed(reader, tag.into_buf(), |h| settings.size = h)
             } else {
                 // FIXME:
                 // SpaceWidth

--- a/src/layout/parser/graph.rs
+++ b/src/layout/parser/graph.rs
@@ -26,10 +26,7 @@ where
                 settings.ahead_background_color = c
             })
         } else if tag.name() == b"GridlinesColor" {
-            color(reader, tag.into_buf(), |c| {
-                println!("{:?} <- {:?}", settings.grid_lines_color, c);
-                settings.grid_lines_color = c
-            })
+            color(reader, tag.into_buf(), |c| settings.grid_lines_color = c)
         } else if tag.name() == b"PartialFillColorAhead" {
             // Version >= 1.2
             color(reader, tag.into_buf(), |c| settings.partial_fill_color = c)

--- a/src/layout/parser/splits.rs
+++ b/src/layout/parser/splits.rs
@@ -150,7 +150,7 @@ where
                                 start_with: ColumnStartWith::Empty,
                                 update_with: ColumnUpdateWith::Delta,
                                 update_trigger: ColumnUpdateTrigger::Contextual,
-                                comparison_override: comparison_override,
+                                comparison_override,
                                 timing_method: None,
                             });
                         }

--- a/src/rendering/component/current_comparison.rs
+++ b/src/rendering/component/current_comparison.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::current_comparison::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -14,8 +14,9 @@ pub(in crate::rendering) fn render(
     context.render_info_text_component(
         &[&component.text, "Comparison"],
         &component.comparison,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/current_pace.rs
+++ b/src/rendering/component/current_pace.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::current_pace::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -33,8 +33,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         abbreviations,
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/delta.rs
+++ b/src/rendering/component/delta.rs
@@ -1,7 +1,7 @@
 use crate::{
     comparison,
     component::delta::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -15,8 +15,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         &[&component.text, comparison::shorten(&component.text)],
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.visual_color,
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -1,7 +1,10 @@
 use crate::{
     component::detailed_timer::State,
     layout::LayoutState,
-    rendering::{component::timer, icon::Icon, Backend, RenderContext, MARGIN},
+    rendering::{
+        component::timer, icon::Icon, vertical_padding, Backend, RenderContext, BOTH_PADDINGS,
+        PADDING,
+    },
 };
 
 pub(in crate::rendering) fn render<B: Backend>(
@@ -13,7 +16,8 @@ pub(in crate::rendering) fn render<B: Backend>(
 ) {
     context.render_rectangle([0.0, 0.0], [width, height], &component.background);
 
-    let icon_size = height - 2.0 * MARGIN;
+    let vertical_padding = vertical_padding(height);
+    let icon_size = height - 2.0 * vertical_padding;
 
     if let Some(url) = &component.icon_change {
         if let Some(old_icon) = detailed_timer_icon.take() {
@@ -23,10 +27,10 @@ pub(in crate::rendering) fn render<B: Backend>(
     }
 
     let left_side = if let Some(icon) = detailed_timer_icon {
-        context.render_icon([MARGIN, MARGIN], [icon_size, icon_size], icon);
-        2.0 * MARGIN + icon_size
+        context.render_icon([PADDING, vertical_padding], [icon_size, icon_size], icon);
+        BOTH_PADDINGS + icon_size
     } else {
-        MARGIN
+        PADDING
     };
 
     let top_height = 0.55 * height;
@@ -92,7 +96,7 @@ pub(in crate::rendering) fn render<B: Backend>(
             .max(time_width);
     }
 
-    let time_x = name_end + MARGIN + time_width;
+    let time_x = name_end + PADDING + time_width;
 
     if let Some(comparison) = &component.comparison2 {
         context.render_numbers(

--- a/src/rendering/component/graph.rs
+++ b/src/rendering/component/graph.rs
@@ -17,13 +17,13 @@ use {
 
 pub(in crate::rendering) fn render(
     context: &mut RenderContext<'_, impl Backend>,
-    [_, height]: [f32; 2],
+    [width, height]: [f32; 2],
     component: &State,
     _layout_state: &LayoutState,
 ) {
-    let (old_width, old_transform) = (context.width, context.transform);
+    let old_transform = context.transform;
     context.scale(height);
-    let width = context.width;
+    let width = width / height;
 
     const GRID_LINE_WIDTH: f32 = 0.015;
     const LINE_WIDTH: f32 = 0.025;
@@ -157,6 +157,5 @@ pub(in crate::rendering) fn render(
         }
     }
 
-    context.width = old_width;
     context.transform = old_transform;
 }

--- a/src/rendering/component/possible_time_save.rs
+++ b/src/rendering/component/possible_time_save.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::possible_time_save::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -33,8 +33,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         abbreviations,
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/previous_segment.rs
+++ b/src/rendering/component/previous_segment.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::previous_segment::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -27,8 +27,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         abbreviations,
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.visual_color,
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/sum_of_best.rs
+++ b/src/rendering/component/sum_of_best.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::sum_of_best::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -14,8 +14,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         &[&component.text, "Sum of Best", "SoB"],
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/component/text.rs
+++ b/src/rendering/component/text.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::text::{State, Text},
-    layout::LayoutState,
-    rendering::{Backend, RenderContext, MARGIN},
+    layout::{LayoutDirection, LayoutState},
+    rendering::{Backend, RenderContext, DEFAULT_TEXT_SIZE, PADDING, TEXT_ALIGN_TOP},
 };
 
 pub(in crate::rendering) fn render(
@@ -14,10 +14,10 @@ pub(in crate::rendering) fn render(
     match &component.text {
         Text::Center(text) => context.render_text_centered(
             text,
-            MARGIN,
-            width - MARGIN,
-            [0.5 * width, 0.7],
-            0.8,
+            PADDING,
+            width - PADDING,
+            [0.5 * width, TEXT_ALIGN_TOP],
+            DEFAULT_TEXT_SIZE,
             component
                 .left_center_color
                 .unwrap_or(layout_state.text_color),
@@ -25,11 +25,12 @@ pub(in crate::rendering) fn render(
         Text::Split(left, right) => context.render_info_text_component(
             &[&left],
             &right,
+            [width, height],
             component
                 .left_center_color
                 .unwrap_or(layout_state.text_color),
             component.right_color.unwrap_or(layout_state.text_color),
-            component.display_two_rows,
+            component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
         ),
     }
 }

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::timer::State,
-    rendering::{Backend, RenderContext, MARGIN},
+    rendering::{Backend, RenderContext, DEFAULT_TEXT_SIZE, PADDING},
 };
 
 pub(in crate::rendering) fn render(
@@ -11,8 +11,8 @@ pub(in crate::rendering) fn render(
     context.render_rectangle([0.0, 0.0], [width, height], &component.background);
     let x = context.render_timer(
         &component.fraction,
-        [width - MARGIN, 0.85 * height],
-        0.8 * height,
+        [width - PADDING, 0.85 * height],
+        DEFAULT_TEXT_SIZE * height,
         [component.bottom_color, component.top_color],
     );
     context.render_timer(

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         component::title::State,
         layout::LayoutState,
-        rendering::{icon::Icon, Backend, RenderContext, MARGIN},
+        rendering::{
+            icon::Icon, vertical_padding, Backend, RenderContext, BOTH_PADDINGS, DEFAULT_TEXT_SIZE,
+            PADDING, TEXT_ALIGN_BOTTOM, TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP,
+        },
     },
     livesplit_title_abbreviations::abbreviate,
 };
@@ -25,11 +28,12 @@ pub(in crate::rendering) fn render<B: Backend>(
     }
 
     let left_bound = if let Some(icon) = game_icon {
-        let icon_size = 2.0 - 2.0 * MARGIN;
-        context.render_icon([MARGIN, MARGIN], [icon_size, icon_size], icon);
-        2.0 * MARGIN + icon_size
+        let vertical_padding = vertical_padding(height);
+        let icon_size = height - 2.0 * vertical_padding;
+        context.render_icon([PADDING, vertical_padding], [icon_size, icon_size], icon);
+        BOTH_PADDINGS + icon_size
     } else {
-        MARGIN
+        PADDING
     };
 
     let (line_x, align) = if component.is_centered {
@@ -45,8 +49,8 @@ pub(in crate::rendering) fn render<B: Backend>(
     let abbreviations = abbreviate(&component.line1);
     let line1 = context.choose_abbreviation(
         abbreviations.iter().map(String::as_str),
-        0.8,
-        width - MARGIN - left_bound,
+        DEFAULT_TEXT_SIZE,
+        width - PADDING - left_bound,
     );
 
     let attempts = match (component.finished_runs, component.attempts) {
@@ -54,22 +58,26 @@ pub(in crate::rendering) fn render<B: Backend>(
         (Some(a), _) | (_, Some(a)) => a.to_string(),
         _ => String::new(),
     };
-    let line2_end_x =
-        context.render_numbers(&attempts, [width - MARGIN, 1.63], 0.8, [text_color; 2]);
+    let line2_end_x = context.render_numbers(
+        &attempts,
+        [width - PADDING, height + TEXT_ALIGN_BOTTOM],
+        DEFAULT_TEXT_SIZE,
+        [text_color; 2],
+    );
 
     let (line1_y, line1_end_x) = if let Some(line2) = &component.line2 {
         context.render_text_align(
             line2,
             left_bound,
-            line2_end_x - MARGIN,
-            [line_x, 1.63],
-            0.8,
+            line2_end_x - PADDING,
+            [line_x, height + TEXT_ALIGN_BOTTOM],
+            DEFAULT_TEXT_SIZE,
             align,
             text_color,
         );
-        (0.83, width - MARGIN)
+        (TEXT_ALIGN_TOP, width - PADDING)
     } else {
-        (1.2, line2_end_x - MARGIN)
+        (height / 2.0 + TEXT_ALIGN_CENTER, line2_end_x - PADDING)
     };
 
     context.render_text_align(
@@ -77,7 +85,7 @@ pub(in crate::rendering) fn render<B: Backend>(
         left_bound,
         line1_end_x,
         [line_x, line1_y],
-        0.8,
+        DEFAULT_TEXT_SIZE,
         align,
         text_color,
     );

--- a/src/rendering/component/total_playtime.rs
+++ b/src/rendering/component/total_playtime.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::total_playtime::State,
-    layout::LayoutState,
+    layout::{LayoutDirection, LayoutState},
     rendering::{Backend, RenderContext},
 };
 
@@ -14,8 +14,9 @@ pub(in crate::rendering) fn render(
     context.render_info_time_component(
         &[&component.text, "Playtime"],
         &component.time,
+        dim,
         component.label_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
-        component.display_two_rows,
+        component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
     );
 }

--- a/src/rendering/glyph_cache.rs
+++ b/src/rendering/glyph_cache.rs
@@ -32,7 +32,7 @@ impl<M> GlyphCache<M> {
     ) -> &M {
         self.glyphs.entry(glyph).or_insert_with(|| {
             let metrics = font.v_metrics(Scale::uniform(1.0));
-            let delta_h = (metrics.ascent - metrics.descent).recip();
+            let delta_h = metrics.ascent - metrics.descent;
             let offset_h = metrics.descent;
 
             let glyph = font.glyph(glyph).scaled(Scale::uniform(1.0));
@@ -63,7 +63,7 @@ impl<M> GlyphCache<M> {
 
             let path = builder.build();
 
-            let mut glyph_mesh: Mesh = Mesh::new();
+            let mut glyph_mesh = Mesh::new();
             let mut tessellator = FillTessellator::new();
             tessellator
                 .tessellate_path(
@@ -74,7 +74,7 @@ impl<M> GlyphCache<M> {
                 .unwrap();
 
             for vertex in glyph_mesh.vertices_mut() {
-                vertex.v = (-vertex.y - offset_h) / delta_h;
+                vertex.v = (-vertex.y - offset_h) * delta_h;
             }
 
             backend.create_mesh(&glyph_mesh)

--- a/src/rendering/software/mod.rs
+++ b/src/rendering/software/mod.rs
@@ -90,7 +90,7 @@ impl Backend for SoftwareBackend {
     }
     fn free_texture(&mut self, _: Self::Texture) {}
 
-    fn resize(&mut self, _: f32) {}
+    fn resize(&mut self, _: f32, _: f32) {}
 }
 
 struct NoDepth([usize; 2]);

--- a/src/rendering/software/tests.rs
+++ b/src/rendering/software/tests.rs
@@ -2,7 +2,7 @@ use {
     super::render,
     crate::{
         component,
-        layout::{self, Layout, LayoutState},
+        layout::{self, Component, Layout, LayoutDirection, LayoutState},
         run::parser::{livesplit, llanfair, wsplit},
         tests_helper, Run, Timer,
     },
@@ -39,7 +39,7 @@ fn default() {
 
     let state = layout.state(&timer);
 
-    check(&state, 0xe4f643cb, "default");
+    check(&state, 0xaa93be84, "default");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn actual_split_file() {
     let timer = Timer::new(run).unwrap();
     let mut layout = Layout::default_layout();
 
-    check(&layout.state(&timer), 0x7ca4c8db, "actual_split_file");
+    check(&layout.state(&timer), 0x2e274e3e, "actual_split_file");
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn wsplit() {
     let timer = Timer::new(run).unwrap();
     let mut layout = lsl("tests/layout_files/WSplit.lsl");
 
-    check_dims(&layout.state(&timer), [250, 300], 0x1f81d9cf, "wsplit");
+    check_dims(&layout.state(&timer), [250, 300], 0xf3d67b92, "wsplit");
 }
 
 #[test]
@@ -73,9 +73,9 @@ fn all_components() {
 
     let state = layout.state(&timer);
 
-    check_dims(&state, [300, 800], 0x2b6a2a14, "all_components");
+    check_dims(&state, [300, 800], 0x17358ffe, "all_components");
 
-    check_dims(&state, [150, 800], 0xf9c76ec8, "all_components_thin");
+    check_dims(&state, [150, 800], 0xb6d7bba6, "all_components_thin");
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn score_split() {
     state.components.push(ComponentState::Timer(timer_state));
     state.components.push(prev_seg);
 
-    check_dims(&state, [300, 400], 0x2ca22c6d, "score_split");
+    check_dims(&state, [300, 400], 0x271ca3b5, "score_split");
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn dark_layout() {
     let timer = Timer::new(run).unwrap();
     let mut layout = lsl("tests/layout_files/dark.lsl");
 
-    check(&layout.state(&timer), 0x54a82761, "dark_layout");
+    check(&layout.state(&timer), 0xaefa906f, "dark_layout");
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn subsplits_layout() {
     check_dims(
         &layout.state(&timer),
         [300, 800],
-        0x33fefeb8,
+        0xc34c3323,
         "subsplits_layout",
     );
 }
@@ -145,9 +145,61 @@ fn display_two_rows() {
     check_dims(
         &layout.state(&timer),
         [200, 100],
-        0x39aa87c3,
+        0x2f0674f6,
         "display_two_rows",
     );
+}
+
+#[test]
+fn single_line_title() {
+    let mut run = tests_helper::create_run(&["A"]);
+    run.set_game_name("Some Game");
+    run.set_category_name("Some Category");
+    run.set_attempt_count(1337);
+    let timer = Timer::new(run).unwrap();
+    let mut layout = Layout::new();
+    let mut component = component::title::Component::new();
+    let settings = component.settings_mut();
+    settings.display_as_single_line = true;
+    settings.show_attempt_count = true;
+    settings.show_finished_runs_count = true;
+    layout.push(component);
+
+    check_dims(
+        &layout.state(&timer),
+        [150, 30],
+        0x10fb224c,
+        "single_line_title",
+    );
+}
+
+#[test]
+fn horizontal() {
+    let run = lss("tests/run_files/Celeste - Any% (1.2.1.5).lss");
+    let mut timer = Timer::new(run).unwrap();
+    let mut layout = Layout::default_layout();
+    layout.general_settings_mut().direction = LayoutDirection::Horizontal;
+    match &mut layout.components[1] {
+        Component::Splits(splits) => splits.settings_mut().visual_split_count = 4,
+        _ => unreachable!("We wanted to configure the splits"),
+    }
+    layout.push(component::separator::Component::new());
+    layout.push(component::graph::Component::new());
+    layout.push(component::separator::Component::new());
+    layout.push(Box::new(
+        component::detailed_timer::Component::with_settings(component::detailed_timer::Settings {
+            display_icon: true,
+            ..Default::default()
+        }),
+    ));
+
+    tests_helper::start_run(&mut timer);
+    tests_helper::make_progress_run_with_splits_opt(
+        &mut timer,
+        &[Some(10.0), None, Some(20.0), Some(55.0)],
+    );
+
+    check_dims(&layout.state(&timer), [1500, 40], 0x49d1b352, "horizontal");
 }
 
 fn check(state: &LayoutState, expected_checksum: u32, name: &str) {

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -1,8 +1,11 @@
-use super::{Alignment, Color, Gradient, ListGradient};
-use crate::component::splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith};
-use crate::hotkey::KeyCode;
-use crate::timing::formatter::{Accuracy, DigitsFormat};
-use crate::TimingMethod;
+use crate::{
+    component::splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith},
+    hotkey::KeyCode,
+    layout::LayoutDirection,
+    settings::{Alignment, Color, Gradient, ListGradient},
+    timing::formatter::{Accuracy, DigitsFormat},
+    TimingMethod,
+};
 use std::result::Result as StdResult;
 
 /// Describes a setting's value. Such a value can be of a variety of different
@@ -49,6 +52,8 @@ pub enum Value {
     ColumnUpdateTrigger(ColumnUpdateTrigger),
     /// A value describing what hotkey to press to trigger a certain action.
     Hotkey(Option<KeyCode>),
+    /// A value describing the direction of a layout.
+    LayoutDirection(LayoutDirection),
 }
 
 quick_error! {
@@ -216,6 +221,14 @@ impl Value {
             _ => Err(Error::WrongType),
         }
     }
+
+    /// Tries to convert the value into a layout direction.
+    pub fn into_layout_direction(self) -> Result<LayoutDirection> {
+        match self {
+            Value::LayoutDirection(v) => Ok(v),
+            _ => Err(Error::WrongType),
+        }
+    }
 }
 
 impl Into<bool> for Value {
@@ -323,5 +336,11 @@ impl Into<ColumnUpdateTrigger> for Value {
 impl Into<Option<KeyCode>> for Value {
     fn into(self) -> Option<KeyCode> {
         self.into_hotkey().unwrap()
+    }
+}
+
+impl Into<LayoutDirection> for Value {
+    fn into(self) -> LayoutDirection {
+        self.into_layout_direction().unwrap()
     }
 }


### PR DESCRIPTION
Implement horizontal layouts for livesplit-core.

There's a few changes in how they work compared to the original LiveSplit. In the original LiveSplit we simply flipped the logic between the two axes. This doesn't work well in practice though, as text always flows horizontally and it is the main problem when it comes to the layout. Text can't arbitrarily be shaped, and cutting it off (or even abbreviating it) loses valuable information. Therefore the livesplit-core port pursues a different strategy, a more hybrid approach between both layout directions. Essentially the height of the window now similar to how it works in vertical mode, merely influences the resolution of the content. Increasing the height doesn't introduce any additional spacing, the content is just adjusted to fit the height chosen. Instead the width now, similar to how it works in vertical mode, decides on how wide to render the components. If text doesn't fit, it needs to be cut off. But this way now allows the user to widen the window to show more text, while the horizontal mode in the original LiveSplit always showed the same amount of text, as it always chose the same component space width, regardless of the aspect ratio or other influences.

Roadmap:
- [x] Add basic support for horizontal layouts.
- [x] Clean up the matrix math.
- [x] Add constants for "first row" and "second row", as these positions keep reappearing.
    - [x] Document the constants.
    - [x] There also seem to be vertical icon paddings.
- [x] Lay out the splits horizontally.
- [x] Change window width when the layout changes.
- [x] Implement better component width hints. (They should probably use the component space coordinates, e.g. the width of one column is 3 component units).
- [x] Calculate proper window dimensions when changing between horizontal and vertical (we can probably somehow make it so we choose the new dimensions such that the component space coordinates are the same size as before. New Window Height = Window Height * Two Row Height / Old Layout Height, New Window Width = Layout Width * New Window Height / Two Row Height).
- [x] Make sure the C API works.
- [x] Fix up the documentation.
    - [x] Document the "legacy" component space (24 legacy units equals 1 component unit).
- [x] Implement tests.
    - [x] Single Line Mode for Title Component is probably broken now with the new height.

Resolves #173 