### PR TITLE
Reattach unattached Segment History Elements

### DIFF
--- a/src/run/segment_history.rs
+++ b/src/run/segment_history.rs
@@ -18,8 +18,9 @@ impl SegmentHistory {
         Some(self.0.first()?.0)
     }
 
-    /// Returns the minimum index of all the segment times. If there's no
-    /// segment times or the minimum is less than 1, 1 is returned instead.
+    /// Returns the minimum index of all the segment times. If there are no
+    /// segment times or there are only indices above 1, then 1 is returned
+    /// instead.
     pub fn min_index(&self) -> i32 {
         self.try_get_min_index().map_or(1, |m| min(m, 1))
     }
@@ -65,10 +66,9 @@ impl SegmentHistory {
     /// Removes the segment time with the given index. If it doesn't exist,
     /// nothing is done.
     #[inline]
-    pub fn remove(&mut self, index: i32) {
-        if let Ok(pos) = self.get_pos(index) {
-            self.0.remove(pos);
-        }
+    pub fn remove(&mut self, index: i32) -> Option<Time> {
+        let pos = self.get_pos(index).ok()?;
+        Some(self.0.remove(pos).1)
     }
 
     /// Removes all the segment times from the Segment History.

--- a/src/run/tests/fixing.rs
+++ b/src/run/tests/fixing.rs
@@ -1,0 +1,23 @@
+use crate::tests_helper::{create_timer, run_with_splits};
+
+#[test]
+fn reattaches_unattached_segment_history_elements_by_using_negative_ids() {
+    let mut timer = create_timer(&["A", "B"]);
+    run_with_splits(&mut timer, &[3.0, 6.0]);
+    run_with_splits(&mut timer, &[2.0, 4.0]);
+    let mut run = timer.into_run(true);
+
+    // We pop the last attempt from the history, but keep it in the segment
+    // history, which makes the segment history elements unattached.
+    run.attempt_history.pop().unwrap();
+
+    run.fix_splits();
+
+    let segments = run.segments();
+
+    assert_eq!(segments[0].segment_history().try_get_min_index(), Some(0));
+    assert_eq!(segments[0].segment_history().try_get_max_index(), Some(1));
+
+    assert_eq!(segments[1].segment_history().try_get_min_index(), Some(0));
+    assert_eq!(segments[1].segment_history().try_get_max_index(), Some(1));
+}

--- a/src/run/tests/mod.rs
+++ b/src/run/tests/mod.rs
@@ -1,3 +1,4 @@
 mod comparison;
 mod empty_run;
+mod fixing;
 mod metadata;


### PR DESCRIPTION
In `Run::fix_splits` we now check for segment history elements that are considered achieved by the runner, but don't correspond to an element in the attempt history. We move them over into the synthetic segment history elements (elements with index <= 0).

Fixes #249 