### PR TITLE
Make Software Rendering `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hashbrown = "0.7.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.5.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.1.0" }
-odds = { version = "0.3.1", default-features = false }
+odds = { version = "0.4.0", default-features = false }
 ordered-float = { version = "1.0.2", default-features = false }
 palette = { version = "0.5.0", default-features = false, features = ["libm"] }
 serde = { version = "1.0.98", default-features = false, features = ["derive", "alloc"] }
@@ -60,12 +60,12 @@ utf-8 = { version = "0.7.4", optional = true }
 # Rendering
 euclid = { version = "0.20.0", default-features = false, optional = true }
 lyon = { version = "0.15.3", default-features = false, optional = true }
-rusttype = { version = "0.8.0", default-features = false, features = ["std"], optional = true }
-smallvec = { version = "1.0.0", default-features = false, optional = true }
+rusttype = { version = "0.8.3", default-features = false, features = ["std"], optional = true }
+smallvec = { version = "1.3.0", default-features = false, optional = true }
 
 # Software Rendering
-euc = { version = "0.4.2", default-features = false, optional = true }
-vek = { version = "0.9.8", default-features = false, optional = true }
+euc = { version = "0.5.0", default-features = false, features = ["libm"], optional = true }
+vek = { version = "0.10.1", default-features = false, features = ["libm"], optional = true }
 
 # Networking
 splits-io-api = { version = "0.1.2", optional = true }
@@ -83,7 +83,7 @@ tokio = { version = "0.2", features = ["macros"] }
 [features]
 default = ["image-shrinking", "std"]
 doesnt-have-atomics = []
-std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
+std = ["byteorder", "chrono/std", "chrono/clock", "euc/std", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8", "vek/std"]
 more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype", "smallvec"]

--- a/src/rendering/software/mod.rs
+++ b/src/rendering/software/mod.rs
@@ -22,7 +22,6 @@ use {
 pub use image::{self, RgbaImage};
 
 struct SoftwareBackend {
-    dims: [usize; 2],
     color: AlphaBlended,
 }
 
@@ -60,10 +59,10 @@ impl Backend for SoftwareBackend {
             color_br: Rgba::new(br[0], br[1], br[2], br[3]),
             texture,
         }
-        .draw::<rasterizer::Triangles<'_, _, BackfaceCullingDisabled>, _>(
+        .draw::<rasterizer::Triangles<'_, (f32,), BackfaceCullingDisabled>, _>(
             mesh,
             &mut self.color,
-            &mut NoDepth(self.dims),
+            None,
         );
     }
 
@@ -80,24 +79,6 @@ impl Backend for SoftwareBackend {
     fn free_texture(&mut self, _: Self::Texture) {}
 
     fn resize(&mut self, _: f32, _: f32) {}
-}
-
-struct NoDepth([usize; 2]);
-
-impl Target for NoDepth {
-    type Item = f32;
-
-    fn size(&self) -> [usize; 2] {
-        self.0
-    }
-
-    unsafe fn set(&mut self, _pos: [usize; 2], _item: Self::Item) {}
-
-    unsafe fn get(&self, _pos: [usize; 2]) -> Self::Item {
-        1.0
-    }
-
-    fn clear(&mut self, _fill: Self::Item) {}
 }
 
 struct AlphaBlended(Buffer2d<Rgba<f32>>);
@@ -232,7 +213,6 @@ pub fn render(state: &LayoutState, [width, height]: [usize; 2]) -> RgbaImage {
             [width, height],
             Rgba::new(0.0, 0.0, 0.0, 0.0),
         )),
-        dims: [width, height],
     };
 
     Renderer::new().render(&mut backend, (width as _, height as _), &state);


### PR DESCRIPTION
This updates the dependencies such that the software rendering is now `no_std` compatible. However this still won't entirely work, as the `rendering` feature itself isn't fully `no_std` compatible yet. `lyon`
is the only crate remaining however that still needs to be made `no_std` compatible.

cc #223 