### PR TITLE
Expose the Skill Curve in the API

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -5,10 +5,12 @@ pub mod current_pace;
 pub mod delta;
 pub mod pb_chance;
 pub mod possible_time_save;
+mod skill_curve;
 pub mod state_helper;
 pub mod sum_of_segments;
 pub mod total_playtime;
 
+pub use self::skill_curve::SkillCurve;
 pub use self::state_helper::*;
 
 #[cfg(test)]

--- a/src/analysis/pb_chance/mod.rs
+++ b/src/analysis/pb_chance/mod.rs
@@ -5,8 +5,9 @@
 //! result as the PB chance for the Run. The value is being reported as a
 //! floating point number in the range from 0 (0%) to 1 (100%).
 //!
-//! The PB chance is currently calculated through the Balanced PB algorithm. The
-//! PB chance is the percentile at which the Balanced PB algorithm finds the PB.
+//! The PB chance is currently calculated with the skill curve. The PB chance is
+//! the percentile at which the PB is located on the skill curve. This is also
+//! where the Balanced PB would source its split times.
 
 use super::SkillCurve;
 use crate::{comparison, Run, Segment, TimeSpan, Timer, TimingMethod};

--- a/src/analysis/pb_chance/mod.rs
+++ b/src/analysis/pb_chance/mod.rs
@@ -8,7 +8,7 @@
 //! The PB chance is currently calculated through the Balanced PB algorithm. The
 //! PB chance is the percentile at which the Balanced PB algorithm finds the PB.
 
-use crate::platform::prelude::*;
+use super::SkillCurve;
 use crate::{comparison, Run, Segment, TimeSpan, Timer, TimingMethod};
 
 #[cfg(test)]
@@ -24,17 +24,7 @@ fn calculate(segments: &[Segment], method: TimingMethod, offset: TimeSpan) -> f6
         return 1.0;
     }
 
-    let mut all_weighted_segment_times = vec![Vec::new(); segments.len()];
-    let mut time_span_buf = Vec::with_capacity(segments.len());
-
-    comparison::goal::determine_percentile(
-        offset,
-        segments,
-        method,
-        None,
-        &mut time_span_buf,
-        &mut all_weighted_segment_times,
-    )
+    comparison::goal::determine_percentile(offset, segments, method, None, &mut SkillCurve::new())
 }
 
 /// Calculates the PB chance for a run. No information about an active attempt

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -7,7 +7,7 @@ const WEIGHT: f64 = 0.75;
 const TRIES: usize = 50;
 
 /// The skill curve analyzes the segment history across all segments. For each
-/// segment all the segment times are sorted by length and weighted by their
+/// segment, all the segment times are sorted by length and weighted by their
 /// recency. Plotting this on a graph with the y-axis representing the segment
 /// time and the x-axis representing the percentile, with the shortest time at 0
 /// and the longest time at 1, yields the so called "skill curve". If you sum
@@ -16,9 +16,9 @@ const TRIES: usize = 50;
 ///
 /// # Properties of the Skill Curve
 ///
-/// If you sample the curve at 0, you get the simple sum of best segments and if
-/// you sample the curve at 1, you get the simple sum of worst segments. At 0.5
-/// you get the median segments. If you sample the individual segments where you
+/// If you sample the curve at 0, you get the simple sum of best segments, and if
+/// you sample the curve at 1, you get the simple sum of worst segments. At 0.5,
+/// you get the median segments. If you sample the individual segments at the same percentile where you
 /// find the Personal Best on the overall run's curve, you get the Balanced PB.
 /// The position of the Balanced PB on the x-axis is the PB chance.
 #[derive(Default, Clone)]
@@ -33,7 +33,7 @@ impl SkillCurve {
         Default::default()
     }
 
-    /// Returns the amount of segments this skill curve is comprised of.
+    /// Returns the number of segments this skill curve is comprised of.
     pub fn len(&self) -> usize {
         self.all_weighted_segment_times.len()
     }
