### PR TITLE
C API: Support generating definitions for structs.

### DIFF
--- a/capi/bind_gen/src/c.rs
+++ b/capi/bind_gen/src/c.rs
@@ -1,4 +1,4 @@
-use crate::{Class, Type, TypeKind};
+use crate::{Class, Struct, Type, TypeKind};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io::{Result, Write};
@@ -35,7 +35,11 @@ fn get_type(ty: &Type) -> Cow<'_, str> {
     name
 }
 
-pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Result<()> {
+pub fn write<W: Write>(
+    mut writer: W,
+    classes: &BTreeMap<String, Class>,
+    structs: &Vec<Struct>,
+) -> Result<()> {
     write!(
         writer,
         "{}",
@@ -65,6 +69,14 @@ typedef struct {0}_s const* {0}Ref;
 "#,
             name
         )?;
+    }
+
+    for item in structs {
+        writeln!(writer, "struct {0}_s {{", item.name)?;
+        for field in item.fields.iter() {
+            writeln!(writer, "    {1} {0};", field.0, get_type(&field.1))?;
+        }
+        writeln!(writer, "}};")?;
     }
 
     for class in classes.values() {

--- a/capi/bind_gen/src/c.rs
+++ b/capi/bind_gen/src/c.rs
@@ -72,6 +72,27 @@ typedef struct {0}_s const* {0}Ref;
     }
 
     for item in structs {
+        if !item.comments.is_empty() {
+            write!(writer, r#"/**"#)?;
+
+            for comment in &item.comments {
+                write!(
+                    writer,
+                    r#"
+{}"#,
+                    comment
+                        .replace("<NULL>", "NULL")
+                        .replace("<TRUE>", "true")
+                        .replace("<FALSE>", "false")
+                )?;
+            }
+
+            writeln!(
+                writer,
+                r#"
+*/"#
+            )?;
+        }
         writeln!(writer, "struct {0}_s {{", item.name)?;
         for field in item.fields.iter() {
             writeln!(writer, "    {1} {0};", field.0, get_type(&field.1))?;


### PR DESCRIPTION
# Overview

The goal of this PR is to support generating definitions for `#[repr(C)]` structs defined in the C API. The main use case behind this will be returning a component's state as a single struct instead of going through JSON or multiple getter functions.

This will definitely require some experimentation and discussion so I don't see this getting merged any time soon. Most of the discussion for this is happening in #275

# Todo
## Needed Improvements
- [ ] Only generate definitions for structs marked `#[repr(C)]`
- [x] Not generating definitions in languages where we don't support this. (Obsoleted by making this an extension to the opaque API)
- [x] Support documentation.
- [ ] Find a way to attach a struct to a class instead of having it as a separate datatype. 

## Languages to Support:
- [x] C
- [ ] C# (Requires unsafe code)
- [ ] Java/Kotlin JNI (Unlikely to happen)
- [ ] Java JNA
- [ ] JS/TS (Emscripten)
- [ ] JS/TS (Node FFI)
- [ ] JS/TS (Wasm)
- [ ] Ruby
- [ ] Python