### PR TITLE
Delay registering the Gamepad Hook

### DIFF
--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -195,8 +195,8 @@ impl Hook {
             });
 
             Ok(Hook {
-                sender: sender,
-                ping: ping,
+                sender,
+                ping,
                 _registration: registration,
                 join_handle: Some(join_handle),
             })


### PR DESCRIPTION
In the web we support gamepads. Unfortunately there's no callbacks or so that we could use, so instead we have to use an interval where we poll for button presses. This isn't super expensive, but still unnecessary if you don't use a gamepad. Additionally Chrome has the problem that it gets exclusive access to the gamepads and doesn't really yield control back until the whole browser is closed. So you really don't want that unless you really intend to use the gamepad for splitting. This is why the gamepad interval is now only being set when the first gamepad button is registered.