@@ -43,7 +43,7 @@ impl SkillCurve {
         self.all_weighted_segment_times.is_empty()
     }
 
-    /// Reduces the amount of segments that are being considered by this curve.
+    /// Reduces the number of segments that are being considered by this curve.
     pub fn truncate(&mut self, len: usize) {
         self.all_weighted_segment_times.truncate(len);
     }
@@ -120,7 +120,7 @@ impl SkillCurve {
             }
         }
 
-        // Limit the slice to only the segments that have segment times.
+        // Limit the slice to only the segments that have segment times
         self.truncate(len);
     }
 
@@ -147,7 +147,7 @@ impl SkillCurve {
                         // array. Both could go out of bounds.
                         let left_index = right_index.saturating_sub(1);
                         // This assumes len can never be 0. This only works out
-                        // for us, because we truncate all the empty segments away.
+                        // for us because we truncate all the empty segments away.
                         let right_index = right_index.min(weighted_segment_times.len() - 1);
 
                         if left_index == right_index {
@@ -184,7 +184,7 @@ impl SkillCurve {
 
     /// Searches the curve for the final run time specified and returns the
     /// percentile the time can be found at. The percentile is always within the
-    /// range 0..1. If the time specified can not be found, the percentile
+    /// range 0..1. If the time specified cannot be found, the percentile
     /// saturates at one of those boundaries.
     pub fn find_percentile_for_time(&self, offset: TimeSpan, time_to_find: TimeSpan) -> f64 {
         let (mut perc_min, mut perc_max) = (0.0, 1.0);

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -1,0 +1,223 @@
+use crate::platform::prelude::*;
+use crate::{Segment, TimeSpan, TimingMethod};
+use core::cmp::Ordering;
+use ordered_float::OrderedFloat;
+
+const WEIGHT: f64 = 0.75;
+const TRIES: usize = 50;
+
+/// The skill curve analyzes the segment history across all segments. For each
+/// segment all the segment times are sorted by length and weighted by their
+/// recency. Plotting this on a graph with the y-axis representing the segment
+/// time and the x-axis representing the percentile, with the shortest time at 0
+/// and the longest time at 1, yields the so called "skill curve". If you sum
+/// all the different curves together for all the segments, you get the overall
+/// curve for the whole run.
+///
+/// # Properties of the Skill Curve
+///
+/// If you sample the curve at 0, you get the simple sum of best segments and if
+/// you sample the curve at 1, you get the simple sum of worst segments. At 0.5
+/// you get the median segments. If you sample the individual segments where you
+/// find the Personal Best on the overall run's curve, you get the Balanced PB.
+/// The position of the Balanced PB on the x-axis is the PB chance.
+#[derive(Default, Clone)]
+pub struct SkillCurve {
+    all_weighted_segment_times: Vec<Vec<(f64, TimeSpan)>>,
+}
+
+impl SkillCurve {
+    /// Constructs a new empty skill curve. Before querying information, you
+    /// need to calculate the curve for some segments.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns the amount of segments this skill curve is comprised of.
+    pub fn len(&self) -> usize {
+        self.all_weighted_segment_times.len()
+    }
+
+    /// Returns `true` if there are no segments in this skill curve.
+    pub fn is_empty(&self) -> bool {
+        self.all_weighted_segment_times.is_empty()
+    }
+
+    /// Reduces the amount of segments that are being considered by this curve.
+    pub fn truncate(&mut self, len: usize) {
+        self.all_weighted_segment_times.truncate(len);
+    }
+
+    /// Calculate the skill curve for the segments and timing method provided.
+    /// All previous information available in the skill curve will be discarded.
+    /// The segment curve may not always contain information for all segments.
+    /// Once a segment with no segment history is encountered, the remainder of
+    /// the segments get discarded.
+    pub fn for_segments(&mut self, segments: &[Segment], method: TimingMethod) {
+        let mut len = segments.len();
+
+        self.all_weighted_segment_times
+            .resize_with(len, Default::default);
+
+        for ((i, segment), weighted_segment_times) in segments
+            .iter()
+            .enumerate()
+            .zip(&mut self.all_weighted_segment_times)
+        {
+            weighted_segment_times.clear();
+
+            // Collect initial weighted segments
+            let mut current_weight = 1.0;
+            for &(id, time) in segment.segment_history().iter_actual_runs().rev() {
+                if let Some(time) = time[method] {
+                    // Skip all the combined segments
+                    let skip = catch! {
+                        segments[i.checked_sub(1)?].segment_history().get(id)?[method].is_none()
+                    }
+                    .unwrap_or(false);
+
+                    if !skip {
+                        weighted_segment_times.push((current_weight, time));
+                        current_weight *= WEIGHT;
+                    }
+                }
+            }
+
+            // End early if we don't have any segment times anymore
+            if weighted_segment_times.is_empty() {
+                len = i;
+                break;
+            }
+
+            // Sort everything by the times
+            weighted_segment_times
+                .sort_unstable_by_key(|&(_, time)| OrderedFloat(time.total_milliseconds()));
+
+            // Cumulative sum of the weights
+            let mut sum = 0.0;
+            for (weight, _) in weighted_segment_times.iter_mut() {
+                sum += *weight;
+                *weight = sum;
+            }
+
+            // Reweigh all of the weights to be in the range 0..1
+            let min = weighted_segment_times
+                .first()
+                .map(|&(w, _)| w)
+                .unwrap_or_default();
+
+            let max = weighted_segment_times
+                .last()
+                .map(|&(w, _)| w)
+                .unwrap_or_default();
+
+            let diff = max - min;
+
+            if diff != 0.0 {
+                for (weight, _) in weighted_segment_times.iter_mut() {
+                    *weight = (*weight - min) / diff;
+                }
+            }
+        }
+
+        // Limit the slice to only the segments that have segment times.
+        self.truncate(len);
+    }
+
+    /// This function returns an iterator that iterates over each segment and
+    /// yields their segment times for the percentile specified. A percentile of
+    /// 0 yields the fastest times, while a percentile of 1 yields the slowest
+    /// times.
+    pub fn iter_segment_times_at_percentile(
+        &self,
+        percentile: f64,
+    ) -> impl Iterator<Item = TimeSpan> + '_ {
+        self.all_weighted_segment_times
+            .iter()
+            .map(move |weighted_segment_times| {
+                let found_index = weighted_segment_times
+                    .binary_search_by(|&(w, _)| w.partial_cmp(&percentile).unwrap());
+
+                match found_index {
+                    // The percentile perfectly matched a segment time
+                    Ok(index) => weighted_segment_times[index].1,
+                    // The percentile didn't perfectly match, interpolate instead
+                    Err(right_index) => {
+                        // Saturate both left and right index at the bounds of the
+                        // array. Both could go out of bounds.
+                        let left_index = right_index.saturating_sub(1);
+                        // This assumes len can never be 0. This only works out
+                        // for us, because we truncate all the empty segments away.
+                        let right_index = right_index.min(weighted_segment_times.len() - 1);
+
+                        if left_index == right_index {
+                            weighted_segment_times[left_index].1
+                        } else {
+                            let right = weighted_segment_times[right_index];
+                            let left = weighted_segment_times[left_index];
+
+                            interpolate(percentile, left, right)
+                        }
+                    }
+                }
+            })
+    }
+
+    /// This function returns an iterator that iterates over each segment and
+    /// yields their split times for the percentile specified. A percentile of 0
+    /// yields the fastest times, while a percentile of 1 yields the slowest
+    /// times. The offset provided is the initial split time going into the
+    /// first segment. This is only relevant when the segments don't represent
+    /// the beginning of the run.
+    pub fn iter_split_times_at_percentile(
+        &self,
+        percentile: f64,
+        offset: TimeSpan,
+    ) -> impl Iterator<Item = TimeSpan> + '_ {
+        let mut sum = offset;
+        self.iter_segment_times_at_percentile(percentile)
+            .map(move |segment_time| {
+                sum += segment_time;
+                sum
+            })
+    }
+
+    /// Searches the curve for the final run time specified and returns the
+    /// percentile the time can be found at. The percentile is always within the
+    /// range 0..1. If the time specified can not be found, the percentile
+    /// saturates at one of those boundaries.
+    pub fn find_percentile_for_time(&self, offset: TimeSpan, time_to_find: TimeSpan) -> f64 {
+        let (mut perc_min, mut perc_max) = (0.0, 1.0);
+
+        // Try to find the correct percentile
+        for _ in 0..TRIES {
+            let percentile = (perc_max + perc_min) / 2.0;
+
+            let sum = self
+                .iter_segment_times_at_percentile(percentile)
+                .fold(offset, |sum, segment_time| sum + segment_time);
+
+            // Binary search the correct percentile
+            match sum.partial_cmp(&time_to_find) {
+                Some(Ordering::Equal) => return percentile,
+                Some(Ordering::Less) => perc_min = percentile,
+                Some(Ordering::Greater) => perc_max = percentile,
+                None => {}
+            }
+        }
+
+        (perc_max + perc_min) / 2.0
+    }
+}
+
+fn interpolate(
+    perc: f64,
+    (weight_left, time_left): (f64, TimeSpan),
+    (weight_right, time_right): (f64, TimeSpan),
+) -> TimeSpan {
+    let perc_down =
+        (weight_right - perc) * time_left.total_milliseconds() / (weight_right - weight_left);
+    let perc_up =
+        (perc - weight_left) * time_right.total_milliseconds() / (weight_right - weight_left);
+    TimeSpan::from_milliseconds(perc_up + perc_down)
+}

--- a/src/comparison/balanced_pb.rs
+++ b/src/comparison/balanced_pb.rs
@@ -10,6 +10,9 @@
 //! perfect situation to compare against the Balanced Personal Best comparison
 //! instead, as all of the mistakes of the early game in such a situation would
 //! be smoothed out throughout the whole comparison.
+//!
+//! The algorithm is sampling the split times on the skill curve where the
+//! Personal Best is located.
 
 use super::{goal, ComparisonGenerator};
 use crate::{analysis::SkillCurve, Attempt, Segment, TimingMethod};
@@ -26,6 +29,9 @@ use crate::{analysis::SkillCurve, Attempt, Segment, TimingMethod};
 /// compare against the Balanced Personal Best comparison instead, as all of the
 /// mistakes of the early game in such a situation would be smoothed out
 /// throughout the whole comparison.
+///
+/// The algorithm is sampling the split times on the skill curve where the
+/// Personal Best is located.
 #[derive(Copy, Clone, Debug)]
 pub struct BalancedPB;
 

--- a/src/comparison/balanced_pb.rs
+++ b/src/comparison/balanced_pb.rs
@@ -12,8 +12,7 @@
 //! be smoothed out throughout the whole comparison.
 
 use super::{goal, ComparisonGenerator};
-use crate::platform::prelude::*;
-use crate::{Attempt, Segment, TimingMethod};
+use crate::{analysis::SkillCurve, Attempt, Segment, TimingMethod};
 
 /// The Comparison Generator for calculating a comparison which has the same
 /// final time as the runner's Personal Best. Unlike the Personal Best however,
@@ -42,24 +41,21 @@ impl ComparisonGenerator for BalancedPB {
     }
 
     fn generate(&mut self, segments: &mut [Segment], _: &[Attempt]) {
-        let mut all_weighted_segment_times = vec![Vec::new(); segments.len()];
-        let mut time_span_buf = Vec::with_capacity(segments.len());
+        let mut skill_curve = SkillCurve::new();
 
         goal::generate_for_timing_method_with_buf(
             segments,
             TimingMethod::RealTime,
             None,
             NAME,
-            &mut time_span_buf,
-            &mut all_weighted_segment_times,
+            &mut skill_curve,
         );
         goal::generate_for_timing_method_with_buf(
             segments,
             TimingMethod::GameTime,
             None,
             NAME,
-            &mut time_span_buf,
-            &mut all_weighted_segment_times,
+            &mut skill_curve,
         );
     }
 }

--- a/src/comparison/goal.rs
+++ b/src/comparison/goal.rs
@@ -5,27 +5,10 @@
 //! Balanced PB comparison however is based on this, which uses the Personal
 //! Best as a goal time to balance the mistakes that happened in the Personal Best.
 
-use crate::platform::prelude::*;
-use crate::{Segment, Time, TimeSpan, TimingMethod};
-use ordered_float::OrderedFloat;
+use crate::{analysis::SkillCurve, Segment, Time, TimeSpan, TimingMethod};
 
 /// The default name of the goal comparison.
 pub const NAME: &str = "Goal";
-
-const WEIGHT: f64 = 0.75;
-const TRIES: usize = 50;
-
-fn interpolate(
-    perc: f64,
-    (weight_left, time_left): (f64, TimeSpan),
-    (weight_right, time_right): (f64, TimeSpan),
-) -> TimeSpan {
-    let perc_down =
-        (weight_right - perc) * time_left.total_milliseconds() / (weight_right - weight_left);
-    let perc_up =
-        (perc - weight_left) * time_right.total_milliseconds() / (weight_right - weight_left);
-    TimeSpan::from_milliseconds(perc_up + perc_down)
-}
 
 // FIXME: Possibly move this into the analysis module.
 pub(crate) fn determine_percentile(
@@ -33,142 +16,28 @@ pub(crate) fn determine_percentile(
     segments: &[Segment],
     method: TimingMethod,
     goal_time: Option<TimeSpan>,
-    time_span_buf: &mut Vec<TimeSpan>,
-    all_weighted_segment_times: &mut [Vec<(f64, TimeSpan)>],
+    skill_curve: &mut SkillCurve,
 ) -> f64 {
-    let mut len = segments.len();
+    skill_curve.for_segments(segments, method);
 
-    for ((i, segment), weighted_segment_times) in segments
-        .iter()
-        .enumerate()
-        .zip(all_weighted_segment_times.iter_mut())
-    {
-        weighted_segment_times.clear();
-
-        // Collect initial weighted segments
-        let mut current_weight = 1.0;
-        for &(id, time) in segment.segment_history().iter_actual_runs().rev() {
-            if let Some(time) = time[method] {
-                // Skip all the combined segments
-                let skip = catch! {
-                    segments[i.checked_sub(1)?].segment_history().get(id)?[method].is_none()
-                }
-                .unwrap_or(false);
-
-                if !skip {
-                    weighted_segment_times.push((current_weight, time));
-                    current_weight *= WEIGHT;
-                }
-            }
-        }
-
-        // End early if we don't have any segment times anymore
-        if weighted_segment_times.is_empty() {
-            len = i;
-            break;
-        }
-
-        // Sort everything by the times
-        weighted_segment_times
-            .sort_unstable_by_key(|&(_, time)| OrderedFloat(time.total_milliseconds()));
-
-        // Cumulative sum of the weights
-        let mut sum = 0.0;
-        for (weight, _) in weighted_segment_times.iter_mut() {
-            sum += *weight;
-            *weight = sum;
-        }
-
-        // Reweigh all of the weights to be in the range 0..1
-        let min = weighted_segment_times
-            .first()
-            .map(|&(w, _)| w)
-            .unwrap_or_default();
-        let max = weighted_segment_times
-            .last()
-            .map(|&(w, _)| w)
-            .unwrap_or_default();
-        let diff = max - min;
-
-        if diff != 0.0 {
-            for (weight, _) in weighted_segment_times.iter_mut() {
-                *weight = (*weight - min) / diff;
-            }
-        }
-    }
-
-    // Limit the slice to only the segments that have segment times.
-    let mut all_weighted_segment_times = &mut all_weighted_segment_times[..len];
-
-    // Depending on whether we have a goal time or not, we used that goal time
+    // Depending on whether we have a goal time or not, we use that goal time
     // or try to determine a personal best split time that we use for the goal
     // time. In that case we may need to limit the slice again to the last split
     // that actually has a split time we can work with.
     let goal_time = if let Some(goal_time) = goal_time {
         goal_time
     } else {
-        let (new_len, goal_time) = segments[..len]
+        let (new_len, goal_time) = segments[..skill_curve.len()]
             .iter()
             .enumerate()
             .rev()
             .find_map(|(i, s)| s.personal_best_split_time()[method].map(|t| (i + 1, t)))
             .unwrap_or_default();
-        all_weighted_segment_times = &mut all_weighted_segment_times[..new_len];
+        skill_curve.truncate(new_len);
         goal_time
     };
 
-    let (mut perc_min, mut perc_max) = (0.0, 1.0);
-
-    // Try to find the correct percentile
-    for _ in 0..TRIES {
-        let percentile = (perc_max + perc_min) / 2.0;
-        let mut sum = offset;
-
-        time_span_buf.clear();
-        time_span_buf.extend(
-            all_weighted_segment_times
-                .iter()
-                .map(|weighted_segment_times| {
-                    // Binary search the percentile in the segment's segment times
-                    let percentile_segment_time = if weighted_segment_times.len() == 1 {
-                        // Shortcut for a single segment time
-                        weighted_segment_times[0].1
-                    } else {
-                        let found_index = weighted_segment_times
-                            .binary_search_by(|&(w, _)| w.partial_cmp(&percentile).unwrap());
-
-                        match found_index {
-                            // The percentile perfectly matched a segment time
-                            Ok(index) => weighted_segment_times[index].1,
-                            // The percentile didn't perfectly match, interpolate instead
-                            Err(right_index) => {
-                                let right = weighted_segment_times[right_index];
-                                let left = right_index
-                                    .checked_sub(1)
-                                    .map(|left_index| weighted_segment_times[left_index])
-                                    .unwrap_or_default();
-
-                                interpolate(percentile, left, right)
-                            }
-                        }
-                    };
-
-                    sum += percentile_segment_time;
-                    sum
-                }),
-        );
-
-        // Binary search the correct percentile
-        if sum == goal_time {
-            return percentile;
-        } else if sum < goal_time {
-            perc_min = percentile;
-        } else {
-            perc_max = percentile;
-        }
-    }
-
-    (perc_max + perc_min) / 2.0
+    skill_curve.find_percentile_for_time(offset, goal_time)
 }
 
 pub(super) fn generate_for_timing_method_with_buf(
@@ -176,22 +45,19 @@ pub(super) fn generate_for_timing_method_with_buf(
     method: TimingMethod,
     goal_time: Option<TimeSpan>,
     comparison: &str,
-    time_span_buf: &mut Vec<TimeSpan>,
-    all_weighted_segment_times: &mut [Vec<(f64, TimeSpan)>],
+    skill_curve: &mut SkillCurve,
 ) {
-    let _percentile = determine_percentile(
-        TimeSpan::zero(),
-        segments,
-        method,
-        goal_time,
-        time_span_buf,
-        all_weighted_segment_times,
-    );
+    let percentile =
+        determine_percentile(TimeSpan::zero(), segments, method, goal_time, skill_curve);
 
-    for (segment, &val) in segments.iter_mut().zip(time_span_buf.iter()) {
+    let mut segments = segments.iter_mut();
+    for (segment, val) in segments
+        .by_ref()
+        .zip(skill_curve.iter_split_times_at_percentile(percentile, TimeSpan::zero()))
+    {
         segment.comparison_mut(comparison)[method] = Some(val);
     }
-    for segment in &mut segments[time_span_buf.len()..] {
+    for segment in segments {
         segment.comparison_mut(comparison)[method] = None;
     }
 }
@@ -209,16 +75,14 @@ pub fn generate_for_timing_method(
     goal_time: TimeSpan,
     comparison: &str,
 ) {
-    let mut all_weighted_segment_times = vec![Vec::new(); segments.len()];
-    let mut time_span_buf = Vec::with_capacity(segments.len());
+    let mut skill_curve = SkillCurve::new();
 
     generate_for_timing_method_with_buf(
         segments,
         method,
         Some(goal_time),
         comparison,
-        &mut time_span_buf,
-        &mut all_weighted_segment_times,
+        &mut skill_curve,
     );
 }
 
@@ -228,8 +92,7 @@ pub fn generate_for_timing_method(
 /// Only the range between the sum of the best segments and the sum of the worst
 /// segments is supported. Every other goal time is capped within that range.
 pub fn generate(segments: &mut [Segment], goal_time: Time, comparison: &str) {
-    let mut all_weighted_segment_times = vec![Vec::new(); segments.len()];
-    let mut time_span_buf = Vec::with_capacity(segments.len());
+    let mut skill_curve = SkillCurve::new();
 
     if let Some(real_time) = goal_time.real_time {
         generate_for_timing_method_with_buf(
@@ -237,8 +100,7 @@ pub fn generate(segments: &mut [Segment], goal_time: Time, comparison: &str) {
             TimingMethod::RealTime,
             Some(real_time),
             comparison,
-            &mut time_span_buf,
-            &mut all_weighted_segment_times,
+            &mut skill_curve,
         );
     } else {
         for segment in &mut *segments {
@@ -252,8 +114,7 @@ pub fn generate(segments: &mut [Segment], goal_time: Time, comparison: &str) {
             TimingMethod::GameTime,
             Some(game_time),
             comparison,
-            &mut time_span_buf,
-            &mut all_weighted_segment_times,
+            &mut skill_curve,
         );
     } else {
         for segment in &mut *segments {

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -78,12 +78,7 @@ impl Component {
 
     /// Accesses the name of the component.
     pub fn name(&self) -> Cow<'static, str> {
-        self.text(
-            self.settings
-                .comparison_override
-                .as_ref()
-                .map(String::as_str),
-        )
+        self.text(self.settings.comparison_override.as_deref())
     }
 
     fn text(&self, comparison: Option<&str>) -> Cow<'static, str> {

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -179,15 +179,13 @@ impl Component {
             let mut comparison1 = self
                 .settings
                 .comparison1
-                .as_ref()
-                .map(String::as_str)
+                .as_deref()
                 .unwrap_or_else(|| timer.current_comparison());
 
             let comparison2 = self
                 .settings
                 .comparison2
-                .as_ref()
-                .map(String::as_str)
+                .as_deref()
                 .unwrap_or_else(|| timer.current_comparison());
 
             let mut hide_comparison = self.settings.hide_second_comparison;

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -81,12 +81,7 @@ impl Component {
 
     /// Accesses the name of the component.
     pub fn name(&self) -> Cow<'static, str> {
-        self.text(
-            self.settings
-                .comparison_override
-                .as_ref()
-                .map(String::as_str),
-        )
+        self.text(self.settings.comparison_override.as_deref())
     }
 
     fn text(&self, comparison: Option<&str>) -> Cow<'static, str> {

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -26,7 +26,7 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Result<Cow<'_, [u8]>, ImageError> 
         // TGA doesn't have a Header.
         // DDS isn't a format we really care for.
         // And the image format is non-exhaustive.
-        ImageFormat::Gif | ImageFormat::Tga | ImageFormat::Dds | _ => return Ok(data.into()),
+        _ => return Ok(data.into()),
     };
 
     let is_too_large = width > max_dim || height > max_dim;


### PR DESCRIPTION
We've used the Balanced PB algorithm for various things by now: Balanced PB itself, the goal generator, the PB chance and it theoretically could also be used for the median segments and for calculating the simple sum of best and worst segments. The underlying curve that is being sampled here contains lots of interesting information, so it makes sense to expose it for analysis purposes in the API. I dubbed it the "skill curve" here, but the name is not necessarily final.