### PR TITLE
Generate wasm-bindgen compatible bindings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -527,6 +527,9 @@ jobs:
           - label: Android x86_64
             target: x86_64-linux-android
             os: ubuntu-latest
+            tests: skip
+             # The tests fail with an illegal instruction since 1.40
+             # https://github.com/rust-lang/rust/issues/67582
 
           - label: Android arm
             target: arm-linux-androideabi
@@ -684,7 +687,7 @@ jobs:
           args: --all-features
 
   docs:
-    if: startsWith(github.ref, 'refs/tags/') 
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -12,6 +12,7 @@ mod ruby;
 mod swift;
 mod typescript;
 mod wasm;
+mod wasm_bindgen;
 
 use std::fs::{create_dir_all, remove_dir_all, File};
 use std::io::{BufWriter, Read, Result};
@@ -345,6 +346,19 @@ fn write_files(classes: &BTreeMap<String, Class>, opt: &Opt) -> Result<()> {
 
         path.push("livesplit_core.ts");
         wasm::write(BufWriter::new(File::create(&path)?), classes, true)?;
+        path.pop();
+    }
+    path.pop();
+
+    path.push("wasm_bindgen");
+    create_dir_all(&path)?;
+    {
+        path.push("index.js");
+        wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, false)?;
+        path.pop();
+
+        path.push("index.ts");
+        wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, true)?;
         path.pop();
     }
     path.pop();


### PR DESCRIPTION
In order to use the `wasm-web` feature in the web version of LiveSplit One, we need to integrate our bindings with wasm-bindgen. This commit adds new bindings to our binding generator that are compatible with wasm-bindgen.

Resolves #281 