### PR TITLE
Partially switch to cross 0.1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ env:
     - RUST_BACKTRACE=1
 
 matrix:
+  allow_failures:
+    # Failing for now until this is fixed:
+    # https://github.com/LiveSplit/livesplit-core/issues/164
+    - env: TARGET=asmjs-unknown-emscripten
+      rust: nightly
+
   include:
     # no-std
     # - env: TARGET=x86_64-unknown-dragonfly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ env:
     - RUST_BACKTRACE=1
 
 matrix:
-  allow_failures:
-    # Failing for now until this is fixed:
-    # https://github.com/LiveSplit/livesplit-core/issues/164
-    - env: TARGET=asmjs-unknown-emscripten
-      rust: nightly
-    - env: TARGET=wasm32-unknown-emscripten
-      rust: nightly
-
   include:
     # no-std
     # - env: TARGET=x86_64-unknown-dragonfly

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,6 +1,17 @@
 set -ex
 
 main() {
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | $sort --version-sort \
+                       | tail -n1)
+
+    # # FIXME: We are staying on 0.1.14 until cross works again for the targets that we compile to.
+    # # https://github.com/LiveSplit/livesplit-core/issues/237
+    # local tag=v0.1.14
+
     local target=
     if [ $TRAVIS_OS_NAME = linux ]; then
         target=x86_64-unknown-linux-musl
@@ -62,18 +73,13 @@ main() {
         mipsisa64r6el-unknown-linux-gnuabi64)
             rustup target install $TARGET
             ;;
+        # wasm32-unknown-emscripten)
+        #     tag=v0.1.15
+        #     ;;
+        # asmjs-unknown-emscripten)
+        #     tag=v0.1.15
+        #     ;;
     esac
-
-    # This fetches latest stable release
-    # local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
-    #                    | cut -d/ -f3 \
-    #                    | grep -E '^v[0.1.0-9.]+$' \
-    #                    | $sort --version-sort \
-    #                    | tail -n1)
-
-    # FIXME: We are staying on 0.1.14 until cross works again for the targets that we compile to.
-    # https://github.com/LiveSplit/livesplit-core/issues/237
-    local tag=v0.1.14
 
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,6 +1,15 @@
 set -ex
 
 main() {
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
     # This fetches latest stable release
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
                        | cut -d/ -f3 \
@@ -11,15 +20,6 @@ main() {
     # # FIXME: We are staying on 0.1.14 until cross works again for the targets that we compile to.
     # # https://github.com/LiveSplit/livesplit-core/issues/237
     # local tag=v0.1.14
-
-    local target=
-    if [ $TRAVIS_OS_NAME = linux ]; then
-        target=x86_64-unknown-linux-musl
-        sort=sort
-    else
-        target=x86_64-apple-darwin
-        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
-    fi
 
     case $TARGET in
         aarch64-apple-ios)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,10 +17,6 @@ main() {
                        | $sort --version-sort \
                        | tail -n1)
 
-    # # FIXME: We are staying on 0.1.14 until cross works again for the targets that we compile to.
-    # # https://github.com/LiveSplit/livesplit-core/issues/237
-    # local tag=v0.1.14
-
     case $TARGET in
         aarch64-apple-ios)
             rustup target install $TARGET
@@ -40,9 +36,6 @@ main() {
         wasm32-unknown-unknown)
             rustup target install $TARGET
             ;;
-        x86_64-unknown-linux-gnux32)
-            rustup target install $TARGET
-            ;;
         i586-unknown-linux-musl)
             rustup target install $TARGET
             ;;
@@ -50,9 +43,6 @@ main() {
             rustup target install $TARGET
             ;;
         arm-unknown-linux-musleabihf)
-            rustup target install $TARGET
-            ;;
-        armv5te-unknown-linux-gnueabi)
             rustup target install $TARGET
             ;;
         armv5te-unknown-linux-musleabi)
@@ -73,12 +63,25 @@ main() {
         mipsisa64r6el-unknown-linux-gnuabi64)
             rustup target install $TARGET
             ;;
-        # wasm32-unknown-emscripten)
-        #     tag=v0.1.15
-        #     ;;
-        # asmjs-unknown-emscripten)
-        #     tag=v0.1.15
-        #     ;;
+        # FIXME: We are partially staying on 0.1.14 until cross works for these targets again.
+        # https://github.com/LiveSplit/livesplit-core/issues/237
+        x86_64-unknown-linux-gnux32)
+            rustup target install $TARGET
+            tag=v0.1.14
+            ;;
+        armv5te-unknown-linux-gnueabi)
+            rustup target install $TARGET
+            tag=v0.1.14
+            ;;
+        powerpc64le-unknown-linux-gnu)
+            tag=v0.1.14
+            ;;
+        i686-unknown-freebsd)
+            tag=v0.1.14
+            ;;
+        x86_64-unknown-freebsd)
+            tag=v0.1.14
+            ;;
     esac
 
     curl -LSfs https://japaric.github.io/trust/install.sh | \


### PR DESCRIPTION
Switch to cross 0.1.15, but only use it for the targets that work. This fixes our emscripten builds.

Resolves #164 