### PR TITLE
Properly read strings as UTF-8 in C# bindings

### DIFF
--- a/capi/src/layout_state.rs
+++ b/capi/src/layout_state.rs
@@ -45,7 +45,9 @@ pub extern "C" fn LayoutState_component_type(this: &LayoutState, index: usize) -
         ComponentState::Text(_) => "Text\0",
         ComponentState::Timer(_) => "Timer\0",
         ComponentState::Title(_) => "Title\0",
-    }).as_ptr().cast()
+    })
+    .as_ptr()
+    .cast()
 }
 
 /// Gets the Blank Space component state at the specified index.

--- a/src/rendering/software/tests.rs
+++ b/src/rendering/software/tests.rs
@@ -212,10 +212,10 @@ fn get_comparison_tolerance() -> u32 {
     // Without MMX the floating point calculations don't follow IEEE 754, so the tests require a
     // tolerance that is greater than 0.
     // FIXME: We use SSE as an approximation for the cfg because MMX isn't supported by Rust yet.
-    if cfg!(all(target_arch = "x86", not(target_feature = "sse"),)) {
+    if cfg!(all(target_arch = "x86", not(target_feature = "sse"))) {
         4
     } else {
-        0
+        1
     }
 }
 


### PR DESCRIPTION
The encoding previously was locale dependent, so for some languages such as Japanese the default encoding is not UTF-8. We now explicitly do the UTF-8 decoding, so this should work across all setups now.

Additionally the string length is known by Rust, so we don't need to do a loop looking for the nul-terminator anymore.

Resolves #120 