### PR TITLE
Switch Error Handling to snafu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,10 @@ odds = { version = "0.3.1", default-features = false }
 ordered-float = "1.0.0"
 palette = { version = "0.4.0", default-features = false }
 parking_lot = { version = "0.9.0", default-features = false }
-quick-error = "1.2.2"
 quick-xml = { version = "0.15.0", default-features = false }
-serde = "1.0.55"
-serde_derive = "1.0.55"
+serde = { version = "1.0.55", features = ["derive"] }
 serde_json = "1.0.8"
+snafu = { version = "0.4.3", default-features = false, features = ["rust_1_30"] }
 unicase = "2.2.0"
 utf-8 = "0.7.4"
 
@@ -63,7 +62,7 @@ smallvec = { version = "0.6.9", default-features = false, optional = true }
 
 # Software Rendering
 euc = { version = "0.3.0", default-features = false, optional = true }
-vek = { version = "0.9.6", default-features = false, optional = true }
+vek = { version = "0.9.8", default-features = false, optional = true }
 
 [dev-dependencies]
 memmem = "0.1.1"

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -27,6 +27,5 @@ stdweb = "0.3.0"
 parking_lot = "0.8.0"
 
 [dependencies]
-quick-error = "1.2.2"
-serde_derive = "1.0.55"
-serde = "1.0.55"
+snafu = { version = "0.4.3", default-features = false, features = ["rust_1_30"] }
+serde = { version = "1.0.55", features = ["derive"] }

--- a/crates/livesplit-hotkey/src/emscripten/key_code.rs
+++ b/crates/livesplit-hotkey/src/emscripten/key_code.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 // Based on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
 
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum KeyCode {
     Again,
     AltLeft,

--- a/crates/livesplit-hotkey/src/emscripten/mod.rs
+++ b/crates/livesplit-hotkey/src/emscripten/mod.rs
@@ -7,12 +7,10 @@ use std::sync::Arc;
 use stdweb::web::event::{IKeyboardEvent, KeypressEvent};
 use stdweb::web::{window, EventListenerHandle, IEventTarget};
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        AlreadyRegistered {}
-        NotRegistered {}
-    }
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    AlreadyRegistered,
+    NotRegistered,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -1,9 +1,5 @@
+// For js! macro.
 #![recursion_limit = "1024"]
-
-#[macro_use]
-extern crate quick_error;
-#[macro_use]
-extern crate serde_derive;
 
 #[cfg(windows)]
 pub mod windows;

--- a/crates/livesplit-hotkey/src/linux/key_code.rs
+++ b/crates/livesplit-hotkey/src/linux/key_code.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 #[repr(u32)]
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum KeyCode {
     BackSpace = 0xFF08,
     Tab = 0xFF09,

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -13,16 +13,14 @@ use x11_dl::xlib::{
     Display, GrabModeAsync, KeyPress, KeyPressMask, Mod2Mask, XErrorEvent, XKeyEvent, Xlib,
 };
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        NoXLib {}
-        OpenXServerConnection {}
-        EPoll {}
-        ThreadStopped {}
-        AlreadyRegistered {}
-        NotRegistered {}
-    }
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    NoXLib,
+    OpenXServerConnection,
+    EPoll,
+    ThreadStopped,
+    AlreadyRegistered,
+    NotRegistered,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/livesplit-hotkey/src/other/mod.rs
+++ b/crates/livesplit-hotkey/src/other/mod.rs
@@ -1,12 +1,9 @@
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-    }
-}
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {}
 
 pub type Result<T> = StdResult<T, Error>;
 
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub struct KeyCode;
 
 pub struct Hook;

--- a/crates/livesplit-hotkey/src/wasm/key_code.rs
+++ b/crates/livesplit-hotkey/src/wasm/key_code.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 // Based on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
 
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum KeyCode {
     Again,
     AltLeft,

--- a/crates/livesplit-hotkey/src/wasm/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm/mod.rs
@@ -5,12 +5,10 @@ use std::collections::hash_map::{Entry, HashMap};
 use std::sync::{Arc, Mutex};
 use std::{slice, str};
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        AlreadyRegistered {}
-        NotRegistered {}
-    }
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    AlreadyRegistered,
+    NotRegistered,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/livesplit-hotkey/src/windows/key_code.rs
+++ b/crates/livesplit-hotkey/src/windows/key_code.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 #[repr(u8)]
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum KeyCode {
     LButton = 0x01,
     RButton = 0x02,

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -19,15 +19,13 @@ use winapi::um::winuser::{KBDLLHOOKSTRUCT, WH_KEYBOARD_LL, WM_KEYDOWN};
 
 const MSG_EXIT: UINT = 0x400;
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        AlreadyRegistered {}
-        NotRegistered {}
-        WindowsHook {}
-        ThreadStopped {}
-        MessageLoop {}
-    }
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    AlreadyRegistered,
+    NotRegistered,
+    WindowsHook,
+    ThreadStopped,
+    MessageLoop,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -5,6 +5,7 @@
 
 use crate::settings::{Field, Gradient, SettingsDescription, Value};
 use crate::Timer;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -5,6 +5,7 @@
 use super::DEFAULT_INFO_TEXT_GRADIENT;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::Timer;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -8,6 +8,7 @@ use crate::analysis::current_pace;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, Regular, TimeFormatter};
 use crate::{comparison, Timer, TimerPhase};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -7,6 +7,7 @@ use crate::analysis::{delta, state_helper};
 use crate::settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, Delta, TimeFormatter};
 use crate::{comparison, GeneralLayoutSettings, Timer};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -14,6 +14,7 @@ use crate::timing::formatter::{
 use crate::{
     CachedImageId, GeneralLayoutSettings, Segment, TimeSpan, Timer, TimerPhase, TimingMethod,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -5,6 +5,7 @@
 
 use crate::settings::{Color, Field, SettingsDescription, Value};
 use crate::{analysis, comparison, GeneralLayoutSettings, TimeSpan, Timer, TimerPhase};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -9,6 +9,7 @@ use crate::analysis::possible_time_save;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, PossibleTimeSave, TimeFormatter};
 use crate::{comparison, Timer, TimerPhase};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::fmt::Write as FmtWrite;

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -9,6 +9,7 @@ use super::DEFAULT_INFO_TEXT_GRADIENT;
 use crate::settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, Delta, PossibleTimeSave, TimeFormatter};
 use crate::{analysis, comparison, GeneralLayoutSettings, Timer, TimerPhase};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::fmt::Write as FmtWrite;

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -4,6 +4,7 @@
 
 use crate::settings::{SettingsDescription, Value};
 use crate::Timer;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -5,6 +5,7 @@ use crate::{
     timing::formatter::{Delta, PossibleTimeSave, Regular, TimeFormatter},
     GeneralLayoutSettings, Segment, TimeSpan, Timer, TimingMethod,
 };
