### PR TITLE
Method path in Run needed not be mutable.

### DIFF
--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -169,7 +169,7 @@ impl Run {
 
     /// Returns the path of the associated splits file in the file system.
     #[inline]
-    pub fn path(&mut self) -> &Option<PathBuf> {
+    pub fn path(&self) -> &Option<PathBuf> {
         &self.path
     }
 


### PR DESCRIPTION
Yesterday it was late and I was sleepy, didn't realize I had made the path method mutable.