### PR TITLE
Use `strip_prefix` to parse strings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,10 +72,12 @@ jobs:
           # - env: TARGET=mipsisa64r6-unknown-linux-gnuabi64
           # - env: TARGET=mipsisa64r6el-unknown-linux-gnuabi64
           - Linux powerpc
-          - Linux powerpc64
           - Linux powerpc64le
           - Linux s390x
-          - Linux sparc64
+          # These got removed from cross, because they kept breaking:
+          # https://github.com/rust-embedded/cross/pull/440
+          # - Linux powerpc64
+          # - Linux sparc64
 
           # macOS
           # 32-bit macOS is deprecated and doesn't build:
@@ -437,13 +439,6 @@ jobs:
             os: ubuntu-latest
             tests: skip
 
-          - label: Linux powerpc64
-            target: powerpc64-unknown-linux-gnu
-            os: ubuntu-latest
-            tests: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
-
           - label: Linux powerpc64le
             target: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
@@ -454,10 +449,18 @@ jobs:
             os: ubuntu-latest
             tests: skip
 
-          - label: Linux sparc64
-            target: sparc64-unknown-linux-gnu
-            os: ubuntu-latest
-            tests: skip
+          # These got removed from cross
+          # - label: Linux powerpc64
+          #   target: powerpc64-unknown-linux-gnu
+          #   os: ubuntu-latest
+          #   tests: skip
+          #   # FIXME: Networking Tests fail due to missing OpenSSL
+          #   # https://github.com/LiveSplit/livesplit-core/issues/308
+
+          # - label: Linux sparc64
+          #   target: sparc64-unknown-linux-gnu
+          #   os: ubuntu-latest
+          #   tests: skip
 
           # macOS
           # - label: macOS i686

--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -1,4 +1,4 @@
-use structopt;
+#![allow(clippy::write_literal)]
 
 mod c;
 mod csharp;
@@ -106,15 +106,15 @@ fn get_type(ty: &SynType) -> Type {
         SynType::Path(path) => {
             if let Some(segment) = path.path.segments.iter().last() {
                 let mut name = segment.ident.to_string();
-                let is_nullable = if name.starts_with("Nullable") {
-                    name = name["Nullable".len()..].to_string();
+                let is_nullable = if let Some(rest) = name.strip_prefix("Nullable") {
+                    name = rest.to_string();
                     true
                 } else {
                     false
                 };
 
-                if name.starts_with("Owned") {
-                    name = name["Owned".len()..].to_string();
+                if let Some(rest) = name.strip_prefix("Owned") {
+                    name = rest.to_string();
                 }
                 if name == "TimingMethod" || name == "TimerPhase" {
                     name = String::from("u8");

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -230,16 +230,23 @@ impl Component {
                     let unchanged = catch! {
                         let mut rem = &**state.line1.last()?;
 
-                        // FIXME: strip_prefix
-                        if !rem.starts_with(game_name) { return None; }
-                        rem = &rem[game_name.len()..];
-
-                        if !game_name.is_empty() && !full_category_name.is_empty() {
-                            if !rem.starts_with(" - ") { return None; }
-                            rem = &rem[" - ".len()..];
+                        if let Some(rest) = rem.strip_prefix(game_name) {
+                            rem = rest;
+                        } else {
+                            return None;
                         }
 
-                        if rem != full_category_name { return None; }
+                        if !game_name.is_empty() && !full_category_name.is_empty() {
+                            if let Some(rest) = rem.strip_prefix(" - ") {
+                                rem = rest;
+                            } else {
+                                return None;
+                            }
+                        }
+
+                        if rem != full_category_name {
+                            return None;
+                        }
                     };
                     if unchanged.is_none() {
                         let abbrevs = &mut state.line1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 // Clippy false positives
 #![allow(
-    clippy::block_in_if_condition_stmt,
+    clippy::blocks_in_if_conditions,
     clippy::redundant_closure_call,
     clippy::new_ret_no_self
 )]

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -66,9 +66,8 @@ impl<'de> Deserialize<'de> for ImageData {
             let data: &'de str = Deserialize::deserialize(deserializer)?;
             if data.is_empty() {
                 Ok(ImageData(Box::new([])))
-            } else if data.starts_with("data:;base64,") {
-                let image_data =
-                    base64::decode(&data["data:;base64,".len()..]).map_err(de::Error::custom)?;
+            } else if let Some(encoded_image_data) = data.strip_prefix("data:;base64,") {
+                let image_data = base64::decode(encoded_image_data).map_err(de::Error::custom)?;
                 Ok(ImageData(image_data.into_boxed_slice()))
             } else {
                 Err(de::Error::custom("Invalid Data URL for image"))

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -80,15 +80,15 @@ impl FromStr for TimeSpan {
     type Err = ParseError;
 
     fn from_str(mut text: &str) -> Result<Self, ParseError> {
-        let factor = if text.starts_with('-') {
-            text = &text[1..];
-            -1.0
-        } else if text.starts_with('−') {
-            text = &text[3..];
-            -1.0
-        } else {
-            1.0
-        };
+        // It's faster to use `strip_prefix` with char literals if it's an ASCII
+        // char, otherwise prefer using string literals.
+        let factor =
+            if let Some(remainder) = text.strip_prefix('-').or_else(|| text.strip_prefix("−")) {
+                text = remainder;
+                -1.0
+            } else {
+                1.0
+            };
 
         let mut seconds = 0.0;
         for split in text.split(':') {


### PR DESCRIPTION
We used to use `starts_with` + string slicing in order to parse strings, but that is a bit slower and causes some duplication. Rust 1.45 came out today and it introduces the new `strip_prefix` method which doesn't have these problems.

Resolves #293 