+use serde::{Deserialize, Serialize};
 
 /// The settings of an individual column showing timing information on each
 /// split.

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     settings::{Color, Field, Gradient, ListGradient, SettingsDescription, Value},
     CachedImageId, GeneralLayoutSettings, Timer,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::cmp::{max, min};

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -12,6 +12,7 @@ use crate::analysis::sum_of_segments::calculate_best;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, Regular, TimeFormatter};
 use crate::Timer;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/text.rs
+++ b/src/component/text.rs
@@ -5,6 +5,7 @@
 
 use super::DEFAULT_INFO_TEXT_GRADIENT;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -9,6 +9,7 @@ use crate::timing::formatter::{timer as formatter, Accuracy, DigitsFormat, TimeF
 use crate::{GeneralLayoutSettings, TimeSpan, Timer, TimerPhase, TimingMethod};
 use palette::rgb::LinSrgb;
 use palette::Hsv;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::settings::{Alignment, Color, Field, Gradient, SettingsDescription, Value};
 use crate::{CachedImageId, Image, Timer, TimerPhase};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -7,6 +7,7 @@ use crate::analysis::total_playtime;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::timing::formatter::{Days, Regular, TimeFormatter};
 use crate::Timer;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::borrow::Cow;
 use std::io::Write;

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -2,6 +2,7 @@
 
 use crate::hotkey::KeyCode;
 use crate::settings::{Field, SettingsDescription, Value};
+use serde::{Deserialize, Serialize};
 use serde_json::{self, from_reader, to_writer};
 use std::io::{Read, Write};
 

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 
 /// A Component provides information about a run in a way that is easy to
 /// visualize. This type can store any of the components provided by this crate.
-#[derive(From, Clone)]
+#[derive(derive_more::From, Clone)]
 pub enum Component {
     /// The Blank Space Component.
     BlankSpace(blank_space::Component),

--- a/src/layout/component_settings.rs
+++ b/src/layout/component_settings.rs
@@ -4,6 +4,7 @@ use crate::component::{
     possible_time_save, previous_segment, separator, splits, sum_of_best, text, timer, title,
     total_playtime,
 };
+use serde::{Deserialize, Serialize};
 
 /// The settings for one of the components available.
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/layout/component_state.rs
+++ b/src/layout/component_state.rs
@@ -3,6 +3,7 @@ use crate::component::{
     possible_time_save, previous_segment, separator, splits, sum_of_best, text, timer, title,
     total_playtime,
 };
+use serde::{Deserialize, Serialize};
 
 /// The state object for one of the components available.
 #[derive(Serialize, Deserialize)]

--- a/src/layout/editor/mod.rs
+++ b/src/layout/editor/mod.rs
@@ -22,14 +22,12 @@ pub struct Editor {
     selected_component: usize,
 }
 
-quick_error! {
-    /// Describes an Error that occurred while opening the Layout Editor.
-    #[derive(Debug)]
-    pub enum Error {
-        /// The Layout Editor couldn't be opened because an empty layout with no
-        /// components was provided.
-        EmptyLayout {}
-    }
+/// Describes an Error that occurred while opening the Layout Editor.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// The Layout Editor couldn't be opened because an empty layout with no
+    /// components was provided.
+    EmptyLayout,
 }
 
 /// The Result type for the Layout Editor.

--- a/src/layout/editor/state.rs
+++ b/src/layout/editor/state.rs
@@ -1,5 +1,6 @@
 use super::Editor;
 use crate::settings::SettingsDescription;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result as JsonResult};
 use std::io::Write;
 

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -1,5 +1,6 @@
 use super::LayoutDirection;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
+use serde::{Deserialize, Serialize};
 
 /// The general settings of the layout that apply to all components.
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/layout/layout_direction.rs
+++ b/src/layout/layout_direction.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Describes the direction the components of a layout are laid out in.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LayoutDirection {

--- a/src/layout/layout_settings.rs
+++ b/src/layout/layout_settings.rs
@@ -1,4 +1,5 @@
 use super::{ComponentSettings, GeneralSettings};
+use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_writer, Result};
 use std::io::{Read, Write};
 

--- a/src/layout/layout_state.rs
+++ b/src/layout/layout_state.rs
@@ -1,5 +1,6 @@
 use super::{ComponentState, LayoutDirection};
 use crate::settings::{Color, Gradient};
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result};
 use std::io::Write;
 

