### PR TITLE
Added get_path method to Run so the path can be actually accessed.

### DIFF
--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -167,13 +167,13 @@ impl Run {
         self.category_name.push_str(name.as_ref());
     }
 
-    /// Gets the path of the associated splits file in the file system.
+    /// Returns the path of the associated splits file in the file system.
     #[inline]
-    pub fn get_path(&mut self) -> &Option<PathBuf> {
+    pub fn path(&mut self) -> &Option<PathBuf> {
         &self.path
     }
 
-	/// Sets the path of the associated splits file in the file system.
+    /// Sets the path of the associated splits file in the file system.
     #[inline]
     pub fn set_path(&mut self, path: Option<PathBuf>) {
         self.path = path;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -167,7 +167,13 @@ impl Run {
         self.category_name.push_str(name.as_ref());
     }
 
-    /// Sets the path of the associated splits file in the file system.
+    /// Gets the path of the associated splits file in the file system.
+    #[inline]
+    pub fn get_path(&mut self) -> &Option<PathBuf> {
+        &self.path
+    }
+
+	/// Sets the path of the associated splits file in the file system.
     #[inline]
     pub fn set_path(&mut self, path: Option<PathBuf>) {
         self.path = path;


### PR DESCRIPTION
Aded a get_path method to Run so the path can be accessed for saving, as I asume it was intended to be.

The Run struct contains an Option<PathBuf> to store the path to the save file it was loaded from. 
This comes in really handy when saving, as the path can be simply read from the path.
However, the path attribute of Run was private and inaccessible in any way, making it unusable.

Now the path should be easily accessible.