### PR TITLE
Improve Annotations on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -679,12 +679,30 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@v1
+      - name: Checkout Commit
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          components: clippy
+
+      - name: Run Clippy
+        run: cargo clippy --all-features
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt -- --check || true
 
   docs:
     if: startsWith(github.ref, 'refs/tags/')

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -431,14 +431,16 @@ public class {class} extends {base_class} implements AutoCloseable {{
 fn write_native_class<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
 
-    writeln!(writer,
-           "{}",
-           r#"package livesplitcore;
+    writeln!(
+        writer,
+        "{}",
+        r#"package livesplitcore;
 
 import com.sun.jna.*;
 
 public interface LiveSplitCoreNative extends Library {
-    LiveSplitCoreNative INSTANCE = (LiveSplitCoreNative) Native.loadLibrary("livesplit_core", LiveSplitCoreNative.class);"#)?;
+    LiveSplitCoreNative INSTANCE = (LiveSplitCoreNative) Native.loadLibrary("livesplit_core", LiveSplitCoreNative.class);"#
+    )?;
 
     for class in classes.values() {
         for function in class

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -169,9 +169,10 @@ extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jn
 }
 
 pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Result<()> {
-    write!(writer,
-           "{}",
-           r#"#include <jni.h>
+    write!(
+        writer,
+        "{}",
+        r#"#include <jni.h>
 #include <string>
 #include "livesplit_core.h"
 
@@ -185,7 +186,8 @@ extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseStri
     jni_env->ReleaseStringUTFChars(data, cstr_data);
     return result;
 }
-"#)?;
+"#
+    )?;
 
     for (class_name, class) in classes {
         for function in class

--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -217,9 +217,10 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
 }
 
 pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Result<()> {
-    write!(writer,
-           "{}",
-           r#"#!/usr/bin/env python3
+    write!(
+        writer,
+        "{}",
+        r#"#!/usr/bin/env python3
 # coding: utf-8
 
 import sys, ctypes
@@ -228,7 +229,8 @@ from ctypes import c_char_p, c_void_p, c_int8, c_int16, c_int32, c_int64, c_uint
 prefix = {'win32': ''}.get(sys.platform, './lib')
 extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')
 livesplit_core_native = ctypes.cdll.LoadLibrary(prefix + "livesplit_core" + extension)
-"#)?;
+"#
+    )?;
 
     for class in classes.values() {
         for function in class

--- a/src/platform/no_std/indexmap.rs
+++ b/src/platform/no_std/indexmap.rs
@@ -74,6 +74,7 @@ pub mod map {
         }
     }
 
+    /// Entry for an existing key-value pair or a vacant location to insert one.
     pub struct Entry<'a, K, V> {
         map: &'a mut IndexMap<K, V>,
         index: Option<usize>,

--- a/src/rendering/software/tests.rs
+++ b/src/rendering/software/tests.rs
@@ -200,17 +200,19 @@ fn horizontal() {
         &[Some(10.0), None, Some(20.0), Some(55.0)],
     );
 
-    check_dims(&layout.state(&timer), [1500, 40], "YmJicmJSUmM=", "horizontal");
+    check_dims(
+        &layout.state(&timer),
+        [1500, 40],
+        "YmJicmJSUmM=",
+        "horizontal",
+    );
 }
 
 fn get_comparison_tolerance() -> u32 {
     // Without MMX the floating point calculations don't follow IEEE 754, so the tests require a
     // tolerance that is greater than 0.
     // FIXME: We use SSE as an approximation for the cfg because MMX isn't supported by Rust yet.
-    if cfg!(all(
-        target_arch = "x86",	
-        not(target_feature = "sse"),	
-    )) {
+    if cfg!(all(target_arch = "x86", not(target_feature = "sse"),)) {
         4
     } else {
         0
@@ -225,9 +227,9 @@ fn check_dims(state: &LayoutState, dims: [usize; 2], expected_hash_data: &str, n
     let image = render(state, dims);
     let hasher = HasherConfig::with_bytes_type::<[u8; 8]>().to_hasher();
 
-    let calculated_hash = hasher.hash_image(&image);	
+    let calculated_hash = hasher.hash_image(&image);
     let calculated_hash_data = calculated_hash.to_base64();
-    let expected_hash = ImageHash::<[u8; 8]>::from_base64(expected_hash_data).unwrap();	
+    let expected_hash = ImageHash::<[u8; 8]>::from_base64(expected_hash_data).unwrap();
     let distance = calculated_hash.dist(&expected_hash);
 
     fs::create_dir_all("target/renders").ok();


### PR DESCRIPTION
This replaces the existing clippy support with the annotation support in the `setup-rust-action` that we use. This should make it so the annotations actually show up now. Additionally this adds a check for formatting and fixes a bunch of warnings.