--- a/src/layout/parser/splits.rs
+++ b/src/layout/parser/splits.rs
@@ -106,7 +106,7 @@ where
                                             ColumnUpdateWith::SegmentDeltaWithFallback,
                                             ColumnUpdateTrigger::Contextual,
                                         ),
-                                        _ => return Err(Error::ColumnType),
+                                        _ => return Err(Error::ParseColumnType),
                                     };
                                     column.start_with = start_with;
                                     column.update_with = update_with;

--- a/src/layout/parser/title.rs
+++ b/src/layout/parser/title.rs
@@ -40,7 +40,7 @@ where
                         b"0" => Alignment::Auto,
                         b"1" => Alignment::Left,
                         b"2" => Alignment::Center,
-                        _ => return Err(Error::Alignment),
+                        _ => return Err(Error::ParseAlignment),
                     };
                     Ok(())
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,6 @@
 //! assert_eq!(timer.current_phase(), TimerPhase::NotRunning);
 //! ```
 
-#[macro_use]
-extern crate derive_more;
-#[macro_use]
-extern crate quick_error;
-#[macro_use]
-extern crate serde_derive;
-
 mod platform;
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -4,6 +4,7 @@ use crate::run::RunMetadata;
 use crate::timing::formatter::none_wrapper::EmptyWrapper;
 use crate::timing::formatter::{Accuracy, Short, TimeFormatter};
 use crate::CachedImageId;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_writer, Result as JsonResult};
 use std::io::Write;
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -85,15 +85,13 @@ impl PartialEq for ComparisonGenerators {
     }
 }
 
