### PR TITLE
Various Improvements to the C API

### DIFF
--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -460,7 +460,7 @@ interface Slice {
     len: number,
 }
 
-function allocInt8Array(src: Int8Array): Slice {
+function allocUint8Array(src: Uint8Array): Slice {
     const len = src.length;
     const ptr = wasm.alloc(len);
     const slice = new Uint8Array(wasm.memory.buffer, ptr, len);
@@ -570,7 +570,7 @@ if (!global["TextDecoder"]) {
     decodeUtf8 = (data) => decoder.decode(data);
 }
 
-function allocInt8Array(src) {
+function allocUint8Array(src) {
     const len = src.length;
     const ptr = wasm.alloc(len);
     const slice = new Uint8Array(wasm.memory.buffer, ptr, len);
@@ -756,13 +756,13 @@ export class {class} extends {base_class} {{"#,
                     writer,
                     "{}",
                     r#"
-    setGameIconFromArray(data: Int8Array) {
-        const slice = allocInt8Array(data);
+    setGameIconFromArray(data: Uint8Array) {
+        const slice = allocUint8Array(data);
         this.setGameIcon(slice.ptr, slice.len);
         dealloc(slice);
     }
-    activeSetIconFromArray(data: Int8Array) {
-        const slice = allocInt8Array(data);
+    activeSetIconFromArray(data: Uint8Array) {
+        const slice = allocUint8Array(data);
         this.activeSetIcon(slice.ptr, slice.len);
         dealloc(slice);
     }"#
@@ -773,18 +773,18 @@ export class {class} extends {base_class} {{"#,
                     "{}",
                     r#"
     /**
-     * @param {Int8Array} data
+     * @param {Uint8Array} data
      */
     setGameIconFromArray(data) {
-        const slice = allocInt8Array(data);
+        const slice = allocUint8Array(data);
         this.setGameIcon(slice.ptr, slice.len);
         dealloc(slice);
     }
     /**
-     * @param {Int8Array} data
+     * @param {Uint8Array} data
      */
     activeSetIconFromArray(data) {
-        const slice = allocInt8Array(data);
+        const slice = allocUint8Array(data);
         this.activeSetIcon(slice.ptr, slice.len);
         dealloc(slice);
     }"#
@@ -885,8 +885,8 @@ export class {class} extends {base_class} {{"#,
                     writer,
                     "{}",
                     r#"
-    static parseArray(data: Int8Array, path: string, loadFiles: boolean): ParseRunResult {
-        const slice = allocInt8Array(data);
+    static parseArray(data: Uint8Array, path: string, loadFiles: boolean): ParseRunResult {
+        const slice = allocUint8Array(data);
         const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
         dealloc(slice);
         return result;
@@ -904,13 +904,13 @@ export class {class} extends {base_class} {{"#,
                     "{}",
                     r#"
     /**
-     * @param {Int8Array} data
+     * @param {Uint8Array} data
      * @param {string} path
      * @param {boolean} loadFiles
      * @return {ParseRunResult}
      */
     static parseArray(data, path, loadFiles) {
-        const slice = allocInt8Array(data);
+        const slice = allocUint8Array(data);
         const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
         dealloc(slice);
         return result;
@@ -935,8 +935,8 @@ export class {class} extends {base_class} {{"#,
                     writer,
                     "{}",
                     r#"
-    static parseOriginalLivesplitArray(data: Int8Array): Layout | null {
-        const slice = allocInt8Array(data);
+    static parseOriginalLivesplitArray(data: Uint8Array): Layout | null {
+        const slice = allocUint8Array(data);
         const result = Layout.parseOriginalLivesplit(slice.ptr, slice.len);
         dealloc(slice);
         return result;
@@ -954,11 +954,11 @@ export class {class} extends {base_class} {{"#,
                     "{}",
                     r#"
     /**
-     * @param {Int8Array} data
+     * @param {Uint8Array} data
      * @return {Layout | null}
      */
     static parseOriginalLivesplitArray(data) {
-        const slice = allocInt8Array(data);
+        const slice = allocUint8Array(data);
         const result = Layout.parseOriginalLivesplit(slice.ptr, slice.len);
         dealloc(slice);
         return result;

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -185,3 +185,10 @@ pub extern "C" fn dealloc(ptr: *mut u8, cap: usize) {
         let _buf = Vec::from_raw_parts(ptr, 0, cap);
     }
 }
+
+/// Returns the byte length of the last nul-terminated string returned on the
+/// current thread. The length excludes the nul-terminator.
+#[no_mangle]
+pub extern "C" fn get_buf_len() -> usize {
+    OUTPUT_VEC.with(|v| v.borrow().len() - 1)
+}


### PR DESCRIPTION
1. A `get_buf_len` function is introduced that helps languages skip the string length calculation. This should reduce some overhead.
2. Adds a way to allow JavaScript to obtain the splits as an `Uint8Array`. This is super cheap as it directly points into the wasm memory without allocating anything on JavaScript's side.
3. Turns the `Int8Array` in the JavaScript bindings to `Uint8Array`. This more closely reflects the `&[u8]` / `Vec<u8>` on Rust's side.