### PR TITLE
Move the Title Abbreviations into the Component

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -405,18 +405,30 @@ jobs:
           - label: Linux mips
             target: mips-unknown-linux-gnu
             os: ubuntu-latest
+            tests: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux mips64
             target: mips64-unknown-linux-gnuabi64
             os: ubuntu-latest
+            tests: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux mips64el
             target: mips64el-unknown-linux-gnuabi64
             os: ubuntu-latest
+            tests: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux mipsel
             target: mipsel-unknown-linux-gnu
             os: ubuntu-latest
+            tests: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux mipsel musl
             target: mipsel-unknown-linux-musl
@@ -432,6 +444,9 @@ jobs:
           - label: Linux powerpc64
             target: powerpc64-unknown-linux-gnu
             os: ubuntu-latest
+            tests: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux powerpc64le
             target: powerpc64le-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ derive_more = { version = "0.99.1", default-features = false, features = ["not",
 hashbrown = "0.7.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.5.0", default-features = false }
+livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.1.0" }
 odds = { version = "0.3.1", default-features = false }
 ordered-float = { version = "1.0.2", default-features = false }
 palette = { version = "0.5.0", default-features = false, features = ["libm"] }
@@ -58,7 +59,6 @@ utf-8 = { version = "0.7.4", optional = true }
 
 # Rendering
 euclid = { version = "0.20.0", default-features = false, optional = true }
-livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.1.0", optional = true }
 lyon = { version = "0.15.3", default-features = false, optional = true }
 rusttype = { version = "0.8.0", default-features = false, features = ["std"], optional = true }
 smallvec = { version = "1.0.0", default-features = false, optional = true }
@@ -86,7 +86,7 @@ doesnt-have-atomics = []
 std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
 more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/gif", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "bytemuck", "more-image-formats"]
-rendering = ["std", "more-image-formats", "euclid", "livesplit-title-abbreviations", "lyon", "rusttype", "smallvec"]
+rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype", "smallvec"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]

--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -129,15 +129,19 @@ export interface TitleComponentStateJson {
     icon_change: string | null,
     /**
      * The first title line to show. This is either the game's name, or a
-     * combination of the game's name and the category.
+     * combination of the game's name and the category. This is a list of all
+     * the possible abbreviations. It contains at least one element and the last
+     * element is the unabbreviated value.
      */
-    line1: string,
+    line1: string[],
     /**
      * By default the category name is shown on the second line. Based on the
      * settings, it can however instead be shown in a single line together with
-     * the game name.
+     * the game name. This is a list of all the possible abbreviations. It
+     * contains at least one element and the last element is the unabbreviated
+     * value.
      */
-    line2: string | null,
+    line2: string[] | null,
     /**
      * Specifies whether the title should centered or aligned to the left
      * instead.

--- a/capi/src/title_component_state.rs
+++ b/capi/src/title_component_state.rs
@@ -35,7 +35,8 @@ pub extern "C" fn TitleComponentState_icon_change_len(this: &TitleComponentState
 /// combination of the game's name and the category.
 #[no_mangle]
 pub extern "C" fn TitleComponentState_line1(this: &TitleComponentState) -> *const c_char {
-    output_str(&this.line1)
+    // FIXME: Add API for querying the abbreviations.
+    output_str(&this.line1.last().unwrap())
 }
 
 /// By default the category name is shown on the second line. Based on the
@@ -43,7 +44,10 @@ pub extern "C" fn TitleComponentState_line1(this: &TitleComponentState) -> *cons
 /// the game name. In that case <NULL> is returned instead.
 #[no_mangle]
 pub extern "C" fn TitleComponentState_line2(this: &TitleComponentState) -> *const Nullablec_char {
-    this.line2.as_ref().map_or_else(ptr::null, output_str)
+    // FIXME: Add API for querying the abbreviations.
+    this.line2
+        .as_ref()
+        .map_or_else(ptr::null, |abbrevs| output_str(&abbrevs.last().unwrap()))
 }
 
 /// Specifies whether the title should centered or aligned to the left

--- a/crates/livesplit-title-abbreviations/src/lib.rs
+++ b/crates/livesplit-title-abbreviations/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use unicase::UniCase;
 
 fn ends_with_roman_numeral(name: &str) -> bool {
@@ -15,7 +15,7 @@ fn ends_with_numeric(name: &str) -> bool {
     name.chars().last().map_or(false, |c| c.is_numeric())
 }
 
-fn series_subtitle_handling(name: &str, split_token: &str, list: &mut Vec<String>) -> bool {
+fn series_subtitle_handling(name: &str, split_token: &str, list: &mut Vec<Box<str>>) -> bool {
     let mut iter = name.splitn(2, split_token);
     if let (Some(series), Some(subtitle)) = (iter.next(), iter.next()) {
         let series_abbreviations = abbreviate(series);
@@ -30,13 +30,16 @@ fn series_subtitle_handling(name: &str, split_token: &str, list: &mut Vec<String
         for subtitle_abbreviation in &subtitle_abbreviations {
             for series_abbreviation in &series_abbreviations {
                 if is_series_representative
-                    || series_abbreviation != series
+                    || &**series_abbreviation != series
                     || is_there_only_one_series_abbreviation
                 {
-                    list.push(format!(
-                        "{}{}{}",
-                        series_abbreviation, split_token, subtitle_abbreviation
-                    ));
+                    list.push(
+                        format!(
+                            "{}{}{}",
+                            series_abbreviation, split_token, subtitle_abbreviation
+                        )
+                        .into(),
+                    );
                 }
             }
         }
@@ -52,7 +55,7 @@ fn series_subtitle_handling(name: &str, split_token: &str, list: &mut Vec<String
     }
 }
 
-fn left_right_handling(name: &str, split_token: &str, list: &mut Vec<String>) -> bool {
+fn left_right_handling(name: &str, split_token: &str, list: &mut Vec<Box<str>>) -> bool {
     let mut iter = name.splitn(2, split_token);
     if let (Some(series), Some(subtitle)) = (iter.next(), iter.next()) {
         let series_abbreviations = abbreviate(series);
@@ -60,10 +63,13 @@ fn left_right_handling(name: &str, split_token: &str, list: &mut Vec<String>) ->
 
         for subtitle_abbreviation in &subtitle_abbreviations {
             for series_abbreviation in &series_abbreviations {
-                list.push(format!(
-                    "{}{}{}",
-                    series_abbreviation, split_token, subtitle_abbreviation
-                ));
+                list.push(
+                    format!(
+                        "{}{}{}",
+                        series_abbreviation, split_token, subtitle_abbreviation
+                    )
+                    .into(),
+                );
             }
         }
 
@@ -73,7 +79,7 @@ fn left_right_handling(name: &str, split_token: &str, list: &mut Vec<String>) ->
     }
 }
 
-fn and_handling(name: &str, list: &mut Vec<String>) -> bool {
+fn and_handling(name: &str, list: &mut Vec<Box<str>>) -> bool {
     let and = UniCase::new("and");
     for word in name.split_whitespace() {
         if UniCase::new(word) == and {
@@ -101,7 +107,7 @@ fn is_all_caps_or_digits(text: &str) -> bool {
     text.chars().all(|c| c.is_uppercase() || c.is_numeric())
 }
 
-pub fn abbreviate(name: &str) -> Vec<String> {
+pub fn abbreviate(name: &str) -> Vec<Box<str>> {
     let name = name.trim();
     let mut list = vec![name.into()];
     if name.is_empty() {
@@ -158,7 +164,7 @@ pub fn abbreviate(name: &str) -> Vec<String> {
                     }
                 }
             }
-            list.push(abbreviated);
+            list.push(abbreviated.into());
         }
     }
 

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -1,13 +1,10 @@
-use {
-    crate::{
-        component::title::State,
-        layout::LayoutState,
-        rendering::{
-            icon::Icon, vertical_padding, Backend, RenderContext, BOTH_PADDINGS, DEFAULT_TEXT_SIZE,
-            PADDING, TEXT_ALIGN_BOTTOM, TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP,
-        },
+use crate::{
+    component::title::State,
+    layout::LayoutState,
+    rendering::{
+        icon::Icon, vertical_padding, Backend, RenderContext, BOTH_PADDINGS, DEFAULT_TEXT_SIZE,
+        PADDING, TEXT_ALIGN_BOTTOM, TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP,
     },
-    livesplit_title_abbreviations::abbreviate,
 };
 
 pub(in crate::rendering) fn render<B: Backend>(
@@ -42,17 +39,6 @@ pub(in crate::rendering) fn render<B: Backend>(
         (left_bound, 0.0)
     };
 
-    // FIXME: For a single line the component provides both the game and category
-    // in a single string, which makes it hard for us to properly abbreviate it.
-    // We may want to rethink merging both values into a single string because
-    // of that. https://github.com/LiveSplit/livesplit-core/issues/170
-    let abbreviations = abbreviate(&component.line1);
-    let line1 = context.choose_abbreviation(
-        abbreviations.iter().map(String::as_str),
-        DEFAULT_TEXT_SIZE,
-        width - PADDING - left_bound,
-    );
-
     let attempts = match (component.finished_runs, component.attempts) {
         (Some(a), Some(b)) => format!("{}/{}", a, b),
         (Some(a), _) | (_, Some(a)) => a.to_string(),
@@ -66,6 +52,11 @@ pub(in crate::rendering) fn render<B: Backend>(
     );
 
     let (line1_y, line1_end_x) = if let Some(line2) = &component.line2 {
+        let line2 = context.choose_abbreviation(
+            line2.iter().map(|a| &**a),
+            DEFAULT_TEXT_SIZE,
+            line2_end_x - PADDING - left_bound,
+        );
         context.render_text_align(
             line2,
             left_bound,
@@ -79,6 +70,12 @@ pub(in crate::rendering) fn render<B: Backend>(
     } else {
         (height / 2.0 + TEXT_ALIGN_CENTER, line2_end_x - PADDING)
     };
+
+    let line1 = context.choose_abbreviation(
+        component.line1.iter().map(|a| &**a),
+        DEFAULT_TEXT_SIZE,
+        width - PADDING - left_bound,
+    );
 
     context.render_text_align(
         line1,


### PR DESCRIPTION
So far the renderer took care of handling the abbreviations for the title, but other frontends may want to make use of them as well, such is the case in the React based renderer in the web frontend of LiveSplit One.