### PR TITLE
Don't duplicate CI Jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,12 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
This restricts when the CI runs. It shouldn't run everything twice on a Pull Request that originates from this repository.