### PR TITLE
Update image to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ web-sys = { version = "0.3.28", default-features = false, features = ["Performan
 [dev-dependencies]
 memmem = "0.1.1"
 criterion = "0.3.0"
-img_hash = "3.0.0"
+img_hash = "3.1.0"
 tokio = { version = "0.2", features = ["macros"] }
 
 [features]
@@ -99,9 +99,6 @@ networking = ["std", "splits-io-api"]
 # when `--all-features` is passed, so we can ignore the `doesnt-have-atomics` in
 # that case. https://github.com/rust-lang/rust/issues/32976
 internal-use-all-features = []
-
-[patch.crates-io]
-img_hash = { git = "https://github.com/CryZe/img_hash", branch = "image-0.23" }
 
 [[bench]]
 name = "balanced_pb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ snafu = { version = "0.6.0", default-features = false }
 unicase = "2.6.0"
 
 # std
+bytemuck = { version = "1.2.0", optional = true }
 byteorder = { version = "1.3.2", optional = true }
 image = { version = "0.23.0", features = ["png"], default-features = false, optional = true }
 indexmap = { version = "1.2.0", default-features = false, features = ["serde-1"], optional = true }
@@ -84,7 +85,7 @@ default = ["image-shrinking", "std"]
 doesnt-have-atomics = []
 std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
 more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/gif", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
-image-shrinking = ["std", "more-image-formats"]
+image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviations", "lyon", "rusttype", "smallvec"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ unicase = "2.6.0"
 
 # std
 byteorder = { version = "1.3.2", optional = true }
-image = { version = "0.22.0", features = ["png_codec"], default-features = false, optional = true }
+image = { version = "0.23.0", features = ["png"], default-features = false, optional = true }
 indexmap = { version = "1.2.0", default-features = false, features = ["serde-1"], optional = true }
 parking_lot = { version = "0.10.0", default-features = false, optional = true }
 quick-xml = { version = "0.17.0", default-features = false, optional = true }
@@ -83,7 +83,7 @@ tokio = { version = "0.2", features = ["macros"] }
 default = ["image-shrinking", "std"]
 doesnt-have-atomics = []
 std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
-more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/gif_codec", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
+more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/gif", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviations", "lyon", "rusttype", "smallvec"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
@@ -99,6 +99,9 @@ networking = ["std", "splits-io-api"]
 # when `--all-features` is passed, so we can ignore the `doesnt-have-atomics` in
 # that case. https://github.com/rust-lang/rust/issues/32976
 internal-use-all-features = []
+
+[patch.crates-io]
+img_hash = { git = "https://github.com/CryZe/img_hash", branch = "image-0.23" }
 
 [[bench]]
 name = "balanced_pb"

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -247,7 +247,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
             {
                 buf2.clear();
                 if png::PNGEncoder::new(&mut buf2)
-                    .encode(image.as_ref(), width, height, ColorType::RGBA(8))
+                    .encode(image.as_ref(), width, height, ColorType::Rgba8)
                     .is_ok()
                 {
                     icon = Some(Image::new(&buf2));

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -131,7 +131,7 @@ where
 
     buf.clear();
     png::PNGEncoder::new(&mut *buf)
-        .encode(image.as_ref(), width, height, ColorType::RGBA(8))
+        .encode(image.as_ref(), width, height, ColorType::Rgba8)
         .map_err(|_| Error::Image)?;
 
     f(buf);

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -116,7 +116,7 @@ where
 
         tag_buf.clear();
         png::PNGEncoder::new(&mut *tag_buf)
-            .encode(image.as_ref(), width, height, ColorType::RGBA(8))
+            .encode(image.as_ref(), width, height, ColorType::Rgba8)
             .map_err(|_| Error::Image)?;
 
         f(tag_buf);

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -38,10 +38,10 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Result<Cow<'_, [u8]>, ImageError> 
             DynamicImage::ImageRgba8(x) => x.as_ref(),
             DynamicImage::ImageBgr8(x) => x.as_ref(),
             DynamicImage::ImageBgra8(x) => x.as_ref(),
-            DynamicImage::ImageLuma16(x) => unsafe { x.align_to::<u8>().1 },
-            DynamicImage::ImageLumaA16(x) => unsafe { x.align_to::<u8>().1 },
-            DynamicImage::ImageRgb16(x) => unsafe { x.align_to::<u8>().1 },
-            DynamicImage::ImageRgba16(x) => unsafe { x.align_to::<u8>().1 },
+            DynamicImage::ImageLuma16(x) => bytemuck::cast_slice(x.as_ref()),
+            DynamicImage::ImageLumaA16(x) => bytemuck::cast_slice(x.as_ref()),
+            DynamicImage::ImageRgb16(x) => bytemuck::cast_slice(x.as_ref()),
+            DynamicImage::ImageRgba16(x) => bytemuck::cast_slice(x.as_ref()),
         };
         let mut data = Vec::new();
         png::PNGEncoder::new(&mut data).encode(

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use image::{
     bmp, gif, guess_format, hdr, ico, jpeg, load_from_memory_with_format, png, pnm, tiff, webp,
-    DynamicImage, ImageDecoder, ImageError, ImageFormat,
+    DynamicImage, GenericImageView, ImageDecoder, ImageError, ImageFormat,
 };
 use std::io::Cursor;
 
@@ -10,34 +10,46 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Result<Cow<'_, [u8]>, ImageError> 
 
     let cursor = Cursor::new(data);
     let (width, height) = match format {
-        ImageFormat::PNG => png::PNGDecoder::new(cursor)?.dimensions(),
-        ImageFormat::JPEG => jpeg::JPEGDecoder::new(cursor)?.dimensions(),
-        ImageFormat::GIF => gif::Decoder::new(cursor)?.dimensions(),
-        ImageFormat::WEBP => webp::WebpDecoder::new(cursor)?.dimensions(),
-        ImageFormat::TIFF => tiff::TIFFDecoder::new(cursor)?.dimensions(),
-        ImageFormat::BMP => bmp::BMPDecoder::new(cursor)?.dimensions(),
-        ImageFormat::ICO => ico::ICODecoder::new(cursor)?.dimensions(),
-        ImageFormat::HDR => hdr::HDRAdapter::new(cursor)?.dimensions(),
-        ImageFormat::PNM => pnm::PNMDecoder::new(cursor)?.dimensions(),
-        ImageFormat::TGA => return Ok(data.into()), // TGA doesn't have a Header
+        ImageFormat::Png => png::PngDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Jpeg => jpeg::JpegDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Gif => gif::GifDecoder::new(cursor)?.dimensions(),
+        ImageFormat::WebP => webp::WebPDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Tiff => tiff::TiffDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Bmp => bmp::BmpDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Ico => ico::IcoDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Hdr => hdr::HDRAdapter::new(cursor)?.dimensions(),
+        ImageFormat::Pnm => pnm::PnmDecoder::new(cursor)?.dimensions(),
+        // TGA doesn't have a Header.
+        // DDS isn't a format we really care for.
+        // And the image format is non-exhaustive.
+        ImageFormat::Tga | ImageFormat::Dds | _ => return Ok(data.into()),
     };
 
-    let is_too_large = width > u64::from(max_dim) || height > u64::from(max_dim);
-    if is_too_large || format == ImageFormat::BMP {
+    let is_too_large = width > max_dim || height > max_dim;
+    if is_too_large || format == ImageFormat::Bmp {
         let mut image = load_from_memory_with_format(data, format)?;
         if is_too_large {
             image = image.thumbnail(max_dim, max_dim);
         }
-        let mut data = Vec::new();
-        let ((width, height), image_data) = match &image {
-            DynamicImage::ImageLuma8(x) => (x.dimensions(), x.as_ref()),
-            DynamicImage::ImageLumaA8(x) => (x.dimensions(), x.as_ref()),
-            DynamicImage::ImageRgb8(x) => (x.dimensions(), x.as_ref()),
-            DynamicImage::ImageRgba8(x) => (x.dimensions(), x.as_ref()),
-            DynamicImage::ImageBgr8(x) => (x.dimensions(), x.as_ref()),
-            DynamicImage::ImageBgra8(x) => (x.dimensions(), x.as_ref()),
+        let image_data = match &image {
+            DynamicImage::ImageLuma8(x) => x.as_ref(),
+            DynamicImage::ImageLumaA8(x) => x.as_ref(),
+            DynamicImage::ImageRgb8(x) => x.as_ref(),
+            DynamicImage::ImageRgba8(x) => x.as_ref(),
+            DynamicImage::ImageBgr8(x) => x.as_ref(),
+            DynamicImage::ImageBgra8(x) => x.as_ref(),
+            DynamicImage::ImageLuma16(x) => unsafe { x.align_to::<u8>().1 },
+            DynamicImage::ImageLumaA16(x) => unsafe { x.align_to::<u8>().1 },
+            DynamicImage::ImageRgb16(x) => unsafe { x.align_to::<u8>().1 },
+            DynamicImage::ImageRgba16(x) => unsafe { x.align_to::<u8>().1 },
         };
-        png::PNGEncoder::new(&mut data).encode(image_data, width, height, image.color())?;
+        let mut data = Vec::new();
+        png::PNGEncoder::new(&mut data).encode(
+            image_data,
+            image.width(),
+            image.height(),
+            image.color(),
+        )?;
         Ok(data.into())
     } else {
         Ok(data.into())


### PR DESCRIPTION
This also finally gets rid of 0.x versions of syn, which is a slow dependency to compile.

This is blocked by https://github.com/abonander/img_hash/pull/33 being merged.