### PR TITLE
Implement updating the Layout States

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ edition = "2018"
 [package.metadata.docs.rs]
 all-features = true
 
-[badges]
-# FIXME: Add GitHub Actions badge
-
 [workspace]
 members = ["capi", "capi/bind_gen", "capi/staticlib", "capi/cdylib", "crates/*"]
 exclude = ["crates/no-std-test"]
@@ -44,6 +41,8 @@ odds = { version = "0.4.0", default-features = false }
 ordered-float = { version = "1.0.2", default-features = false }
 palette = { version = "0.5.0", default-features = false, features = ["libm"] }
 serde = { version = "1.0.98", default-features = false, features = ["derive", "alloc"] }
+smallstr = { version = "0.2.0", default-features = false }
+smallvec = { version = "1.3.0", default-features = false }
 snafu = { version = "0.6.0", default-features = false }
 unicase = "2.6.0"
 
@@ -61,7 +60,6 @@ utf-8 = { version = "0.7.4", optional = true }
 euclid = { version = "0.20.0", default-features = false, optional = true }
 lyon = { version = "0.15.3", default-features = false, optional = true }
 rusttype = { version = "0.9.1", default-features = false, features = ["std"], optional = true }
-smallvec = { version = "1.3.0", default-features = false, optional = true }
 
 # Software Rendering
 euc = { version = "0.5.0", default-features = false, features = ["libm"], optional = true }
@@ -88,7 +86,7 @@ doesnt-have-atomics = []
 std = ["byteorder", "chrono/std", "chrono/clock", "euc/std", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8", "vek/std"]
 more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "bytemuck", "more-image-formats"]
-rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype", "smallvec"]
+rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]
@@ -105,6 +103,10 @@ internal-use-all-features = []
 
 [[bench]]
 name = "balanced_pb"
+harness = false
+
+[[bench]]
+name = "layout_state"
 harness = false
 
 [[bench]]

--- a/benches/layout_state.rs
+++ b/benches/layout_state.rs
@@ -1,0 +1,68 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use livesplit_core::{run::parser::livesplit, Layout, Run, Segment, Timer};
+use std::{fs, io::Cursor};
+
+criterion_main!(benches);
+criterion_group!(
+    benches,
+    no_reuse_real,
+    reuse_real,
+    no_reuse_artificial,
+    reuse_artificial
+);
+
+fn artificial() -> (Timer, Layout) {
+    let mut run = Run::new();
+    run.set_game_name("Game");
+    run.set_category_name("Category");
+    run.push_segment(Segment::new("Foo"));
+
+    let mut timer = Timer::new(run).unwrap();
+    timer.start();
+
+    (timer, Layout::default_layout())
+}
+
+fn real() -> (Timer, Layout) {
+    let buf = fs::read("tests/run_files/Celeste - Any% (1.2.1.5).lss").unwrap();
+    let run = livesplit::parse(Cursor::new(&buf), None).unwrap();
+
+    let mut timer = Timer::new(run).unwrap();
+    timer.start();
+
+    (timer, Layout::default_layout())
+}
+
+fn no_reuse_real(c: &mut Criterion) {
+    let (timer, mut layout) = real();
+
+    c.bench_function("No Reuse (Real)", move |b| b.iter(|| layout.state(&timer)));
+}
+
+fn reuse_real(c: &mut Criterion) {
+    let (timer, mut layout) = real();
+
+    let mut state = layout.state(&timer);
+
+    c.bench_function("Reuse (Real)", move |b| {
+        b.iter(|| layout.update_state(&mut state, &timer))
+    });
+}
+
+fn no_reuse_artificial(c: &mut Criterion) {
+    let (timer, mut layout) = artificial();
+
+    c.bench_function("No Reuse (Artificial)", move |b| {
+        b.iter(|| layout.state(&timer))
+    });
+}
+
+fn reuse_artificial(c: &mut Criterion) {
+    let (timer, mut layout) = artificial();
+
+    let mut state = layout.state(&timer);
+
+    c.bench_function("Reuse (Artificial)", move |b| {
+        b.iter(|| layout.update_state(&mut state, &timer))
+    });
+}

