### PR TITLE
Stop shrinking GIFs for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tokio = { version = "0.2", features = ["macros"] }
 default = ["image-shrinking", "std"]
 doesnt-have-atomics = []
 std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
-more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/gif", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
+more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype", "smallvec"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]


### PR DESCRIPTION
Shrinking GIFs to PNGs removes all their animations, so optimally we'd like to shrink them to GIFs and retain their animation. However it looks like the image crate is brushing over too many properties of GIFs. This makes it infeasible to do this without breaking GIFs. We could eventually look into using the underlying gif crate directly. For now we'll just not shrink GIFs at all.

Unfortunately closes #321 