### PR TITLE
Don't merge: See if rustls builds for the different targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ vek = { version = "0.9.8", default-features = false, optional = true }
 web-sys = { version = "0.3.28", default-features = false, features = ["Performance", "Window"], optional = true }
 
 # Networking
-splits-io-api = { version = "0.1.0", optional = true }
+splits-io-api = { git = "https://github.com/CryZe/splits-io-api", branch = "rustls", optional = true }
 
 [dev-dependencies]
 memmem = "0.1.1"
@@ -91,7 +91,7 @@ image-shrinking = ["std", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviations", "lyon", "rusttype", "smallvec"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
-networking = ["splits-io-api"]
+networking = ["std", "splits-io-api"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly
 # yet. So there's a feature you explicitly have to opt into to deactivate the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ vek = { version = "0.9.8", default-features = false, optional = true }
 web-sys = { version = "0.3.28", default-features = false, features = ["Performance", "Window"], optional = true }
 
 # Networking
-splits-io-api = { git = "https://github.com/CryZe/splits-io-api", branch = "rustls", optional = true }
+splits-io-api = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 memmem = "0.1.1"


### PR DESCRIPTION
So far splits-io-api is using hyper-tls, but I intend to switch to hyper-rustls. However I'm not quite sure if that breaks our builds, so this PR is to check for that. It's not meant to be merged at all.