### PR TITLE
capi: Make some minor fixes

### DIFF
--- a/capi/src/hotkey_config.rs
+++ b/capi/src/hotkey_config.rs
@@ -18,6 +18,12 @@ pub extern "C" fn HotkeyConfig_drop(this: OwnedHotkeyConfig) {
     drop(this);
 }
 
+/// Creates a new Hotkey Configuration with default settings.
+#[no_mangle]
+pub extern "C" fn HotkeyConfig_new() -> OwnedHotkeyConfig {
+    Box::new(HotkeyConfig::default())
+}
+
 /// Encodes generic description of the settings available for the hotkey
 /// configuration and their current values as JSON.
 #[no_mangle]

--- a/capi/src/key_value_component_state.rs
+++ b/capi/src/key_value_component_state.rs
@@ -1,7 +1,8 @@
 //! The state object describes the information to visualize for a key value based component.
 
-use super::output_str;
+use super::{output_str, output_vec};
 use livesplit_core::component::key_value::State as KeyValueComponentState;
+use std::io::Write;
 use std::os::raw::c_char;
 
 /// type
@@ -23,4 +24,12 @@ pub extern "C" fn KeyValueComponentState_key(this: &KeyValueComponentState) -> *
 #[no_mangle]
 pub extern "C" fn KeyValueComponentState_value(this: &KeyValueComponentState) -> *const c_char {
     output_str(&this.value)
+}
+
+/// The semantic coloring information the value carries.
+#[no_mangle]
+pub extern "C" fn KeyValueComponentState_semantic_color(
+    this: &KeyValueComponentState,
+) -> *const c_char {
+    output_vec(|f| write!(f, "{:?}", this.semantic_color).unwrap())
 }

--- a/capi/src/splits_component_state.rs
+++ b/capi/src/splits_component_state.rs
@@ -81,7 +81,7 @@ pub extern "C" fn SplitsComponentState_name(
 /// bounds index. The amount of columns to visualize may differ from segment to
 /// segment.
 #[no_mangle]
-pub extern "C" fn SplitComponentState_columns_len(
+pub extern "C" fn SplitsComponentState_columns_len(
     this: &SplitsComponentState,
     index: usize,
 ) -> usize {


### PR DESCRIPTION
Fixes a typo in `splits_component_state.rs`, adds a semantic color getter to `KeyValueComponentState`, and creates `HotkeyState_new()`