--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -137,11 +137,11 @@ export interface TitleComponentStateJson {
     /**
      * By default the category name is shown on the second line. Based on the
      * settings, it can however instead be shown in a single line together with
-     * the game name. This is a list of all the possible abbreviations. It
-     * contains at least one element and the last element is the unabbreviated
-     * value.
+     * the game name. This is a list of all the possible abbreviations. If this
+     * is empty, only a single line is supposed to be shown. If it contains at
+     * least one element, the last element is the unabbreviated value.
      */
-    line2: string[] | null,
+    line2: string[],
     /**
      * Specifies whether the title should centered or aligned to the left
      * instead.

--- a/capi/src/blank_space_component.rs
+++ b/capi/src/blank_space_component.rs
@@ -6,7 +6,6 @@ use super::{output_vec, Json};
 use crate::blank_space_component_state::OwnedBlankSpaceComponentState;
 use crate::component::OwnedComponent;
 use livesplit_core::component::blank_space::Component as BlankSpaceComponent;
-use livesplit_core::Timer;
 
 /// type
 pub type OwnedBlankSpaceComponent = Box<BlankSpaceComponent>;
@@ -34,20 +33,16 @@ pub extern "C" fn BlankSpaceComponent_into_generic(
 
 /// Encodes the component's state information as JSON.
 #[no_mangle]
-pub extern "C" fn BlankSpaceComponent_state_as_json(
-    this: &mut BlankSpaceComponent,
-    timer: &Timer,
-) -> Json {
+pub extern "C" fn BlankSpaceComponent_state_as_json(this: &mut BlankSpaceComponent) -> Json {
     output_vec(|o| {
-        this.state(timer).write_json(o).unwrap();
+        this.state().write_json(o).unwrap();
     })
 }
 
-/// Calculates the component's state based on the timer provided.
+/// Calculates the component's state.
 #[no_mangle]
 pub extern "C" fn BlankSpaceComponent_state(
     this: &mut BlankSpaceComponent,
-    timer: &Timer,
 ) -> OwnedBlankSpaceComponentState {
-    Box::new(this.state(timer))
+    Box::new(this.state())
 }

--- a/capi/src/hotkey_config.rs
+++ b/capi/src/hotkey_config.rs
@@ -4,7 +4,6 @@
 use super::{get_file, output_vec, release_file, str, Json};
 use crate::setting_value::OwnedSettingValue;
 use livesplit_core::HotkeyConfig;
-use serde_json;
 use std::io::{BufReader, Cursor};
 
 /// type

--- a/capi/src/layout.rs
+++ b/capi/src/layout.rs
@@ -4,7 +4,7 @@
 use super::{get_file, output_vec, release_file, str, Json};
 use crate::component::OwnedComponent;
 use crate::layout_state::OwnedLayoutState;
-use livesplit_core::layout::{parser, LayoutSettings};
+use livesplit_core::layout::{parser, LayoutSettings, LayoutState};
 use livesplit_core::{Layout, Timer};
 use std::io::{BufReader, Cursor};
 use std::slice;
@@ -91,6 +91,25 @@ pub unsafe extern "C" fn Layout_parse_original_livesplit(
 #[no_mangle]
 pub extern "C" fn Layout_state(this: &mut Layout, timer: &Timer) -> OwnedLayoutState {
     Box::new(this.state(timer))
+}
+
+/// Updates the layout's state based on the timer provided.
+#[no_mangle]
+pub extern "C" fn Layout_update_state(this: &mut Layout, state: &mut LayoutState, timer: &Timer) {
+    this.update_state(state, timer)
+}
+
+/// Updates the layout's state based on the timer provided.
+#[no_mangle]
+pub extern "C" fn Layout_update_state_as_json(
+    this: &mut Layout,
+    state: &mut LayoutState,
+    timer: &Timer,
+) -> Json {
+    this.update_state(state, timer);
+    output_vec(|o| {
+        state.write_json(o).unwrap();
+    })
 }
 
 /// Calculates the layout's state based on the timer provided and encodes it as

--- a/capi/src/layout.rs
+++ b/capi/src/layout.rs
@@ -99,7 +99,8 @@ pub extern "C" fn Layout_update_state(this: &mut Layout, state: &mut LayoutState
     this.update_state(state, timer)
 }
 
-/// Updates the layout's state based on the timer provided.
+/// Updates the layout's state based on the timer provided and encodes it as
+/// JSON.
 #[no_mangle]
 pub extern "C" fn Layout_update_state_as_json(
     this: &mut Layout,

--- a/capi/src/layout_state.rs
+++ b/capi/src/layout_state.rs
@@ -6,6 +6,7 @@
 //! - Using out of bounds indices.
 //! - Using the wrong getter function on the wrong type of component.
 
+use crate::{output_vec, Json};
 use livesplit_core::component::{
     blank_space::State as BlankSpaceComponentState,
     detailed_timer::State as DetailedTimerComponentState, graph::State as GraphComponentState,
@@ -19,10 +20,26 @@ use std::os::raw::c_char;
 /// type
 pub type OwnedLayoutState = Box<LayoutState>;
 
+/// Creates a new empty Layout State. This is useful for creating an empty
+/// layout state that gets updated over time.
+#[no_mangle]
+pub extern "C" fn LayoutState_new() -> OwnedLayoutState {
+    Box::new(LayoutState::default())
+}
+
 /// drop
 #[no_mangle]
 pub extern "C" fn LayoutState_drop(this: OwnedLayoutState) {
     drop(this);
+}
+
+/// Encodes the layout state as JSON. You can use this to visualize all of the
+/// components of a layout.
+#[no_mangle]
+pub extern "C" fn LayoutState_as_json(this: &LayoutState) -> Json {
+    output_vec(|o| {
+        this.write_json(o).unwrap();
+    })
 }
 
 /// Gets the number of Components in the Layout State.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,4 +1,9 @@
-#![allow(non_snake_case, non_camel_case_types)]
+#![allow(
+    clippy::boxed_local, // FIXME: False Positive https://github.com/rust-lang/rust-clippy/issues/5542
+    clippy::missing_safety_doc,
+    non_camel_case_types,
+    non_snake_case
+)]
 #![warn(missing_docs)]
 
 //! mod

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -5,7 +5,7 @@ use crate::parse_run_result::OwnedParseRunResult;
 use crate::segment::OwnedSegment;
 use livesplit_core::run::{parser, saver};
 use livesplit_core::{Attempt, Run, RunMetadata, Segment, TimeSpan};
-use std::io::{BufReader, Cursor};
+use std::io::{BufReader, Cursor, Write};
 use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::slice;
@@ -176,7 +176,13 @@ pub extern "C" fn Run_extended_category_name(
     show_platform: bool,
     show_variables: bool,
 ) -> *const c_char {
-    output_str(this.extended_category_name(show_region, show_platform, show_variables))
+    output_vec(|o| {
+        let _ = write!(
+            o,
+            "{}",
+            this.extended_category_name(show_region, show_platform, show_variables),
+        );
+    })
 }
 
 /// Returns the amount of runs that have been attempted with these splits.

--- a/capi/src/separator_component.rs
+++ b/capi/src/separator_component.rs
@@ -4,7 +4,6 @@
 use crate::component::OwnedComponent;
 use crate::separator_component_state::OwnedSeparatorComponentState;
 use livesplit_core::component::separator::Component as SeparatorComponent;
-use livesplit_core::Timer;
 
 /// type
 pub type OwnedSeparatorComponent = Box<SeparatorComponent>;
@@ -28,11 +27,10 @@ pub extern "C" fn SeparatorComponent_into_generic(this: OwnedSeparatorComponent)
     Box::new((*this).into())
 }
 
-/// Calculates the component's state based on the timer provided.
+/// Calculates the component's state.
 #[no_mangle]
 pub extern "C" fn SeparatorComponent_state(
     this: &mut SeparatorComponent,
-    timer: &Timer,
 ) -> OwnedSeparatorComponentState {
-    Box::new(this.state(timer))
+    Box::new(this.state())
 }

--- a/capi/src/title_component_state.rs
+++ b/capi/src/title_component_state.rs
@@ -46,8 +46,8 @@ pub extern "C" fn TitleComponentState_line1(this: &TitleComponentState) -> *cons
 pub extern "C" fn TitleComponentState_line2(this: &TitleComponentState) -> *const Nullablec_char {
     // FIXME: Add API for querying the abbreviations.
     this.line2
-        .as_ref()
-        .map_or_else(ptr::null, |abbrevs| output_str(&abbrevs.last().unwrap()))
+        .last()
+        .map_or_else(ptr::null, |abbrev| output_str(&abbrev))
 }
 
 /// Specifies whether the title should centered or aligned to the left

--- a/src/clear_vec.rs
+++ b/src/clear_vec.rs
@@ -1,6 +1,6 @@
-//! A ClearVec is a special kind of Vec that when being cleared doesn't drop its
-//! elements. Instead the elements get cleared out. This allows reusing them
-//! later on again with all their capacity retained. The elements are only
+//! A ClearVec is a special kind of Vec that doesn't drop its elements when
+//! being cleared. Instead, the elements get cleared out. This allows reusing
+//! them later on again with all their capacity retained. The elements are only
 //! dropped once the ClearVec itself gets dropped.
 
 use crate::platform::prelude::*;
@@ -23,9 +23,9 @@ pub trait Clear {
     fn clear(&mut self);
 }
 
-/// A ClearVec is a special kind of Vec that when being cleared doesn't drop its
-/// elements. Instead the elements get cleared out. This allows reusing them
-/// later on again with all their capacity retained. The elements are only
+/// A ClearVec is a special kind of Vec that doesn't drop its elements when
+/// being cleared. Instead, the elements get cleared out. This allows reusing
+/// them later on again with all their capacity retained. The elements are only
 /// dropped once the ClearVec itself gets dropped.
 #[derive(Clone, Debug)]
 pub struct ClearVec<T: Clear> {

--- a/src/clear_vec.rs
+++ b/src/clear_vec.rs
@@ -1,0 +1,212 @@
+//! A ClearVec is a special kind of Vec that when being cleared doesn't drop its
+//! elements. Instead the elements get cleared out. This allows reusing them
+//! later on again with all their capacity retained. The elements are only
+//! dropped once the ClearVec itself gets dropped.
+
+use crate::platform::prelude::*;
+use alloc::{
+    borrow::{Cow, ToOwned},
+    vec,
+};
+use core::{
+    iter::FromIterator,
+    ops::{Deref, DerefMut, Index, IndexMut},
+    slice,
+};
+use serde::{Deserialize, Serialize};
+
+/// Allows clearing an object while retaining its capacity. This usually brings
+/// the object back into the same state that the Default trait would create, but
+/// that's not a hard requirement.
+pub trait Clear {
+    /// Clears the object.
+    fn clear(&mut self);
+}
+
+/// A ClearVec is a special kind of Vec that when being cleared doesn't drop its
+/// elements. Instead the elements get cleared out. This allows reusing them
+/// later on again with all their capacity retained. The elements are only
+/// dropped once the ClearVec itself gets dropped.
+#[derive(Clone, Debug)]
+pub struct ClearVec<T: Clear> {
+    vec: Vec<T>,
+    len: usize,
+}
+
+impl<T: Clear> ClearVec<T> {
+    /// Creates an empty ClearVec.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns the number of elements in the ClearVec, also referred to as its
+    /// 'length'.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the ClearVec contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Pushes an element into the ClearVec by either reusing an unused element
+    /// or constructing a new one via the Default trait if there is no unused
+    /// element available.
+    pub fn push(&mut self) -> &mut T
+    where
+        T: Default,
+    {
+        self.push_with(Default::default)
+    }
+
+    /// Pushes an element into the ClearVec by either reusing an unused element
+    /// or constructing a new one with the closure provided if there is no
+    /// unused element available.
+    pub fn push_with(&mut self, new_element: impl FnOnce() -> T) -> &mut T {
+        let index = self.len;
+        if index >= self.vec.len() {
+            self.vec.push(new_element());
+        }
+        let element = &mut self.vec[index];
+        self.len += 1;
+        element
+    }
+
+    /// Clears the ClearVec and sets its length back to 0. All elements that
+    /// were in use get cleared and stay in the ClearVec as unused elements,
+    /// ready to be reused again.
+    pub fn clear(&mut self) {
+        for element in self.iter_mut() {
+            element.clear();
+        }
+        self.len = 0;
+    }
+
+    /// Turns the ClearVec into a normal Vec, dropping all the unused elements
+    /// in the progress.
+    pub fn into_vec(mut self) -> Vec<T> {
+        let len = self.len;
+        self.vec.truncate(len);
+        self.vec
+    }
+}
+
+impl<T: Clear> Default for ClearVec<T> {
+    fn default() -> Self {
+        Vec::default().into()
+    }
+}
+
+impl<T: Clear> FromIterator<T> for ClearVec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Vec::from_iter(iter).into()
+    }
+}
+
+impl<'a, T: Clear> Index<usize> for ClearVec<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.vec[index]
+    }
+}
+
+impl<'a, T: Clear> IndexMut<usize> for ClearVec<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.vec[index]
+    }
+}
+
+impl<'a, T: Clear> IntoIterator for &'a ClearVec<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T: Clear> IntoIterator for &'a mut ClearVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<T: Clear> IntoIterator for ClearVec<T> {
+    type Item = T;
+    type IntoIter = vec::IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_vec().into_iter()
+    }
+}
+
+impl<T: Clear> Deref for ClearVec<T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        &self.vec[..self.len]
+    }
+}
+
+impl<T: Clear> DerefMut for ClearVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let len = self.len;
+        &mut self.vec[..len]
+    }
+}
+
+impl<T: Clear> From<Vec<T>> for ClearVec<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self {
+            len: vec.len(),
+            vec,
+        }
+    }
+}
+
+impl<T: Clear + Serialize> Serialize for ClearVec<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (&**self).serialize(serializer)
+    }
+}
+
+impl<'de, T: Clear + Deserialize<'de>> Deserialize<'de> for ClearVec<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Vec::<T>::deserialize(deserializer)?.into())
+    }
+}
+
+impl Clear for String {
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+impl<T> Clear for Vec<T> {
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+impl<T: Clear> Clear for ClearVec<T> {
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+impl<B: ?Sized + ToOwned> Clear for Cow<'_, B>
+where
+    B::Owned: Clear,
+{
+    fn clear(&mut self) {
+        if let Cow::Owned(o) = self {
+            o.clear();
+        }
+    }
+}

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -101,13 +101,11 @@ pub fn default_generators() -> Vec<Box<dyn ComparisonGenerator>> {
     ]
 }
 
-/// Shortens a comparison name. If the name of the comparison matches one of the
-/// comparison generators, the short name of that comparison generator is
-/// returned. Otherwise the comparison name is returned without being shortened.
-/// Additional shortening logic for other comparison names may happen in the
-/// future.
-pub fn shorten(comparison: &str) -> &str {
-    match comparison {
+/// Tries to shorten a comparison name. If the name of the comparison matches one
+/// of the comparison generators, the short name of that comparison generator is
+/// returned.
+pub fn try_shorten(comparison: &str) -> Option<&'static str> {
+    Some(match comparison {
         personal_best::NAME => personal_best::SHORT_NAME,
         world_record::NAME => world_record::SHORT_NAME,
         average_segments::NAME => average_segments::SHORT_NAME,
@@ -118,8 +116,17 @@ pub fn shorten(comparison: &str) -> &str {
         latest_run::NAME => latest_run::SHORT_NAME,
         none::NAME => none::SHORT_NAME,
         worst_segments::NAME => worst_segments::SHORT_NAME,
-        c => c,
-    }
+        _ => return Option::None,
+    })
+}
+
+/// Shortens a comparison name. If the name of the comparison matches one of the
+/// comparison generators, the short name of that comparison generator is
+/// returned. Otherwise the comparison name is returned without being shortened.
+/// Additional shortening logic for other comparison names may happen in the
+/// future.
+pub fn shorten(comparison: &str) -> &str {
+    try_shorten(comparison).unwrap_or(comparison)
 }
 
 /// Helper function for accessing either the given comparison or a Timer's

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -122,9 +122,9 @@ pub fn try_shorten(comparison: &str) -> Option<&'static str> {
 
 /// Shortens a comparison name. If the name of the comparison matches one of the
 /// comparison generators, the short name of that comparison generator is
-/// returned. Otherwise the comparison name is returned without being shortened.
-/// Additional shortening logic for other comparison names may happen in the
-/// future.
+/// returned. Otherwise, the comparison name is returned without being
+/// shortened. Additional shortening logic for other comparison names may happen
+/// in the future.
 pub fn shorten(comparison: &str) -> &str {
     try_shorten(comparison).unwrap_or(comparison)
 }

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -5,7 +5,6 @@
 
 use crate::platform::prelude::*;
 use crate::settings::{Field, Gradient, SettingsDescription, Value};
-use crate::Timer;
 use serde::{Deserialize, Serialize};
 
 /// The Blank Space Component is simply an empty component that doesn't show
@@ -36,7 +35,7 @@ impl Default for Settings {
 }
 
 /// The state object describes the information to visualize for this component.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct State {
     /// The background shown behind the component.
     pub background: Gradient,
@@ -81,8 +80,14 @@ impl Component {
         "Blank Space"
     }
 
-    /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, _timer: &Timer) -> State {
+    /// Updates the component's state.
+    pub fn update_state(&self, state: &mut State) {
+        state.background = self.settings.background;
+        state.size = self.settings.size;
+    }
+
+    /// Calculates the component's state.
+    pub fn state(&self) -> State {
         State {
             background: self.settings.background,
             size: self.settings.size,

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -69,18 +69,30 @@ impl Component {
         "Current Comparison"
     }
 
+    /// Updates the component's state based on the timer provided.
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Timer) {
+        state.background = self.settings.background;
+        state.key_color = self.settings.label_color;
+        state.value_color = self.settings.value_color;
+        state.semantic_color = Default::default();
+
+        state.key.clear();
+        state.key.push_str("Comparing Against");
+
+        state.value.clear();
+        state.value.push_str(timer.current_comparison());
+
+        state.key_abbreviations.clear();
+        state.key_abbreviations.push("Comparison".into());
+
+        state.display_two_rows = self.settings.display_two_rows;
+    }
+
     /// Calculates the component's state based on the timer provided.
     pub fn state(&self, timer: &Timer) -> key_value::State {
-        key_value::State {
-            background: self.settings.background,
-            key_color: self.settings.label_color,
-            value_color: self.settings.value_color,
-            semantic_color: Default::default(),
-            key: "Comparing Against".into(),
-            value: timer.current_comparison().into(),
-            key_abbreviations: Box::new(["Comparison".into()]) as _,
-            display_two_rows: self.settings.display_two_rows,
-        }
+        let mut state = Default::default();
+        self.update_state(&mut state, timer);
+        state
     }
 
     /// Accesses a generic description of the settings available for this

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -10,6 +10,7 @@ use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::timing::formatter::{Accuracy, Regular, TimeFormatter};
 use crate::{comparison, Timer, TimerPhase};
 use alloc::borrow::Cow;
+use core::fmt::Write;
 use serde::{Deserialize, Serialize};
 
 /// The Current Pace Component is a component that shows a prediction of the
@@ -95,11 +96,11 @@ impl Component {
         }
     }
 
-    /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, timer: &Timer) -> key_value::State {
+    /// Updates the component's state based on the timer provided.
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Timer) {
         let comparison = comparison::resolve(&self.settings.comparison_override, timer);
         let comparison = comparison::or_current(comparison, timer);
-        let key = self.text(Some(comparison)).into_owned();
+        let key = self.text(Some(comparison));
 
         let current_pace =
             if timer.current_phase() == TimerPhase::NotRunning && key.starts_with("Current Pace") {
@@ -108,31 +109,55 @@ impl Component {
                 current_pace::calculate(timer, comparison)
             };
 
-        let key_abbreviations = match &*key {
+        state.background = self.settings.background;
+        state.key_color = self.settings.label_color;
+        state.value_color = self.settings.value_color;
+        state.semantic_color = Default::default();
+
+        state.key.clear();
+        state.key.push_str(&key); // FIXME: Uncow this
+
+        state.value.clear();
+        let _ = write!(
+            state.value,
+            "{}",
+            Regular::with_accuracy(self.settings.accuracy).format(current_pace)
+        );
+
+        state.key_abbreviations.clear();
+        // FIXME: This &* probably is different when key is uncowed
+        match &*key {
             "Best Possible Time" => {
-                Box::new(["Best Poss. Time".into(), "Best Time".into(), "BPT".into()]) as _
+                state.key_abbreviations.push("Best Poss. Time".into());
+                state.key_abbreviations.push("Best Time".into());
+                state.key_abbreviations.push("BPT".into());
             }
             "Worst Possible Time" => {
-                Box::new(["Worst Poss. Time".into(), "Worst Time".into()]) as _
+                state.key_abbreviations.push("Worst Poss. Time".into());
+                state.key_abbreviations.push("Worst Time".into());
             }
-            "Predicted Time" => Box::new(["Pred. Time".into()]) as _,
-            "Current Pace" => Box::new(["Cur. Pace".into(), "Pace".into()]) as _,
-            _ => Box::new(["Current Pace".into(), "Cur. Pace".into(), "Pace".into()]) as _,
-        };
-
-        key_value::State {
-            background: self.settings.background,
-            key_color: self.settings.label_color,
-            value_color: self.settings.value_color,
-            semantic_color: Default::default(),
-            key: key.into(),
-            value: Regular::with_accuracy(self.settings.accuracy)
-                .format(current_pace)
-                .to_string()
-                .into(),
-            key_abbreviations,
-            display_two_rows: self.settings.display_two_rows,
+            "Predicted Time" => {
+                state.key_abbreviations.push("Pred. Time".into());
+            }
+            "Current Pace" => {
+                state.key_abbreviations.push("Cur. Pace".into());
+                state.key_abbreviations.push("Pace".into());
+            }
+            _ => {
+                state.key_abbreviations.push("Current Pace".into());
+                state.key_abbreviations.push("Cur. Pace".into());
+                state.key_abbreviations.push("Pace".into());
+            }
         }
+
+        state.display_two_rows = self.settings.display_two_rows;
+    }
+
+    /// Calculates the component's state based on the timer provided.
+    pub fn state(&self, timer: &Timer) -> key_value::State {
+        let mut state = Default::default();
+        self.update_state(&mut state, timer);
+        state
     }
 
     /// Accesses a generic description of the settings available for this

--- a/src/component/key_value.rs
+++ b/src/component/key_value.rs
@@ -5,6 +5,7 @@
 
 use crate::platform::prelude::*;
 use crate::settings::{Color, Gradient, SemanticColor};
+use alloc::borrow::Cow;
 use core::marker::PhantomData;
 use palette::rgb::Rgb;
 use palette::Alpha;
@@ -12,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// The state object describes the information to visualize for a key value
 /// based component.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct State {
     /// The background shown behind the component.
     pub background: Gradient,
@@ -25,12 +26,12 @@ pub struct State {
     /// The semantic coloring information the value carries.
     pub semantic_color: SemanticColor,
     /// The key to visualize.
-    pub key: Box<str>,
+    pub key: String,
     /// The value to visualize.
-    pub value: Box<str>,
+    pub value: String,
     /// Specifies additional abbreviations for the key that can be used instead
     /// of the key, if there is not enough space to show the whole key.
-    pub key_abbreviations: Box<[Box<str>]>,
+    pub key_abbreviations: Vec<Cow<'static, str>>,
     /// Specifies whether to display the key and the value in two separate rows.
     pub display_two_rows: bool,
 }

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -8,6 +8,7 @@ use super::key_value;
 use crate::platform::prelude::*;
 use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
 use crate::{analysis::pb_chance, Timer};
+use core::fmt::Write;
 use serde::{Deserialize, Serialize};
 
 /// The PB Chance Component is a component that shows how likely it is to beat
@@ -73,20 +74,30 @@ impl Component {
         "PB Chance"
     }
 
-    /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, timer: &Timer) -> key_value::State {
+    /// Updates the component's state based on the timer provided.
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Timer) {
         let chance = pb_chance::for_timer(timer);
 
-        key_value::State {
-            background: self.settings.background,
-            key_color: self.settings.label_color,
-            value_color: self.settings.value_color,
-            semantic_color: Default::default(),
-            key: self.name().into(),
-            value: format!("{:.1}%", 100.0 * chance).into(),
-            key_abbreviations: Box::new([]) as _,
-            display_two_rows: self.settings.display_two_rows,
-        }
+        state.background = self.settings.background;
+        state.key_color = self.settings.label_color;
+        state.value_color = self.settings.value_color;
+        state.semantic_color = Default::default();
+
+        state.key.clear();
+        state.key.push_str(self.name());
+
+        state.value.clear();
+        let _ = write!(state.value, "{:.1}%", 100.0 * chance);
+
+        state.key_abbreviations.clear();
+        state.display_two_rows = self.settings.display_two_rows;
+    }
+
+    /// Calculates the component's state based on the timer provided.
+    pub fn state(&self, timer: &Timer) -> key_value::State {
+        let mut state = Default::default();
+        self.update_state(&mut state, timer);
+        state
     }
 
     /// Accesses a generic description of the settings available for this

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -3,7 +3,6 @@
 //! separators between components.
 
 use crate::settings::{SettingsDescription, Value};
-use crate::Timer;
 use serde::{Deserialize, Serialize};
 
 /// The Separator Component is a simple component that only serves to render
@@ -12,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct Component;
 
 /// The state object describes the information to visualize for this component.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct State;
 
 #[cfg(feature = "std")]
@@ -37,8 +36,11 @@ impl Component {
         "Separator"
     }
 
-    /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, _timer: &Timer) -> State {
+    /// Updates the component's state.
+    pub fn update_state(&self, _state: &mut State) {}
+
+    /// Calculates the component's state.
+    pub fn state(&self) -> State {
         State
     }
 

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -50,13 +50,79 @@ pub enum Component {
 }
 
 impl Component {
+    /// Updates the component's state based on the timer and settings provided.
+    /// The timer provides the information to visualize and the layout settings
+    /// provide general information about how to expose that information in the
+    /// state.
+    pub fn update_state(
+        &mut self,
+        state: &mut ComponentState,
+        timer: &Timer,
+        layout_settings: &GeneralSettings,
+    ) {
+        match (state, self) {
+            (ComponentState::BlankSpace(state), Component::BlankSpace(component)) => {
+                component.update_state(state)
+            }
+            (ComponentState::KeyValue(state), Component::CurrentComparison(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::KeyValue(state), Component::CurrentPace(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::KeyValue(state), Component::Delta(component)) => {
+                component.update_state(state, timer, layout_settings)
+            }
+            (ComponentState::DetailedTimer(state), Component::DetailedTimer(component)) => {
+                component.update_state(&mut *state, timer, layout_settings)
+            }
+            (ComponentState::Graph(state), Component::Graph(component)) => {
+                component.update_state(state, timer, layout_settings)
+            }
+            (ComponentState::KeyValue(state), Component::PbChance(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::KeyValue(state), Component::PossibleTimeSave(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::KeyValue(state), Component::PreviousSegment(component)) => {
+                component.update_state(state, timer, layout_settings)
+            }
+            (ComponentState::KeyValue(state), Component::SegmentTime(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::Separator(state), Component::Separator(component)) => {
+                component.update_state(state)
+            }
+            (ComponentState::Splits(state), Component::Splits(component)) => {
+                component.update_state(state, timer, layout_settings)
+            }
+            (ComponentState::KeyValue(state), Component::SumOfBest(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::Text(state), Component::Text(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::Timer(state), Component::Timer(component)) => {
+                component.update_state(state, timer, layout_settings)
+            }
+            (ComponentState::Title(state), Component::Title(component)) => {
+                component.update_state(state, timer)
+            }
+            (ComponentState::KeyValue(state), Component::TotalPlaytime(component)) => {
+                component.update_state(state, timer)
+            }
+            (state, component) => *state = component.state(timer, layout_settings),
+        }
+    }
+
     /// Calculates the component's state based on the timer and settings
     /// provided. The timer provides the information to visualize and the layout
     /// settings provide general information about how to expose that
     /// information in the state.
     pub fn state(&mut self, timer: &Timer, layout_settings: &GeneralSettings) -> ComponentState {
         match self {
-            Component::BlankSpace(component) => ComponentState::BlankSpace(component.state(timer)),
+            Component::BlankSpace(component) => ComponentState::BlankSpace(component.state()),
             Component::CurrentComparison(component) => {
                 ComponentState::KeyValue(component.state(timer))
             }
@@ -78,7 +144,7 @@ impl Component {
                 ComponentState::KeyValue(component.state(timer, layout_settings))
             }
             Component::SegmentTime(component) => ComponentState::KeyValue(component.state(timer)),
-            Component::Separator(component) => ComponentState::Separator(component.state(timer)),
+            Component::Separator(component) => ComponentState::Separator(component.state()),
             Component::Splits(component) => {
                 ComponentState::Splits(component.state(timer, layout_settings))
             }

--- a/src/layout/layout_direction.rs
+++ b/src/layout/layout_direction.rs
@@ -8,3 +8,9 @@ pub enum LayoutDirection {
     /// The components are placed next to each other horizontally.
     Horizontal,
 }
+
+impl Default for LayoutDirection {
+    fn default() -> Self {
+        LayoutDirection::Vertical
+    }
+}

--- a/src/layout/layout_state.rs
+++ b/src/layout/layout_state.rs
@@ -4,7 +4,7 @@ use crate::settings::{Color, Gradient};
 use serde::{Deserialize, Serialize};
 
 /// The state object describes the information to visualize for the layout.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct LayoutState {
     /// The state objects for all of the components in the layout.
     pub components: Vec<ComponentState>,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -86,22 +86,35 @@ impl Layout {
         self.components.push(component.into());
     }
 
+    /// Updates the layout's state based on the timer provided. You can use this
+    /// to visualize all of the components of a layout.
+    pub fn update_state(&mut self, state: &mut LayoutState, timer: &Timer) {
+        let settings = &self.settings;
+
+        state.components.truncate(self.components.len());
+        let mut components = self.components.iter_mut();
+        // First update all the states that we have.
+        for (state, component) in state.components.iter_mut().zip(components.by_ref()) {
+            component.update_state(state, timer, settings);
+        }
+        // Then add states for all the components that don't have states yet.
+        state
+            .components
+            .extend(components.map(|c| c.state(timer, settings)));
+
+        state.background = settings.background;
+        state.thin_separators_color = settings.thin_separators_color;
+        state.separators_color = settings.separators_color;
+        state.text_color = settings.text_color;
+        state.direction = settings.direction;
+    }
+
     /// Calculates the layout's state based on the timer provided. You can use
     /// this to visualize all of the components of a layout.
     pub fn state(&mut self, timer: &Timer) -> LayoutState {
-        let settings = &self.settings;
-        LayoutState {
-            components: self
-                .components
-                .iter_mut()
-                .map(|c| c.state(timer, settings))
-                .collect(),
-            background: settings.background,
-            thin_separators_color: settings.thin_separators_color,
-            separators_color: settings.separators_color,
-            text_color: settings.text_color,
-            direction: settings.direction,
-        }
+        let mut state = Default::default();
+        self.update_state(&mut state, timer);
+        state
     }
 
     /// Accesses the settings of the layout.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ macro_rules! catch {
 }
 
 pub mod analysis;
+pub mod clear_vec;
 pub mod comparison;
 pub mod component;
 #[cfg(feature = "std")]

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -51,9 +51,9 @@ pub(in crate::rendering) fn render<B: Backend>(
         [text_color; 2],
     );
 
-    let (line1_y, line1_end_x) = if let Some(line2) = &component.line2 {
+    let (line1_y, line1_end_x) = if !component.line2.is_empty() {
         let line2 = context.choose_abbreviation(
-            line2.iter().map(|a| &**a),
+            component.line2.iter().map(|a| &**a),
             DEFAULT_TEXT_SIZE,
             line2_end_x - PADDING - left_bound,
         );

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -72,16 +72,15 @@ mod mesh;
 #[cfg(feature = "software-rendering")]
 pub mod software;
 
-use {
-    self::{glyph_cache::GlyphCache, icon::Icon},
-    crate::{
-        layout::{ComponentState, LayoutDirection, LayoutState},
-        settings::{Color, Gradient},
-    },
-    euclid::{Transform2D, UnknownUnit},
-    rusttype::Font,
-    std::iter,
+use self::{glyph_cache::GlyphCache, icon::Icon};
+use crate::{
+    layout::{ComponentState, LayoutDirection, LayoutState},
+    settings::{Color, Gradient},
 };
+use alloc::borrow::Cow;
+use core::iter;
+use euclid::{Transform2D, UnknownUnit};
+use rusttype::Font;
 
 pub use self::mesh::{Mesh, Vertex};
 pub use euclid;
@@ -537,7 +536,7 @@ impl<B: Backend> RenderContext<'_, B> {
     fn render_key_value_component(
         &mut self,
         key: &str,
-        abbreviations: &[Box<str>],
+        abbreviations: &[Cow<'_, str>],
         value: &str,
         [width, height]: [f32; 2],
         key_color: Color,
@@ -556,7 +555,7 @@ impl<B: Backend> RenderContext<'_, B> {
             left_of_value_x
         };
         let key = self.choose_abbreviation(
-            iter::once(key).chain(abbreviations.iter().map(|abrv| &**abrv)),
+            iter::once(key).chain(abbreviations.iter().map(|x| &**x)),
             DEFAULT_TEXT_SIZE,
             end_x - BOTH_PADDINGS,
         );

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -143,12 +143,12 @@ struct VsOut {
 
 impl Interpolate for VsOut {
     #[inline(always)]
-    fn lerp2(a: Self, b: Self, x: f32, y: f32) -> Self {
-        a * x + b * y
+    fn lerp2(fx: Self, fy: Self, x: f32, y: f32) -> Self {
+        fx * x + fy * y
     }
     #[inline(always)]
-    fn lerp3(a: Self, b: Self, c: Self, x: f32, y: f32, z: f32) -> Self {
-        a * x + b * y + c * z
+    fn lerp3(fx: Self, fy: Self, fz: Self, x: f32, y: f32, z: f32) -> Self {
+        fx * x + fy * y + fz * z
     }
 }
 
@@ -178,15 +178,11 @@ impl Pipeline for MyPipeline<'_> {
             let x = vsout.texcoord.x * texture.width;
             let y = vsout.texcoord.y * texture.height;
             let pixel = &texture.data[texture.stride * y as usize + x as usize * 4..];
-            let r = pixel[0];
-            let g = pixel[1];
-            let b = pixel[2];
-            let a = pixel[3];
             return Rgba::new(
-                f32::from(r) / 255.0,
-                f32::from(g) / 255.0,
-                f32::from(b) / 255.0,
-                f32::from(a) / 255.0,
+                f32::from(pixel[0]) / 255.0,
+                f32::from(pixel[1]) / 255.0,
+                f32::from(pixel[2]) / 255.0,
+                f32::from(pixel[3]) / 255.0,
             ) * vsout.color;
         }
         vsout.color

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -137,8 +137,7 @@ where
     let taken = replace(vec, Vec::new());
     let mut string = String::from_utf8(taken).unwrap();
     let result = f(&mut string);
-    let bytes = string.into_bytes();
-    replace(vec, bytes);
+    *vec = string.into_bytes();
     result
 }
 

--- a/src/settings/color.rs
+++ b/src/settings/color.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// backgrounds, texts, lines and various other elements that are being shown.
 /// They are stored as RGBA colors with 32-bit float point numbers ranging from
 /// 0.0 to 1.0 per channel.
-#[derive(Debug, Copy, Clone, PartialEq, derive_more::From)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, derive_more::From)]
 pub struct Color {
     /// The Red, Green, Blue, Alpha (RGBA) encoding of the color.
     pub rgba: LinSrgba,

--- a/src/settings/gradient.rs
+++ b/src/settings/gradient.rs
@@ -15,6 +15,12 @@ pub enum Gradient {
     Horizontal(Color, Color),
 }
 
+impl Default for Gradient {
+    fn default() -> Self {
+        Gradient::Transparent
+    }
+}
+
 /// Describes an extended form of a gradient, specifically made for use with
 /// lists. It allows specifying different coloration for the rows in a list.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -23,4 +29,10 @@ pub enum ListGradient {
     Same(Gradient),
     /// Alternate between two colors for each row (Even Index, Odd Index).
     Alternating(Color, Color),
+}
+
+impl Default for ListGradient {
+    fn default() -> Self {
+        ListGradient::Same(Gradient::Transparent)
+    }
 }

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -49,7 +49,7 @@ fn default() {
 
 #[test]
 fn actual_split_file() {
-    // TODO: What are we doing about this in regard to crater? These should
+    // FIXME: What are we doing about this in regard to crater? These should
     // likely be in the tests folder.
     let run = lss(run_files::LIVESPLIT_1_0);
     let timer = Timer::new(run).unwrap();


### PR DESCRIPTION
So far we've always discarded the layout states, but since we want to calculate layout states every frame, it makes a lot more sense to keep the layout state around and just update it. All of the original API is retained, so you are not forced to actually update your layout states. However the code for creating a new layout state now initializes a default state and updates it, instead of directly creating it correctly. This might slightly slow down initial creation, but we don't want to basically duplicate the same code across initial creation and updating.

By doing this an average frame now has 0 allocations, reallocations and deallocations. We are seeing speedups of around 3x - 5x in the newly added benchmarks.

This also introduces a new `ClearVec` type that behaves like a normal `Vec` but when clearing it, instead of dropping all the elements, it just keeps them around and clears them instead. So if you had a `Vec<String>` and cleared it, all the Strings would get deallocated, while a `ClearVec<String>` would keep them around and just set their length back to 0. We use this in a few places to reduce the chances of us needing to allocate new memory. It might make sense to move it into its own crate eventually as this should be a useful type for any kind of Rust code.

Resolves #54 