-quick_error! {
-    /// Error type for an invalid comparison name
-    #[derive(PartialEq, Debug)]
-    pub enum ComparisonError {
-        /// Comparison name starts with "[Race]"
-        NameStartsWithRace {}
-        /// Comparison name is a duplicate
-        DuplicateName {}
-    }
+/// Error type for an invalid comparison name
+#[derive(PartialEq, Debug, snafu::Snafu)]
+pub enum ComparisonError {
+    /// Comparison name starts with "[Race]".
+    NameStartsWithRace,
+    /// Comparison name is a duplicate.
+    DuplicateName,
 }
 
 /// Result type for an invalid comparison name

--- a/src/run/parser/flitter/mod.rs
+++ b/src/run/parser/flitter/mod.rs
@@ -1,6 +1,7 @@
 //! Provides the parser for Flitter splits files.
 
 use crate::{comparison::world_record, Run, Segment, Time, TimeSpan};
+use serde::Deserialize;
 use std::io::BufRead;
 use std::result::Result as StdResult;
 

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -3,29 +3,116 @@
 use crate::{Image, RealTime, Run, Segment, Time, TimeSpan};
 use byteorder::{ReadBytesExt, BE};
 use image::{png, ColorType, ImageBuffer, Rgba};
+use snafu::{OptionExt, ResultExt};
 use std::io::{self, Read, Seek, SeekFrom};
 use std::result::Result as StdResult;
 use std::str::{from_utf8, Utf8Error};
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the Llanfair
-    /// Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// The Header doesn't match the header of a Llanfair file.
-        InvalidHeader {}
-        /// The length of an image or string was larger than the total remaining
-        /// splits file.
-        LengthOutOfBounds {}
-        /// Failed to decode a string as UTF-8.
-        Utf8(err: Utf8Error) {
-            from()
-        }
-        /// Failed to read from the source.
-        Io(err: io::Error) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the Llanfair
+/// Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to read the header.
+    ReadHeader {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// The Header doesn't match the header of a Llanfair file.
+    InvalidHeader,
+    /// Failed to determine the length of the file.
+    DetermineLength {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to skip ahead to the goal.
+    SkipToGoal {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the goal.
+    ReadGoal {
+        /// The underlying error.
+        source: StringError,
+    },
+    /// Failed to skip ahead to the title.
+    SkipToTitle {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the title.
+    ReadTitle {
+        /// The underlying error.
+        source: StringError,
+    },
+    /// Failed to read the amount of segments.
+    ReadSegmentCount {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the next segment.
+    ReadSegment {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the best segment time of a segment.
+    ReadBestSegment {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the icon of a segment.
+    ReadIcon {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// The icon of a segment has invalid dimensions.
+    #[snafu(display(
+        "The dimensions {}x{} of a segment's icon are not valid.",
+        width,
+        height
+    ))]
+    InvalidIconDimensions {
+        /// The width of the icon.
+        width: u32,
+        /// The height of the icon.
+        height: u32,
+    },
+    /// Failed to read the data of a segment's icon.
+    ReadImageData {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the name of a segment.
+    ReadSegmentName {
+        /// The underlying error.
+        source: StringError,
+    },
+    /// Failed to read the segment time of a segment.
+    ReadSegmentTime {
+        /// The underlying error.
+        source: io::Error,
+    },
+}
+
+/// An error type that indicates that a string failed to be parsed.
+#[derive(Debug, snafu::Snafu)]
+pub enum StringError {
+    /// Failed to read the length of the string.
+    ReadLength {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// The string was larger than the total remaining splits file.
+    LengthOutOfBounds,
+    /// Failed to read the string data.
+    ReadData {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// The string is not encoded as valid UTF-8.
+    Validate {
+        /// The underlying error.
+        source: Utf8Error,
+    },
 }
 
 /// The Result type for the Llanfair Parser.
@@ -39,16 +126,20 @@ fn to_time(milliseconds: u64) -> Time {
     }
 }
 
-fn read_string<R: Read>(mut source: R, buf: &mut Vec<u8>, max_length: u64) -> Result<&str> {
-    let str_length = source.read_u16::<BE>()? as usize;
+fn read_string<R: Read>(
+    mut source: R,
+    buf: &mut Vec<u8>,
+    max_length: u64,
+) -> StdResult<&str, StringError> {
+    let str_length = source.read_u16::<BE>().context(ReadLength)? as usize;
     if str_length as u64 > max_length {
-        return Err(Error::LengthOutOfBounds);
+        return Err(StringError::LengthOutOfBounds);
     }
     buf.clear();
     buf.reserve(str_length);
     unsafe { buf.set_len(str_length) };
-    source.read_exact(buf)?;
-    from_utf8(buf).map_err(Into::into)
+    source.read_exact(buf).context(ReadData)?;
+    from_utf8(buf).context(Validate)
 }
 
 /// Attempts to parse a Llanfair splits file.
@@ -70,26 +161,28 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
         0x61, 0x69, 0x72, 0x2E, 0x52, 0x75, 0x6E,
     ];
     let mut header_buf = [0; 30];
-    source.read_exact(&mut header_buf)?;
+    source.read_exact(&mut header_buf).context(ReadHeader)?;
     if HEADER != header_buf {
         return Err(Error::InvalidHeader);
     }
 
     // Determine total length of the source
-    let total_len = source.seek(SeekFrom::End(0))?;
+    let total_len = source.seek(SeekFrom::End(0)).context(DetermineLength)?;
 
     let mut run = Run::new();
 
     // Skip to the goal string
-    source.seek(SeekFrom::Start(0xc5))?;
-    run.set_category_name(read_string(&mut source, &mut buf, total_len)?);
+    source.seek(SeekFrom::Start(0xc5)).context(SkipToGoal)?;
+    run.set_category_name(read_string(&mut source, &mut buf, total_len).context(ReadGoal)?);
 
     // Skip to the title string
-    source.read_u8()?;
-    run.set_game_name(read_string(&mut source, &mut buf, total_len)?);
+    source.read_u8().context(SkipToTitle)?;
+    run.set_game_name(read_string(&mut source, &mut buf, total_len).context(ReadTitle)?);
 
-    source.seek(SeekFrom::Current(0x6))?;
-    let segment_count = source.read_u32::<BE>()?;
+    source
+        .seek(SeekFrom::Current(0x6))
+        .context(ReadSegmentCount)?;
+    let segment_count = source.read_u32::<BE>().context(ReadSegmentCount)?;
 
     // The object header changes if there is no instance of one of the object
     // used by the Run class. The 2 objects that can be affected are the Time
@@ -100,53 +193,55 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
     let mut aggregate_time_ms = 0;
 
     // Seek to the first byte of the first segment
-    source.seek(SeekFrom::Current(0x8F))?;
+    source.seek(SeekFrom::Current(0x8F)).context(ReadSegment)?;
     for _ in 0..segment_count {
         let mut icon = None;
         let mut best_segment_ms = 0;
 
-        let id = source.read_u8()?;
+        let id = source.read_u8().context(ReadSegment)?;
         if id != 0x70 {
             if !time_encountered {
                 time_encountered = true;
 
                 // Seek past the object declaration
-                source.seek(SeekFrom::Current(0x36))?;
+                source.seek(SeekFrom::Current(0x36)).context(ReadSegment)?;
             } else {
-                source.seek(SeekFrom::Current(0x5))?;
+                source.seek(SeekFrom::Current(0x5)).context(ReadSegment)?;
             }
 
-            best_segment_ms = source.read_u64::<BE>()?;
+            best_segment_ms = source.read_u64::<BE>().context(ReadBestSegment)?;
         }
 
-        let id = source.read_u8()?;
+        let id = source.read_u8().context(ReadIcon)?;
         if id != 0x70 {
             let seek_offset_base = if !icon_encountered {
                 icon_encountered = true;
-                source.seek(SeekFrom::Current(0xBC))?;
+                source.seek(SeekFrom::Current(0xBC)).context(ReadIcon)?;
                 0x25
             } else {
-                source.seek(SeekFrom::Current(0x5))?;
+                source.seek(SeekFrom::Current(0x5)).context(ReadIcon)?;
                 0x18
             };
-            let height = source.read_u32::<BE>()?;
-            let width = source.read_u32::<BE>()?;
+            let height = source.read_u32::<BE>().context(ReadIcon)?;
+            let width = source.read_u32::<BE>().context(ReadIcon)?;
 
-            source.seek(SeekFrom::Current(seek_offset_base))?;
+            source
+                .seek(SeekFrom::Current(seek_offset_base))
+                .context(ReadIcon)?;
 
             let len = (width as usize)
                 .checked_mul(height as usize)
                 .and_then(|b| b.checked_mul(4))
-                .ok_or(Error::LengthOutOfBounds)?;
+                .context(InvalidIconDimensions { width, height })?;
 
             if len as u64 > total_len || width == 0 || height == 0 {
-                return Err(Error::LengthOutOfBounds);
+                return Err(Error::InvalidIconDimensions { width, height });
             }
 
             buf.clear();
             buf.reserve(len);
             unsafe { buf.set_len(len) };
-            source.read_exact(&mut buf)?;
+            source.read_exact(&mut buf).context(ReadImageData)?;
 
             if let Some(image) = ImageBuffer::<Rgba<u8>, _>::from_raw(width, height, buf.as_slice())
             {
@@ -161,18 +256,21 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
         }
 
         // Skip to the segment name
-        source.read_u8()?;
-        let mut segment = Segment::new(read_string(&mut source, &mut buf, total_len)?);
+        source.read_u8().context(ReadSegment)?;
+        let mut segment =
+            Segment::new(read_string(&mut source, &mut buf, total_len).context(ReadSegmentName)?);
 
         if let Some(icon) = icon {
             segment.set_icon(icon);
         }
 
         // Read the segment time
-        let id = source.read_u8()?;
+        let id = source.read_u8().context(ReadSegmentTime)?;
         let segment_time_ms = match id {
             0x71 => {
-                source.seek(SeekFrom::Current(0x4))?;
+                source
+                    .seek(SeekFrom::Current(0x4))
+                    .context(ReadSegmentTime)?;
                 best_segment_ms
             }
             0x70 => 0,
@@ -180,8 +278,10 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
                 // Since there is always a best segment when there is a best
                 // time in Llanfair, I assume that there will never be another
                 // Time object declaration before this data.
-                source.seek(SeekFrom::Current(0x5))?;
-                source.read_u64::<BE>()?
+                source
+                    .seek(SeekFrom::Current(0x5))
+                    .context(ReadSegmentTime)?;
+                source.read_u64::<BE>().context(ReadSegmentTime)?
             }
         };
 
@@ -196,7 +296,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
         run.push_segment(segment);
 
         // Seek to the beginning of the next segment name
-        source.seek(SeekFrom::Current(0x6))?;
+        source.seek(SeekFrom::Current(0x6)).context(ReadSegment)?;
     }
 
     Ok(run)

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -12,30 +12,32 @@ use std::io::BufRead;
 
 use crate::xml_util::Error as XmlError;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the Llanfair
-    /// Rewrite Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// The underlying XML format couldn't be parsed.
-        Xml(err: XmlError) {
-            from()
-        }
-        /// Failed to decode a string slice as UTF-8.
-        Utf8Str(err: std::str::Utf8Error) {
-            from()
-        }
-        /// Failed to decode a string as UTF-8.
-        Utf8String(err: std::string::FromUtf8Error) {
-            from()
-        }
-        /// Failed to parse an integer.
-        Int(err: std::num::ParseIntError) {
-            from()
-        }
-        /// Failed to parse an image.
-        Image {}
-    }
+/// The Error type for splits files that couldn't be parsed by the Llanfair
+/// Rewrite Parser.
+#[derive(Debug, snafu::Snafu, derive_more::From)]
+pub enum Error {
+    /// The underlying XML format couldn't be parsed.
+    Xml {
+        /// The underlying error.
+        source: XmlError,
+    },
+    /// Failed to decode a string slice as UTF-8.
+    Utf8Str {
+        /// The underlying error.
+        source: std::str::Utf8Error,
+    },
+    /// Failed to decode a string as UTF-8.
+    Utf8String {
+        /// The underlying error.
+        source: std::string::FromUtf8Error,
+    },
+    /// Failed to parse an integer.
+    Int {
+        /// The underlying error.
+        source: std::num::ParseIntError,
+    },
+    /// Failed to parse an image.
+    Image,
 }
 
 /// The Result type for the Llanfair Rewrite Parser.

--- a/src/run/parser/source_live_timer.rs
+++ b/src/run/parser/source_live_timer.rs
@@ -1,21 +1,22 @@
 //! Provides the parser for the SourceLiveTimer splits files.
 
 use crate::{GameTime, Run, Segment, TimeSpan};
+use serde::Deserialize;
 use serde_json::de::from_reader;
 use serde_json::Error as JsonError;
+use snafu::ResultExt;
 use std::io::Read;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the
-    /// SourceLiveTimer Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// Failed to parse JSON.
-        Json(err: JsonError) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the
+/// SourceLiveTimer Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to parse JSON.
+    Json {
+        /// The underlying error.
+        source: JsonError,
+    },
 }
 
 /// The Result type for the SourceLiveTimer parser.
@@ -51,7 +52,7 @@ fn time_span_from_ticks(category_name: &str, ticks: u64) -> TimeSpan {
 
 /// Attempts to parse a SourceLiveTimer splits file.
 pub fn parse<R: Read>(source: R) -> Result<Run> {
-    let splits: Splits = from_reader(source)?;
+    let splits: Splits = from_reader(source).context(Json)?;
 
     let mut run = Run::new();
 

--- a/src/run/parser/splits_io.rs
+++ b/src/run/parser/splits_io.rs
@@ -1,21 +1,22 @@
 //! Provides the parser for generic Splits I/O splits files.
 
 use crate::{Run, Segment as LiveSplitSegment, Time, TimeSpan};
+use serde::{Deserialize, Serialize};
 use serde_json::de::from_reader;
 use serde_json::Error as JsonError;
+use snafu::ResultExt;
 use std::io::Read;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the generic
-    /// Splits I/O Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// Failed to parse JSON.
-        Json(err: JsonError) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the generic
+/// Splits I/O Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to parse JSON.
+    Json {
+        /// The underlying error.
+        source: JsonError,
+    },
 }
 
 /// The Result type for the generic Splits I/O Parser.
@@ -275,7 +276,7 @@ impl From<RunTime> for Time {
 
 /// Attempts to parse a generic Splits I/O splits file.
 pub fn parse<R: Read>(source: R) -> Result<(Run, String)> {
-    let splits: Splits = from_reader(source)?;
+    let splits: Splits = from_reader(source).context(Json)?;
 
     let mut run = Run::new();
 

--- a/src/run/parser/splitterz.rs
+++ b/src/run/parser/splitterz.rs
@@ -1,41 +1,53 @@
 //! Provides the parser for SplitterZ splits files.
 
 use crate::{timing, Image, RealTime, Run, Segment, TimeSpan};
+use snafu::ResultExt;
 use std::borrow::Cow;
 use std::io::{self, BufRead};
 use std::num::ParseIntError;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the SplitterZ
-    /// Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// An empty splits file was provided.
-        Empty {}
-        /// Expected the name of the category, but didn't find it.
-        ExpectedCategoryName {}
-        /// Expected the attempt count, but didn't find it.
-        ExpectedAttemptCount {}
-        /// Expected the name of the segment, but didn't find it.
-        ExpectedSegmentName {}
-        /// Expected the split time, but didn't find it.
-        ExpectedSplitTime {}
-        /// Expected the best segment time, but didn't find it.
-        ExpectedBestSegment {}
-        /// Failed to parse the amount of attempts.
-        Attempt(err: ParseIntError) {
-            from()
-        }
-        /// Failed to parse a time.
-        Time(err: timing::ParseError) {
-            from()
-        }
-        /// Failed to read from the source.
-        Io(err: io::Error) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the SplitterZ
+/// Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// An empty splits file was provided.
+    Empty,
+    /// Expected the name of the category, but didn't find it.
+    ExpectedCategoryName,
+    /// Expected the attempt count, but didn't find it.
+    ExpectedAttemptCount,
+    /// Failed to parse the amount of attempts.
+    ParseAttemptCount {
+        /// The underlying error.
+        source: ParseIntError,
+    },
+    /// Expected the name of the segment, but didn't find it.
+    ExpectedSegmentName,
+    /// Expected the split time, but didn't find it.
+    ExpectedSplitTime,
+    /// Failed to parse a split time.
+    ParseSplitTime {
+        /// The underlying error.
+        source: timing::ParseError,
+    },
+    /// Expected the best segment time, but didn't find it.
+    ExpectedBestSegment,
+    /// Failed to parse a best segment time.
+    ParseBestSegment {
+        /// The underlying error.
+        source: timing::ParseError,
+    },
+    /// Failed to read the title line.
+    TitleLine {
+        /// The underlying error.
+        source: io::Error,
+    },
+    /// Failed to read the next line.
+    Line {
+        /// The underlying error.
+        source: io::Error,
+    },
 }
 
 /// The Result type for the SplitterZ parser.
@@ -60,26 +72,40 @@ pub fn parse<R: BufRead>(source: R, load_icons: bool) -> Result<Run> {
     let mut icon_buf = Vec::new();
 
     let mut lines = source.lines();
-    let line = lines.next().ok_or(Error::Empty)??;
+    let line = lines.next().ok_or(Error::Empty)?.context(TitleLine)?;
     let mut splits = line.split(',');
     // Title Stuff here, do later
     run.set_category_name(unescape(splits.next().ok_or(Error::ExpectedCategoryName)?));
-    run.set_attempt_count(splits.next().ok_or(Error::ExpectedAttemptCount)?.parse()?);
+    run.set_attempt_count(
+        splits
+            .next()
+            .ok_or(Error::ExpectedAttemptCount)?
+            .parse()
+            .context(ParseAttemptCount)?,
+    );
 
     for line in lines {
-        let line = line?;
+        let line = line.context(Line)?;
         if !line.is_empty() {
             let mut splits = line.split(',');
 
             let mut segment =
                 Segment::new(unescape(splits.next().ok_or(Error::ExpectedSegmentName)?));
 
-            let time: TimeSpan = splits.next().ok_or(Error::ExpectedSplitTime)?.parse()?;
+            let time: TimeSpan = splits
+                .next()
+                .ok_or(Error::ExpectedSplitTime)?
+                .parse()
+                .context(ParseSplitTime)?;
             if time != TimeSpan::zero() {
                 segment.set_personal_best_split_time(RealTime(Some(time)).into());
             }
 
-            let time: TimeSpan = splits.next().ok_or(Error::ExpectedBestSegment)?.parse()?;
+            let time: TimeSpan = splits
+                .next()
+                .ok_or(Error::ExpectedBestSegment)?
+                .parse()
+                .context(ParseBestSegment)?;
             if time != TimeSpan::zero() {
                 segment.set_best_segment_time(RealTime(Some(time)).into());
             }

--- a/src/run/parser/splitty.rs
+++ b/src/run/parser/splitty.rs
@@ -1,21 +1,22 @@
 //! Provides the parser for Splitty splits files.
 
 use crate::{Run, Segment, Time, TimeSpan, TimingMethod};
+use serde::Deserialize;
 use serde_json::de::from_reader;
 use serde_json::Error as JsonError;
+use snafu::ResultExt;
 use std::io::Read;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the Splitty
-    /// Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// Failed to parse JSON.
-        Json(err: JsonError) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the Splitty
+/// Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to parse JSON.
+    Json {
+        /// The underlying error.
+        source: JsonError,
+    },
 }
 
 /// The Result type for the Splitty Parser.
@@ -49,7 +50,7 @@ fn parse_time(milliseconds: Option<f64>, method: TimingMethod) -> Time {
 
 /// Attempts to parse a Splitty splits file.
 pub fn parse<R: Read>(source: R) -> Result<Run> {
-    let splits: Splits = from_reader(source)?;
+    let splits: Splits = from_reader(source).context(Json)?;
 
     let mut run = Run::new();
 

--- a/src/run/parser/urn.rs
+++ b/src/run/parser/urn.rs
@@ -1,25 +1,22 @@
 //! Provides the parser for Urn splits files.
 
-use crate::{timing, Run, Segment, Time, TimeSpan};
+use crate::{Run, Segment, Time, TimeSpan};
+use serde::Deserialize;
 use serde_json::de::from_reader;
 use serde_json::Error as JsonError;
+use snafu::ResultExt;
 use std::io::Read;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the Urn
-    /// Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// Failed to parse a time.
-        Time(err: timing::ParseError) {
-            from()
-        }
-        /// Failed to parse JSON.
-        Json(err: JsonError) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the Urn
+/// Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to parse JSON.
+    Json {
+        /// The underlying error.
+        source: JsonError,
+    },
 }
 
 /// The Result type for the Urn Parser.
@@ -54,7 +51,7 @@ fn parse_time(real_time: TimeSpan) -> Time {
 
 /// Attempts to parse an Urn splits file.
 pub fn parse<R: Read>(source: R) -> Result<Run> {
-    let splits: Splits = from_reader(source)?;
+    let splits: Splits = from_reader(source).context(Json)?;
 
     let mut run = Run::new();
 

--- a/src/run/parser/worstrun.rs
+++ b/src/run/parser/worstrun.rs
@@ -1,21 +1,22 @@
 //! Provides the parser for worstrun splits files.
 
 use crate::{Run, Segment, Time, TimeSpan};
+use serde::Deserialize;
 use serde_json::de::from_reader;
 use serde_json::Error as JsonError;
+use snafu::ResultExt;
 use std::io::Read;
 use std::result::Result as StdResult;
 
-quick_error! {
-    /// The Error type for splits files that couldn't be parsed by the worstrun
-    /// Parser.
-    #[derive(Debug)]
-    pub enum Error {
-        /// Failed to parse JSON.
-        Json(err: JsonError) {
-            from()
-        }
-    }
+/// The Error type for splits files that couldn't be parsed by the worstrun
+/// Parser.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// Failed to parse JSON.
+    Json {
+        /// The underlying error.
+        source: JsonError,
+    },
 }
 
 /// The Result type for the Urn Parser.
@@ -50,7 +51,7 @@ pub(super) fn poke<R: Read>(source: R) -> bool {
 
 /// Attempts to parse a worstrun splits file.
 pub fn parse<R: Read>(source: R) -> Result<Run> {
-    let splits: Splits = from_reader(source)?;
+    let splits: Splits = from_reader(source).context(Json)?;
 
     let mut run = Run::new();
 

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -1,4 +1,5 @@
 use indexmap::map::{IndexMap, Iter};
+use serde::{Deserialize, Serialize};
 
 /// The Run Metadata stores additional information about a run, like the
 /// platform and region of the game. All of this information is optional.

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -38,16 +38,16 @@ use std::result::Result as StdResult;
 
 static LSS_IMAGE_HEADER: &[u8; 156] = include_bytes!("lss_image_header.bin");
 
-quick_error! {
-    #[derive(Debug)]
-    /// The Error type for splits files that couldn't be saved by the LiveSplit
-    /// Saver.
-    pub enum Error {
-        /// Failed writing as XML.
-        Xml(err: XmlError) {
-            from()
-        }
-    }
+#[derive(Debug, snafu::Snafu, derive_more::From)]
+/// The Error type for splits files that couldn't be saved by the LiveSplit
+/// Saver.
+pub enum Error {
+    /// Failed writing the XML.
+    #[snafu(display("{}", error))]
+    Xml {
+        /// The underlying error.
+        error: XmlError,
+    },
 }
 
 /// The Result type for the LiveSplit Saver.

--- a/src/settings/alignment.rs
+++ b/src/settings/alignment.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Describes the Alignment of the Title in the Title Component.
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub enum Alignment {

--- a/src/settings/color.rs
+++ b/src/settings/color.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// backgrounds, texts, lines and various other elements that are being shown.
 /// They are stored as RGBA colors with 32-bit float point numbers ranging from
 /// 0.0 to 1.0 per channel.
-#[derive(Debug, Copy, Clone, PartialEq, From)]
+#[derive(Debug, Copy, Clone, PartialEq, derive_more::From)]
 pub struct Color {
     /// The Red, Green, Blue, Alpha (RGBA) encoding of the color.
     pub rgba: LinSrgba,

--- a/src/settings/field.rs
+++ b/src/settings/field.rs
@@ -1,4 +1,5 @@
 use super::Value;
+use serde::{Deserialize, Serialize};
 
 /// A Field describes a single setting by its name and its current value.
 #[derive(Serialize, Deserialize)]

--- a/src/settings/gradient.rs
+++ b/src/settings/gradient.rs
@@ -1,4 +1,5 @@
 use super::Color;
+use serde::{Deserialize, Serialize};
 
 /// Describes a Gradient for coloring a region with more than just a single
 /// color.

--- a/src/settings/semantic_color.rs
+++ b/src/settings/semantic_color.rs
@@ -1,5 +1,6 @@
 use super::Color;
 use crate::layout;
+use serde::{Deserialize, Serialize};
 
 /// A Semantic Color describes a color by some meaningful event that is
 /// happening. This information can be visualized as a color, but can also be

--- a/src/settings/settings_description.rs
+++ b/src/settings/settings_description.rs
@@ -1,4 +1,5 @@
 use super::Field;
+use serde::{Deserialize, Serialize};
 
 /// A generic description of the settings available and their current values.
 #[derive(Default, Serialize, Deserialize)]

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -6,11 +6,12 @@ use crate::{
     timing::formatter::{Accuracy, DigitsFormat},
     TimingMethod,
 };
+use serde::{Deserialize, Serialize};
 use std::result::Result as StdResult;
 
 /// Describes a setting's value. Such a value can be of a variety of different
 /// types.
-#[derive(From, Serialize, Deserialize)]
+#[derive(derive_more::From, Serialize, Deserialize)]
 pub enum Value {
     /// A boolean value.
     Bool(bool),
@@ -56,13 +57,11 @@ pub enum Value {
     LayoutDirection(LayoutDirection),
 }
 
-quick_error! {
-    /// The Error type for values that couldn't be converted.
-    #[derive(Debug)]
-    pub enum Error {
-        /// The value couldn't be converted because it had an incompatible type.
-        WrongType {}
-    }
+/// The Error type for values that couldn't be converted.
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    /// The value couldn't be converted because it had an incompatible type.
+    WrongType,
 }
 
 /// The Result type for conversions from Values to other types.

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// The Accuracy describes how many digits to show for the fractional part of a
 /// time.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]

--- a/src/timing/formatter/digits_format.rs
+++ b/src/timing/formatter/digits_format.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// A Digits Format describes how many digits of a time to always shown. The
 /// times are prefixed by zeros to fill up the remaining digits.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -63,13 +63,11 @@ pub struct Timer {
 /// multiple threads with multiple owners.
 pub type SharedTimer = Arc<RwLock<Timer>>;
 
-quick_error! {
-    /// The Error type for creating a new Timer from a Run.
-    #[derive(Debug)]
-    pub enum CreationError {
-        /// The Timer couldn't be created, because the Run has no segments.
-        EmptyRun {}
-    }
+/// The Error type for creating a new Timer from a Run.
+#[derive(Debug, snafu::Snafu)]
+pub enum CreationError {
+    /// The Timer couldn't be created, because the Run has no segments.
+    EmptyRun,
 }
 
 impl Timer {
@@ -145,7 +143,7 @@ impl Timer {
     /// is returned as the Err case of the Result. The Run object in use by the
     /// Timer is dropped by this method.
     pub fn set_run(&mut self, run: Run) -> Result<(), Run> {
-        self.replace_run(run, false).map(|_| ())
+        self.replace_run(run, false).map(drop)
     }
 
     /// Accesses the Run in use by the Timer.

--- a/src/timing/timing_method.rs
+++ b/src/timing/timing_method.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// A Timing Method describes which form of timing is used. This can either be
 /// Real Time or Game Time.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -68,9 +68,9 @@ mod editor {
         let c = editor.rename_comparison("Custom", "[Race]Custom");
         assert_eq!(
             c,
-            Err(RenameError::InvalidName(
-                ComparisonError::NameStartsWithRace
-            ))
+            Err(RenameError::InvalidName {
+                source: ComparisonError::NameStartsWithRace
+            })
         );
     }
 
@@ -84,7 +84,9 @@ mod editor {
         let c = editor.rename_comparison("Custom2", "Custom");
         assert_eq!(
             c,
-            Err(RenameError::InvalidName(ComparisonError::DuplicateName))
+            Err(RenameError::InvalidName {
+                source: ComparisonError::DuplicateName
+            })
         );
     }
 }


### PR DESCRIPTION
quick-error is quite outdated and it seems like snafu is an upcoming alternative to it that even provides nice source chaining.

This also gets rid of all the remaining extern crate items.

Resolves #212.