### PR TITLE
Add a Linux-only tool needed for Auto Splitting to work correctly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ vek = { version = "0.10.1", default-features = false, features = ["libm"], optio
 # Networking
 splits-io-api = { version = "0.1.2", optional = true }
 
+# Auto Splitting
+livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
+crossbeam-channel = { version = "0.3.6", default-features = false, optional = true }
+log = { version = "0.4.6", optional = true }
+
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 # WebAssembly in the Web
 web-sys = { version = "0.3.28", default-features = false, features = ["Performance", "Window"], optional = true }
@@ -90,6 +95,7 @@ rendering = ["std", "more-image-formats", "euclid", "lyon", "rusttype"]
 software-rendering = ["rendering", "euc", "vek", "derive_more/mul"]
 wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
 networking = ["std", "splits-io-api"]
+auto-splitting = ["std", "livesplit-auto-splitting", "crossbeam-channel", "log"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly
 # yet. So there's a feature you explicitly have to opt into to deactivate the

--- a/crates/livesplit-auto-splitting/AutoSplittingNotes.md
+++ b/crates/livesplit-auto-splitting/AutoSplittingNotes.md
@@ -1,0 +1,7 @@
+Requested APIs:
+
+1. YaLTeR wants some form of IPC to control the auto splitter from outside
+2. Buffet Time wants an API to get / set the split times for each individual
+   split
+3. there might be multiple processes with the name you are choosing. there needs
+   to be a way to let the auto splitter choose one

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.28"
+bstr = "0.2.12"
 log = "0.4.8"
 num-traits = "0.2.11"
 num-derive = "0.3.0"
 snafu = "0.6.6"
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
+wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
+wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
+wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4.8"
 num-traits = "0.2.11"
 num-derive = "0.3.0"
 snafu = "0.6.6"
-wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
-wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
-wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "stuff", default-features = false }
+wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
+wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
+wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -15,6 +15,7 @@ wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-s
 wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 libc = "0.2.54"
+bytemuck = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "livesplit-auto-splitting"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.28"
+log = "0.4.8"
+num-traits = "0.2.11"
+num-derive = "0.3.0"
+snafu = "0.6.6"
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", default-features = false }
+winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -14,4 +14,7 @@ snafu = "0.6.6"
 wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
+libc = "0.2.54"
+
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -14,8 +14,11 @@ snafu = "0.6.6"
 wasmtime = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 wasmtime-wasi = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
 wasi-common = { git = "https://github.com/CryZe/wasmtime", branch = "wasi-virtual-stdstream", default-features = false }
-libc = "0.2.54"
 bytemuck = "1.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.5", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32", "winnt", "wow64apiset"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nom = "5.1.1"
+libc = "0.2.54"

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -1,0 +1,241 @@
+use crate::{
+    pointer::{PointerType, PointerValue},
+    process::{Offset, Process},
+};
+use num_traits::FromPrimitive;
+use std::{collections::HashMap, error::Error, mem, str, time::Duration};
+use wasmtime::{Memory, Trap};
+
+pub struct Environment {
+    pub memory: Option<Memory>,
+    pub process_name: String,
+    pointer_paths: Vec<PointerPath>,
+    pub tick_rate: Duration,
+    pub process: Option<Process>,
+    pub variable_changes: HashMap<String, String>,
+}
+
+struct PointerPath {
+    module_name: String,
+    offsets: Vec<i64>,
+    current: PointerValue,
+    old: PointerValue,
+}
+
+impl Default for Environment {
+    fn default() -> Self {
+        Self {
+            memory: None,
+            process_name: String::new(),
+            pointer_paths: Vec::new(),
+            tick_rate: Duration::from_secs(1) / 60,
+            process: None,
+            variable_changes: HashMap::new(),
+        }
+    }
+}
+
+fn trap_from_err(e: impl Error + Send + Sync + 'static) -> Trap {
+    Trap::new(anyhow::Error::from(e).to_string())
+}
+
+fn get_bytes(memory: &mut Option<Memory>, ptr: i32, len: i32) -> Result<&mut [u8], Trap> {
+    let memory = unsafe {
+        memory
+            .as_mut()
+            .ok_or_else(|| Trap::new("There is no memory to use"))?
+            .data_unchecked_mut()
+    };
+
+    let ptr = ptr as u32 as usize;
+    let len = len as u32 as usize;
+
+    memory
+        .get_mut(ptr..ptr + len)
+        .ok_or_else(|| Trap::new("Index out of bounds"))
+}
+
+fn read_str(memory: &mut Option<Memory>, ptr: i32, len: i32) -> Result<&str, Trap> {
+    let bytes = get_bytes(memory, ptr, len)?;
+    str::from_utf8(bytes).map_err(trap_from_err)
+}
+
+impl Environment {
+    pub fn set_process_name(&mut self, ptr: i32, len: i32) -> Result<(), Trap> {
+        let process_name = read_str(&mut self.memory, ptr, len)?;
+        self.process_name.clear();
+        self.process_name.push_str(process_name);
+        Ok(())
+    }
+
+    pub fn push_pointer_path(
+        &mut self,
+        ptr: i32,
+        len: i32,
+        pointer_type: i32,
+    ) -> Result<i32, Trap> {
+        let pointer_type = PointerType::from_u32(pointer_type as u32)
+            .ok_or_else(|| Trap::new("Invalid pointer type"))
+            .unwrap();
+
+        let current = match pointer_type {
+            PointerType::U8 => PointerValue::U8(0),
+            PointerType::U16 => PointerValue::U16(0),
+            PointerType::U32 => PointerValue::U32(0),
+            PointerType::U64 => PointerValue::U64(0),
+            PointerType::I8 => PointerValue::I8(0),
+            PointerType::I16 => PointerValue::I16(0),
+            PointerType::I32 => PointerValue::I32(0),
+            PointerType::I64 => PointerValue::I64(0),
+            PointerType::F32 => PointerValue::F32(0.0),
+            PointerType::F64 => PointerValue::F64(0.0),
+            PointerType::String => PointerValue::String(String::new()),
+        };
+
+        let module_name = read_str(&mut self.memory, ptr, len)?.to_owned();
+
+        let id = self.pointer_paths.len();
+
+        self.pointer_paths.push(PointerPath {
+            module_name,
+            offsets: Vec::new(),
+            old: current.clone(),
+            current,
+        });
+
+        Ok(id as _)
+    }
+
+    pub fn push_offset(&mut self, pointer_path_id: i32, offset: i64) -> Result<(), Trap> {
+        self.pointer_paths
+            .get_mut(pointer_path_id as u32 as usize)
+            .ok_or_else(|| Trap::new("Specified invalid pointer path"))?
+            .offsets
+            .push(offset);
+
+        Ok(())
+    }
+
+    pub fn get_val<T>(
+        &self,
+        pointer_path_id: i32,
+        current: i32,
+        convert: impl FnOnce(&PointerValue) -> Option<T>,
+    ) -> Result<T, Trap> {
+        let pointer_path = self
+            .pointer_paths
+            .get(pointer_path_id as u32 as usize)
+            .ok_or_else(|| Trap::new("Specified invalid pointer path"))?;
+
+        let value = if current != 0 {
+            &pointer_path.current
+        } else {
+            &pointer_path.old
+        };
+
+        convert(value).ok_or_else(|| Trap::new("The types did not match"))
+    }
+
+    pub fn scan_signature(&mut self, ptr: i32, len: i32) -> Result<i64, Trap> {
+        // TODO: Don't trap
+        if let Some(process) = &self.process {
+            let signature = read_str(&mut self.memory, ptr, len)?;
+            let address = process.scan_signature(signature).map_err(trap_from_err)?;
+            return Ok(address.unwrap_or(0) as i64);
+        }
+
+        Ok(0)
+    }
+
+    pub fn set_tick_rate(&mut self, ticks_per_sec: f64) {
+        log::info!("New Tick Rate: {}", ticks_per_sec);
+        self.tick_rate = Duration::from_secs_f64(1.0 / ticks_per_sec);
+    }
+
+    pub fn print_message(&mut self, ptr: i32, len: i32) -> Result<(), Trap> {
+        let message = read_str(&mut self.memory, ptr, len)?;
+        log::info!(target: "Auto Splitter", "{}", message);
+        Ok(())
+    }
+
+    pub fn read_into_buf(&mut self, address: i64, buf: i32, buf_len: i32) -> Result<(), Trap> {
+        if let Some(process) = &self.process {
+            if process
+                .read_buf(address as u64, get_bytes(&mut self.memory, buf, buf_len)?)
+                .is_err()
+            {
+                // TODO: Handle error
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_variable(
+        &mut self,
+        key_ptr: i32,
+        key_len: i32,
+        value_ptr: i32,
+        value_len: i32,
+    ) -> Result<(), Trap> {
+        let key = read_str(&mut self.memory, key_ptr, key_len)?.to_owned();
+        let value = read_str(&mut self.memory, value_ptr, value_len)?.to_owned();
+        self.variable_changes.insert(key, value);
+        Ok(())
+    }
+
+    pub fn update_values(&mut self, just_connected: bool) -> anyhow::Result<()> {
+        let process = self
+            .process
+            .as_mut()
+            .expect("The process should be connected at this point");
+
+        for pointer_path in &mut self.pointer_paths {
+            let mut address = if !pointer_path.module_name.is_empty() {
+                process.module_address(&pointer_path.module_name)?
+            } else {
+                0
+            };
+            let mut offsets = pointer_path.offsets.iter().cloned().peekable();
+            if process.is_64bit() {
+                while let Some(offset) = offsets.next() {
+                    address = (address as Offset).wrapping_add(offset) as u64;
+                    if offsets.peek().is_some() {
+                        address = process.read(address)?;
+                    }
+                }
+            } else {
+                while let Some(offset) = offsets.next() {
+                    address = (address as i32).wrapping_add(offset as i32) as u64;
+                    if offsets.peek().is_some() {
+                        address = process.read::<u32>(address)? as u64;
+                    }
+                }
+            }
+            match &mut pointer_path.old {
+                PointerValue::U8(v) => *v = process.read(address)?,
+                PointerValue::U16(v) => *v = process.read(address)?,
+                PointerValue::U32(v) => *v = process.read(address)?,
+                PointerValue::U64(v) => *v = process.read(address)?,
+                PointerValue::I8(v) => *v = process.read(address)?,
+                PointerValue::I16(v) => *v = process.read(address)?,
+                PointerValue::I32(v) => *v = process.read(address)?,
+                PointerValue::I64(v) => *v = process.read(address)?,
+                PointerValue::F32(v) => *v = process.read(address)?,
+                PointerValue::F64(v) => *v = process.read(address)?,
+                PointerValue::String(_) => todo!(),
+            }
+        }
+
+        if just_connected {
+            for pointer_path in &mut self.pointer_paths {
+                pointer_path.current.clone_from(&pointer_path.old);
+            }
+        } else {
+            for pointer_path in &mut self.pointer_paths {
+                mem::swap(&mut pointer_path.current, &mut pointer_path.old);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/livesplit-auto-splitting/src/environment.rs
+++ b/crates/livesplit-auto-splitting/src/environment.rs
@@ -158,16 +158,17 @@ impl Environment {
         Ok(())
     }
 
-    pub fn read_into_buf(&mut self, address: i64, buf: i32, buf_len: i32) -> Result<(), Trap> {
+    pub fn read_into_buf(&mut self, address: i64, buf: i32, buf_len: i32) -> Result<i32, Trap> {
         if let Some(process) = &self.process {
             if process
                 .read_buf(address as u64, get_bytes(&mut self.memory, buf, buf_len)?)
                 .is_err()
             {
-                // TODO: Handle error
+                // TODO: possibly handle this error in a more robust way
+                return Ok(0);
             }
         }
-        Ok(())
+        Ok(1)
     }
 
     pub fn set_variable(

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -2,5 +2,6 @@ mod environment;
 mod pointer;
 mod process;
 mod runtime;
+mod std_stream;
 
 pub use runtime::{Runtime, TimerAction, TimerState};

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -5,3 +5,4 @@ mod runtime;
 mod std_stream;
 
 pub use runtime::{Runtime, TimerAction, TimerState};
+pub use wasmtime::InterruptHandle;

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -1,0 +1,6 @@
+mod environment;
+mod pointer;
+mod process;
+mod runtime;
+
+pub use runtime::{Runtime, TimerAction, TimerState};

--- a/crates/livesplit-auto-splitting/src/pointer.rs
+++ b/crates/livesplit-auto-splitting/src/pointer.rs
@@ -1,0 +1,30 @@
+#[derive(Copy, Clone, PartialEq, Eq, num_derive::FromPrimitive)]
+#[repr(u8)]
+pub enum PointerType {
+    U8 = 0,
+    U16 = 1,
+    U32 = 2,
+    U64 = 3,
+    I8 = 4,
+    I16 = 5,
+    I32 = 6,
+    I64 = 7,
+    F32 = 8,
+    F64 = 9,
+    String = 10,
+}
+
+#[derive(Clone, Debug)]
+pub enum PointerValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+    String(String),
+}

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -182,7 +182,7 @@ impl Process {
                 }
                 #[cfg(not(target_pointer_width = "64"))]
                 {
-                    // TODO Actually idk if 32-bit apps can read from 64-bit
+                    // TODO: Actually idk if 32-bit apps can read from 64-bit
                     // apps. If they can, then this is wrong.
                     is_64bit = false;
                 }

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -1,0 +1,375 @@
+use winapi::shared::minwindef::{BOOL, DWORD};
+use winapi::um::{
+    handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
+    memoryapi::{ReadProcessMemory, VirtualQueryEx},
+    processthreadsapi::{GetProcessTimes, OpenProcess},
+    psapi::GetModuleFileNameExW,
+    tlhelp32::{
+        CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, Process32FirstW, Process32NextW,
+        MODULEENTRY32W, PROCESSENTRY32W, TH32CS_SNAPMODULE, TH32CS_SNAPPROCESS,
+    },
+    winnt::{
+        HANDLE, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS,
+        PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    },
+};
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::{iter, mem, ptr, result, slice};
+
+type Address = u64;
+pub type Offset = i64;
+
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    // TODO: Doc Comments
+    ListProcesses,
+    ProcessDoesntExist,
+    ListModules,
+    ProcessOpening,
+    ModuleDoesntExist,
+    ReadMemory,
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Process {
+    handle: HANDLE,
+    modules: HashMap<String, Address>,
+    is_64bit: bool,
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+impl Process {
+    pub fn is_64bit(&self) -> bool {
+        self.is_64bit
+    }
+
+    pub fn path(&self) -> Option<PathBuf> {
+        let mut path_buf = [0u16; 1024];
+        if unsafe {
+            GetModuleFileNameExW(
+                self.handle,
+                ptr::null_mut(),
+                path_buf.as_mut_ptr() as *mut _,
+                path_buf.len() as _,
+            )
+        } == 0
+        {
+            return None;
+        }
+        Some(PathBuf::from(OsString::from_wide(&path_buf)))
+    }
+
+    pub fn with_name(name: &str) -> Result<Self> {
+        unsafe {
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+            if snapshot == INVALID_HANDLE_VALUE {
+                return Err(Error::ListProcesses);
+            }
+
+            let mut creation_time = mem::uninitialized();
+            let mut exit_time = mem::uninitialized();
+            let mut kernel_time = mem::uninitialized();
+            let mut user_time = mem::uninitialized();
+
+            let mut best_process = None::<(DWORD, u64)>;
+            let mut entry: PROCESSENTRY32W = mem::uninitialized();
+            entry.dwSize = mem::size_of_val(&entry) as _;
+
+            if Process32FirstW(snapshot, &mut entry) != 0 {
+                loop {
+                    {
+                        let entry_name = &entry.szExeFile;
+                        let len = entry_name.iter().take_while(|&&c| c != 0).count();
+                        let entry_name = &entry_name[..len];
+                        let entry_name = &OsString::from_wide(entry_name);
+                        if entry_name == name {
+                            let pid = entry.th32ProcessID;
+                            let process = OpenProcess(PROCESS_QUERY_INFORMATION, false as _, pid);
+
+                            if !process.is_null() {
+                                let success = GetProcessTimes(
+                                    process,
+                                    &mut creation_time,
+                                    &mut exit_time,
+                                    &mut kernel_time,
+                                    &mut user_time,
+                                );
+                                if success != 0 {
+                                    let time = (creation_time.dwHighDateTime as u64) << 32
+                                        | (creation_time.dwLowDateTime as u64);
+
+                                    if best_process.map_or(true, |(_, oldest)| time > oldest) {
+                                        best_process = Some((pid, time));
+                                    }
+                                }
+
+                                CloseHandle(process);
+                            }
+                        }
+                    }
+
+                    if Process32NextW(snapshot, &mut entry) == 0 {
+                        break;
+                    }
+                }
+            }
+
+            CloseHandle(snapshot);
+
+            if let Some((pid, _)) = best_process {
+                Process::with_pid(pid)
+            } else {
+                Err(Error::ProcessDoesntExist)
+            }
+        }
+    }
+
+    pub fn with_pid(pid: DWORD) -> Result<Self> {
+        unsafe {
+            let handle = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false as _, pid);
+
+            if !handle.is_null() {
+                let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
+
+                if snapshot == INVALID_HANDLE_VALUE {
+                    CloseHandle(handle);
+                    return Err(Error::ListModules);
+                }
+
+                let mut modules = HashMap::new();
+                let mut entry: MODULEENTRY32W = mem::uninitialized();
+                entry.dwSize = mem::size_of_val(&entry) as _;
+
+                if Module32FirstW(snapshot, &mut entry) != 0 {
+                    loop {
+                        {
+                            let base_address = entry.modBaseAddr as Address;
+                            let name = &entry.szModule;
+                            let len = name.iter().take_while(|&&c| c != 0).count();
+                            let name = &name[..len];
+                            let name = OsString::from_wide(name).to_string_lossy().into_owned();
+                            modules.insert(name, base_address);
+                        }
+
+                        if Module32NextW(snapshot, &mut entry) == 0 {
+                            break;
+                        }
+                    }
+                }
+
+                let is_64bit;
+                #[cfg(target_pointer_width = "64")]
+                {
+                    use winapi::um::wow64apiset::IsWow64Process;
+
+                    let mut pbool: BOOL = 0;
+                    IsWow64Process(handle, &mut pbool);
+                    is_64bit = pbool == 0;
+                }
+                #[cfg(not(target_pointer_width = "64"))]
+                {
+                    // TODO Actually idk if 32-bit apps can read from 64-bit
+                    // apps. If they can, then this is wrong.
+                    is_64bit = false;
+                }
+
+                CloseHandle(snapshot);
+
+                Ok(Self {
+                    handle,
+                    modules,
+                    is_64bit,
+                })
+            } else {
+                Err(Error::ProcessOpening)
+            }
+        }
+    }
+
+    pub fn module_address(&self, module: &str) -> Result<Address> {
+        self.modules
+            .get(module)
+            .cloned()
+            .ok_or(Error::ModuleDoesntExist)
+    }
+
+    pub fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
+        unsafe {
+            let mut bytes_read = mem::uninitialized();
+
+            let successful = ReadProcessMemory(
+                self.handle,
+                address as _,
+                buf.as_mut_ptr() as _,
+                buf.len() as _,
+                &mut bytes_read,
+            ) != 0;
+
+            if successful && bytes_read as usize == buf.len() {
+                Ok(())
+            } else {
+                Err(Error::ReadMemory)
+            }
+        }
+    }
+
+    pub fn read<T: Copy>(&self, address: Address) -> Result<T> {
+        // TODO Unsound af
+        unsafe {
+            let mut res = mem::uninitialized();
+            let buf = slice::from_raw_parts_mut(mem::transmute(&mut res), mem::size_of::<T>());
+            self.read_buf(address, buf).map(|_| res)
+        }
+    }
+
+    fn memory_pages(&self, all: bool) -> impl Iterator<Item = MEMORY_BASIC_INFORMATION> + '_ {
+        // hardcoded values because GetSystemInfo / GetNativeSystemInfo can't
+        // return info for remote process
+        let min = 0x10000u64;
+        let max = if self.is_64bit() {
+            0x00007FFFFFFEFFFFu64
+        } else {
+            0x7FFEFFFFu64
+        };
+
+        let mbi_size = mem::size_of::<MEMORY_BASIC_INFORMATION>();
+        let mut addr = min;
+        iter::from_fn(move || {
+            while addr < max {
+                unsafe {
+                    let mut mbi: MEMORY_BASIC_INFORMATION = mem::uninitialized();
+                    if VirtualQueryEx(self.handle, addr as _, &mut mbi, mbi_size) == 0 {
+                        break;
+                    }
+                    addr += mbi.RegionSize as u64;
+
+                    // We don't care about reserved / free pages
+                    if mbi.State != MEM_COMMIT {
+                        continue;
+                    }
+
+                    // We can't read from guarded pages
+                    if !all && (mbi.Protect & PAGE_GUARD) != 0 {
+                        continue;
+                    }
+
+                    // We can't read from no access pages
+                    if !all && (mbi.Protect & PAGE_NOACCESS) != 0 {
+                        continue;
+                    }
+
+                    return Some(mbi);
+                }
+            }
+            None
+        })
+    }
+
+    pub fn scan_signature(&self, signature: &str) -> Result<Option<Address>> {
+        let signature = Signature::new(signature);
+
+        let mut page_buf = Vec::<u8>::new();
+
+        for page in self.memory_pages(false) {
+            let base = page.BaseAddress as Address;
+            let len = page.RegionSize as usize;
+            page_buf.clear();
+            page_buf.reserve(len);
+            unsafe {
+                page_buf.set_len(len);
+            }
+            self.read_buf(base, &mut page_buf)?;
+            if let Some(index) = signature.scan(&page_buf) {
+                return Ok(Some(base + index as Address));
+            }
+        }
+        Ok(None)
+    }
+}
+
+struct Signature {
+    bytes: Vec<u8>,
+    mask: Vec<bool>,
+    skip_offsets: [usize; 256],
+}
+
+impl Signature {
+    fn new(signature: &str) -> Self {
+        let mut bytes_iter = signature.bytes().filter_map(|b| match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 0xA),
+            b'A'..=b'F' => Some(b - b'A' + 0xA),
+            b'?' => Some(0x10),
+            _ => None,
+        });
+        let (mut bytes, mut mask) = (Vec::new(), Vec::new());
+
+        while let (Some(a), Some(b)) = (bytes_iter.next(), bytes_iter.next()) {
+            let sig_byte = (a << 4) | b;
+            let is_question_marks = a == 0x10 && b == 0x10;
+            bytes.push(sig_byte);
+            mask.push(is_question_marks);
+        }
+
+        let mut skip_offsets = [0; 256];
+
+        let mut unknown = 0;
+        let end = bytes.len() - 1;
+        for (i, (&byte, mask)) in bytes.iter().zip(&mask).enumerate().take(end) {
+            if !mask {
+                skip_offsets[byte as usize] = end - i;
+            } else {
+                unknown = end - i;
+            }
+        }
+
+        if unknown == 0 {
+            unknown = bytes.len();
+        }
+
+        for offset in &mut skip_offsets[..] {
+            if unknown < *offset || *offset == 0 {
+                *offset = unknown;
+            }
+        }
+
+        Self {
+            bytes,
+            mask,
+            skip_offsets,
+        }
+    }
+
+    fn scan(&self, buf: &[u8]) -> Option<usize> {
+        let mut current = 0;
+        let end = self.bytes.len() - 1;
+        while current <= buf.len() - self.bytes.len() {
+            let rem = &buf[current..];
+            if rem
+                .iter()
+                .zip(&self.bytes)
+                .zip(&self.mask)
+                .all(|((&buf, &search), &mask)| buf == search || mask)
+            {
+                return Some(current);
+            }
+            let offset = self.skip_offsets[rem[end] as usize];
+            current += offset;
+        }
+        None
+    }
+}

--- a/crates/livesplit-auto-splitting/src/process/linux.rs
+++ b/crates/livesplit-auto-splitting/src/process/linux.rs
@@ -1,0 +1,192 @@
+use libc::pid_t;
+use std::os::unix::ffi::OsStringExt;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::{mem, slice, fs, io};
+use std::io::{Read, BufRead};
+use std::collections::HashMap;
+
+use super::{Error, Result, Address, Offset, Signature};
+
+#[derive(Debug, Clone)]
+pub struct Process {
+    pid: pid_t,
+    is_64bit: bool
+}
+
+struct MapRange {
+    range_start: Address,
+    range_end: Address,
+    offset: Offset,
+    path: Option<PathBuf>,
+    perms: [u8; 4]
+}
+
+impl Process {
+    pub fn is_64bit(&self) -> bool {
+        self.is_64bit
+    }
+
+    fn process_name(&self) -> Option<OsString> {
+        let mut process_name = Vec::new();
+        File::open(format!("/proc/{}/comm", self.pid)).ok()?.read_to_end(&mut process_name).ok()?;
+
+        Some(OsString::from_vec(process_name))
+    }
+
+    // fn handle(&self) -> pid_t {
+    //     self.pid
+    // }
+
+    // Autosplitter/user should probably get access to this list to choose from it in the future.
+    fn processes_with_name(name: &OsStr) -> Result<Vec<Self>> {
+        // License: MIT
+        // Copyright (c) 2015 Guillaume Gomez
+        // Based on https://github.com/GuillaumeGomez/sysinfo/blob/4edbf34ad5fcd03979498ec124e15a067c10d0b4/src/linux/system.rs#L512
+        let dir = fs::read_dir("/proc").or(Err(Error::ListProcesses))?;
+        let processes = dir.filter_map(std::result::Result::ok)
+            .filter(|e| e.path().is_dir())
+            .filter_map(|e| e.path().file_name().and_then(OsStr::to_str).map(pid_t::from_str))
+            .filter_map(std::result::Result::ok)
+            .map(Process::with_pid)
+            .filter_map(std::result::Result::ok)
+            .filter(|proc| {
+                if let Some(process_name) = proc.process_name() {
+                    &*process_name == name
+                } else {
+                    false
+                }
+            })
+            // TODO: sort
+            .collect();
+
+        Ok(processes)
+    }
+
+    pub fn with_name<T: AsRef<OsStr>>(name: T) -> Result<Self> {
+        Process::processes_with_name(name.as_ref())?.get(0).cloned().ok_or(Error::ProcessDoesntExist)
+    }
+
+    pub fn with_pid(pid: libc::pid_t) -> Result<Self> {
+        let mut proc = Process { pid, is_64bit: false };
+        // TODO: do we want to cache the pages/modules at all?
+        if let Ok(pages) = proc.memory_pages() {
+            // Inspired by https://unix.stackexchange.com/a/106235 "Parsing the maps file"
+            proc.is_64bit = pages.last().unwrap().range_end > 0xFFFFFFFF;
+            Ok(proc)
+        } else {
+            Err(Error::ProcessDoesntExist)
+        }
+    }
+
+    pub fn module_address<T: AsRef<OsStr>>(&self, module: T) -> Result<Address> {
+        self.modules()?.get(module.as_ref()).cloned().ok_or(Error::ModuleDoesntExist)
+    }
+
+    pub fn modules(&self) -> Result<HashMap<OsString, Address>> {
+        // There are multiple ways of doing this. Could also traverse symlinks in /proc/PID/map_files, for instance
+        Ok(self.memory_pages()?.filter_map(|MapRange { path, range_start, offset, .. }|
+            path.map(|p|
+                (p.file_name().unwrap().to_os_string(), range_start - offset as Address)
+            )
+        ).collect())
+    }
+
+    pub fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
+        use libc::{pid_t, c_void, iovec, process_vm_readv};
+
+        // TODO: what if this is a 32 bit process and we're trying to read from a 64 bit process?
+        // Should we go through /proc/PID/mem instead? ptrace?
+        // TODO: What's required so we don't need to run as root?
+        let local_iov = iovec {
+            iov_base: buf.as_mut_ptr() as *mut c_void,
+            iov_len: buf.len()
+        };
+
+        let remote_iov = iovec {
+            iov_base: address as *mut c_void,
+            iov_len: buf.len()
+        };
+
+        let result = unsafe { process_vm_readv(self.pid, &local_iov, 1, &remote_iov, 1, 0) };
+        if result == -1 {
+            Err(Error::ReadMemory)
+        } else {
+            Ok(())
+        }
+    }
+
+    // TODO: move to shared helper
+    pub fn read<T: Copy>(&self, address: Address) -> Result<T> {
+        // TODO Unsound af
+        unsafe {
+            let mut res = mem::uninitialized();
+            let buf = slice::from_raw_parts_mut(mem::transmute(&mut res), mem::size_of::<T>());
+            self.read_buf(address, buf).map(|_| res)
+        }
+    }
+
+    // Parses /proc/PID/maps
+    fn memory_pages(&self) -> Result<impl Iterator<Item=MapRange>> {
+        // License: MIT
+        // Copyright (c) 2016 Julia Evans, Jorge Aparicio
+        // Based on https://github.com/rbspy/proc-maps/blob/7168cd0a13d464ef00f20a81f064b7729ff58d2e/src/linux_maps.rs#L49
+        let file = io::BufReader::new(File::open(format!("/proc/{}/maps", self.pid)).or(Err(Error::ProcessDoesntExist))?);
+        // TODO: use OsString, use unwrap a bit less.
+        Ok(file.lines().filter_map(std::result::Result::ok).map(|line| {
+            let mut fields = line.split_whitespace();
+
+            let mut range = fields.next().unwrap().split('-');
+            let range_start = Address::from_str_radix(range.next().unwrap(), 16).unwrap();
+            let range_end = Address::from_str_radix(range.next().unwrap(), 16).unwrap();
+
+            let perms = fields.next().unwrap().as_bytes();
+            let perms: [u8; 4] = [perms[0], perms[1], perms[2], perms[3]];
+
+            let offset = Offset::from_str_radix(fields.next().unwrap(), 16).unwrap();
+
+            let _ = fields.next(); // dev
+            let _ = fields.next(); // inode
+
+            let path: Option<PathBuf> = fields.next().map(|s| s.into());
+
+            MapRange {
+                range_start,
+                range_end,
+                offset,
+                perms,
+                path
+            }
+        }))
+    }
+
+    // TODO: move to shared helper
+    pub fn scan_signature(&self, signature: &str) -> Result<Option<Address>> {
+        let signature = Signature::new(signature);
+
+        let mut page_buf = Vec::<u8>::new();
+
+        for page in self.memory_pages()?
+            .filter(|range| range.perms[0] == b'r' && !(range.path.is_some() && (
+                range.path.as_ref().unwrap().starts_with("/dev") ||
+                range.path.as_ref().unwrap().file_name().unwrap() == "[vvar]" ||
+                range.path.as_ref().unwrap().file_name().unwrap() == "[vdso]"
+            )))
+        {
+            let base = page.range_start;
+            let len = page.range_end - page.range_start;
+            page_buf.clear();
+            page_buf.reserve(len as usize);
+            unsafe {
+                page_buf.set_len(len as usize);
+                self.read_buf(base, &mut page_buf)?;
+            }
+            if let Some(index) = signature.scan(&page_buf) {
+                return Ok(Some(base + index as Address));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/crates/livesplit-auto-splitting/src/process/linux.rs
+++ b/crates/livesplit-auto-splitting/src/process/linux.rs
@@ -5,7 +5,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::{mem, slice, fs, io};
+use std::{fs, io};
 use std::io::{Read, BufRead};
 use std::collections::HashMap;
 use std::cell::{RefCell, RefMut};
@@ -15,7 +15,7 @@ use nom::sequence::{tuple, separated_pair, terminated};
 use nom::combinator::{map, map_res, opt, verify};
 use nom::IResult;
 
-use super::{Error, Result, Address, Offset, Signature, ProcessImpl, ScannableRange};
+use super::{Error, Result, Address, ProcessImpl, ScannableRange};
 
 #[derive(Debug)]
 pub struct Process {
@@ -118,8 +118,6 @@ impl ProcessImpl for Process {
     }
 
     fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()> {
-        use libc::{pid_t, c_void, iovec, process_vm_readv};
-
         if let Some(file) = self.memory() {
             file.read_exact_at(buf, address as u64).or(Err(Error::ReadMemory))
         } else {

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -4,9 +4,9 @@ mod os;
 
 pub use os::Process;
 
+use bytemuck::Pod;
 use std::ffi::OsStr;
 use std::mem;
-use bytemuck::Pod;
 
 #[derive(Debug, snafu::Snafu)]
 pub enum Error {
@@ -99,13 +99,15 @@ impl Signature {
 
 pub(crate) struct ScannableRange {
     base: Address,
-    len: u64
+    len: u64,
 }
 
 /// Private trait used for keeping API consistent between platforms
 trait ProcessImpl {
     fn is_64bit(&self) -> bool;
-    fn with_name(name: &OsStr) -> Result<Self> where Self: Sized;
+    fn with_name(name: &OsStr) -> Result<Self>
+    where
+        Self: Sized;
     //fn with_pid(pid: pid_t) -> Result<Self>;
     fn module_address(&self, module: &OsStr) -> Result<Address>;
     fn read_buf(&self, address: Address, buf: &mut [u8]) -> Result<()>;
@@ -117,19 +119,27 @@ trait ProcessImpl {
 impl Process {
     /// Returns whether this Process is 64 bit or not
     #[inline]
-    pub fn is_64bit(&self) -> bool { ProcessImpl::is_64bit(self) }
+    pub fn is_64bit(&self) -> bool {
+        ProcessImpl::is_64bit(self)
+    }
 
     /// Finds a process with a given name and returns it
     #[inline]
-    pub fn with_name<T: AsRef<OsStr>>(name: T) -> Result<Self> { ProcessImpl::with_name(name.as_ref()) }
+    pub fn with_name<T: AsRef<OsStr>>(name: T) -> Result<Self> {
+        ProcessImpl::with_name(name.as_ref())
+    }
 
     /// Returns the address of a module within this process, if present
     #[inline]
-    pub fn module_address<T: AsRef<OsStr>>(&self, module: T) -> Result<Address> { ProcessImpl::module_address(self, module.as_ref()) }
+    pub fn module_address<T: AsRef<OsStr>>(&self, module: T) -> Result<Address> {
+        ProcessImpl::module_address(self, module.as_ref())
+    }
 
     /// Reads bef.len() bytes from address in this process into buf
     #[inline]
-    pub fn read_buf<T: AsMut<[u8]>>(&self, address: Address, mut buf: T) -> Result<()> { ProcessImpl::read_buf(self, address, buf.as_mut()) }
+    pub fn read_buf<T: AsMut<[u8]>>(&self, address: Address, mut buf: T) -> Result<()> {
+        ProcessImpl::read_buf(self, address, buf.as_mut())
+    }
 
     /// Reads a T from address in this process
     pub fn read<T: Pod>(&self, address: Address) -> Result<T> {
@@ -160,7 +170,6 @@ impl Process {
                         }
                     }
                 };
-
             }
             if let Some(index) = signature.scan(&page_buf) {
                 return Ok(Some(base + index as Address));

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -5,7 +5,7 @@ mod os;
 pub use os::Process;
 
 use std::ffi::OsStr;
-use std::{io, slice, mem};
+use std::mem;
 use bytemuck::Pod;
 
 #[derive(Debug, snafu::Snafu)]

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -150,7 +150,17 @@ impl Process {
             page_buf.reserve(len as usize);
             unsafe {
                 page_buf.set_len(len as usize);
-                self.read_buf(base, &mut page_buf)?;
+                // TODO: Handle an error in reading memory more gracefully instead of silently
+                // returning an array of 0s.
+                match self.read_buf(base, &mut page_buf) {
+                    Ok(_) => (),
+                    Err(_) => {
+                        for el in &mut page_buf {
+                            *el = 0;
+                        }
+                    }
+                };
+
             }
             if let Some(index) = signature.scan(&page_buf) {
                 return Ok(Some(base + index as Address));

--- a/crates/livesplit-auto-splitting/src/process/mod.rs
+++ b/crates/livesplit-auto-splitting/src/process/mod.rs
@@ -1,0 +1,94 @@
+#[cfg_attr(linux, path = "linux.rs")]
+#[cfg_attr(windows, path = "windows.rs")]
+mod os;
+
+pub use os::Process;
+
+#[derive(Debug, snafu::Snafu)]
+pub enum Error {
+    // TODO: Doc Comments
+    ListProcesses,
+    ProcessDoesntExist,
+    ListModules,
+    ProcessOpening,
+    ModuleDoesntExist,
+    ReadMemory,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type Address = u64;
+pub type Offset = i64;
+
+pub(crate) struct Signature {
+    bytes: Vec<u8>,
+    mask: Vec<bool>,
+    skip_offsets: [usize; 256],
+}
+
+impl Signature {
+    pub(crate) fn new(signature: &str) -> Self {
+        let mut bytes_iter = signature.bytes().filter_map(|b| match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 0xA),
+            b'A'..=b'F' => Some(b - b'A' + 0xA),
+            b'?' => Some(0x10),
+            _ => None,
+        });
+        let (mut bytes, mut mask) = (Vec::new(), Vec::new());
+
+        while let (Some(a), Some(b)) = (bytes_iter.next(), bytes_iter.next()) {
+            let sig_byte = (a << 4) | b;
+            let is_question_marks = a == 0x10 && b == 0x10;
+            bytes.push(sig_byte);
+            mask.push(is_question_marks);
+        }
+
+        let mut skip_offsets = [0; 256];
+
+        let mut unknown = 0;
+        let end = bytes.len() - 1;
+        for (i, (&byte, mask)) in bytes.iter().zip(&mask).enumerate().take(end) {
+            if !mask {
+                skip_offsets[byte as usize] = end - i;
+            } else {
+                unknown = end - i;
+            }
+        }
+
+        if unknown == 0 {
+            unknown = bytes.len();
+        }
+
+        for offset in &mut skip_offsets[..] {
+            if unknown < *offset || *offset == 0 {
+                *offset = unknown;
+            }
+        }
+
+        Self {
+            bytes,
+            mask,
+            skip_offsets,
+        }
+    }
+
+    pub(crate) fn scan(&self, buf: &[u8]) -> Option<usize> {
+        let mut current = 0;
+        let end = self.bytes.len() - 1;
+        while current <= buf.len() - self.bytes.len() {
+            let rem = &buf[current..];
+            if rem
+                .iter()
+                .zip(&self.bytes)
+                .zip(&self.mask)
+                .all(|((&buf, &search), &mask)| buf == search || mask)
+            {
+                return Some(current);
+            }
+            let offset = self.skip_offsets[rem[end] as usize];
+            current += offset;
+        }
+        None
+    }
+}

--- a/crates/livesplit-auto-splitting/src/process/windows.rs
+++ b/crates/livesplit-auto-splitting/src/process/windows.rs
@@ -15,12 +15,12 @@ use winapi::um::{
 };
 
 use std::collections::HashMap;
-use std::ffi::{OsString, OsStr};
+use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::{iter, mem, ptr, result, slice};
 
-use super::{Error, Address, Offset, Result, Signature, ProcessImpl, ScannableRange};
+use super::{Address, Error, Offset, ProcessImpl, Result, ScannableRange, Signature};
 
 #[derive(Debug)]
 pub struct Process {
@@ -41,7 +41,7 @@ pub(crate) struct ScannableIter {
     handle: HANDLE,
     addr: u64,
     max: u64,
-    all: bool
+    all: bool,
 }
 
 impl Iterator for ScannableIter {
@@ -73,7 +73,7 @@ impl Iterator for ScannableIter {
 
                 return Some(ScannableRange {
                     base: mbi.BaseAddress as u64,
-                    len: mbi.RegionSize as u64
+                    len: mbi.RegionSize as u64,
                 });
             }
         }
@@ -186,7 +186,8 @@ impl ProcessImpl for Process {
 }
 
 impl Process {
-    /*pub*/ fn path(&self) -> Option<PathBuf> {
+    /*pub*/
+    fn path(&self) -> Option<PathBuf> {
         let mut path_buf = [0u16; 1024];
         if unsafe {
             GetModuleFileNameExW(
@@ -202,7 +203,8 @@ impl Process {
         Some(PathBuf::from(OsString::from_wide(&path_buf)))
     }
 
-    /*pub*/ fn with_pid(pid: DWORD) -> Result<Self> {
+    /*pub*/
+    fn with_pid(pid: DWORD) -> Result<Self> {
         unsafe {
             let handle = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false as _, pid);
 
@@ -265,7 +267,8 @@ impl Process {
         }
     }
 
-    /*pub*/ fn modules(&self) -> Result<&HashMap<OsString, Address>> {
+    /*pub*/
+    fn modules(&self) -> Result<&HashMap<OsString, Address>> {
         // TODO: when do we want to refresh this?
         Ok(&self.modules)
     }
@@ -280,13 +283,12 @@ impl Process {
             0x7FFEFFFFu64
         };
 
-
         let mut addr = min;
         ScannableIter {
             handle: self.handle,
             addr: min,
             max,
-            all
+            all,
         }
     }
 }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -1,0 +1,360 @@
+use crate::{environment::Environment, pointer::PointerValue, process::Process};
+use std::{cell::RefCell, mem, rc::Rc, thread};
+use wasmtime::{Export, Instance, Linker, Module, Trap};
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TimerState {
+    NotRunning = 0,
+    Running = 1,
+    Finished = 2,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TimerAction {
+    Start,
+    Split,
+    Reset,
+}
+
+pub struct Runtime {
+    _instance: Instance,
+    env: Rc<RefCell<Environment>>,
+    timer_state: TimerState,
+    hooked: Option<Box<dyn Fn() -> Result<(), Trap>>>,
+    unhooked: Option<Box<dyn Fn() -> Result<(), Trap>>>,
+    should_start: Option<Box<dyn Fn() -> Result<i32, Trap>>>,
+    should_split: Option<Box<dyn Fn() -> Result<i32, Trap>>>,
+    should_reset: Option<Box<dyn Fn() -> Result<i32, Trap>>>,
+    is_loading: Option<Box<dyn Fn() -> Result<i32, Trap>>>,
+    game_time: Option<Box<dyn Fn() -> Result<f64, Trap>>>,
+    update: Option<Box<dyn Fn() -> Result<(), Trap>>>,
+    is_loading_val: Option<bool>,
+    game_time_val: Option<f64>,
+}
+
+impl Runtime {
+    pub fn new(binary: &[u8]) -> anyhow::Result<Self> {
+        let module = Module::from_binary(&Default::default(), binary)?;
+        let env = Rc::new(RefCell::new(Environment::default()));
+        let mut linker = Linker::new(module.store());
+
+        linker.func("env", "set_process_name", {
+            let env = env.clone();
+            move |ptr, len| env.borrow_mut().set_process_name(ptr, len)
+        })?;
+
+        linker.func("env", "push_pointer_path", {
+            let env = env.clone();
+            move |ptr, len, pointer_type| env.borrow_mut().push_pointer_path(ptr, len, pointer_type)
+        })?;
+
+        linker.func("env", "push_offset", {
+            let env = env.clone();
+            move |pointer_path_id, offset| env.borrow_mut().push_offset(pointer_path_id, offset)
+        })?;
+
+        linker.func("env", "get_u8", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::U8(v) => Some(v as i32),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_u16", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::U16(v) => Some(v as i32),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_u32", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::U32(v) => Some(v as i32),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_u64", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::U64(v) => Some(v as i64),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_i8", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::I8(v) => Some(v as i32),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_i16", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::I16(v) => Some(v as i32),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_i32", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::I32(v) => Some(v),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_i64", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::I64(v) => Some(v),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_f32", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::F32(v) => Some(v),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "get_f64", {
+            let env = env.clone();
+            move |pointer_path_id, current| {
+                env.borrow()
+                    .get_val(pointer_path_id, current, |v| match *v {
+                        PointerValue::F64(v) => Some(v),
+                        _ => None,
+                    })
+            }
+        })?;
+
+        linker.func("env", "scan_signature", {
+            let env = env.clone();
+            move |ptr, len| env.borrow_mut().scan_signature(ptr, len)
+        })?;
+
+        linker.func("env", "set_tick_rate", {
+            let env = env.clone();
+            move |ticks_per_sec| env.borrow_mut().set_tick_rate(ticks_per_sec)
+        })?;
+
+        linker.func("env", "print_message", {
+            let env = env.clone();
+            move |ptr, len| env.borrow_mut().print_message(ptr, len)
+        })?;
+
+        linker.func("env", "read_into_buf", {
+            let env = env.clone();
+            move |address, buf, buf_len| env.borrow_mut().read_into_buf(address, buf, buf_len)
+        })?;
+
+        linker.func("env", "set_variable", {
+            let env = env.clone();
+            move |key_ptr, key_len, value_ptr, value_len| {
+                env.borrow_mut()
+                    .set_variable(key_ptr, key_len, value_ptr, value_len)
+            }
+        })?;
+
+        let instance = linker.instantiate(&module)?;
+        env.borrow_mut().memory = instance.exports().find_map(Export::into_memory);
+
+        // TODO: WASI support
+        // if let Some(func) = instance.get_func("_start") {
+        //     func.get0()?()?;
+        // }
+
+        // TODO: Do we error out if this doesn't exist?
+        if let Some(func) = instance.get_func("configure") {
+            func.get0()?()?;
+        }
+
+        let hooked = instance
+            .get_func("hooked")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let unhooked = instance
+            .get_func("unhooked")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let should_start = instance
+            .get_func("should_start")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let should_split = instance
+            .get_func("should_split")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let should_reset = instance
+            .get_func("should_reset")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let is_loading = instance
+            .get_func("is_loading")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let game_time = instance
+            .get_func("game_time")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        let update = instance
+            .get_func("update")
+            .and_then(|f| f.get0().ok())
+            .map(|f| Box::new(f) as _);
+
+        Ok(Self {
+            _instance: instance,
+            env,
+            timer_state: TimerState::NotRunning,
+            hooked,
+            unhooked,
+            should_start,
+            should_split,
+            should_reset,
+            is_loading,
+            game_time,
+            update,
+            is_loading_val: None,
+            game_time_val: None,
+        })
+    }
+
+    pub fn sleep(&self) {
+        thread::sleep(self.env.borrow().tick_rate);
+    }
+
+    pub fn step(&mut self) -> anyhow::Result<Option<TimerAction>> {
+        let mut just_connected = false;
+
+        {
+            let mut env = self.env.borrow_mut();
+            if env.process.is_none() {
+                env.process = match Process::with_name(&env.process_name) {
+                    Ok(p) => Some(p),
+                    Err(_) => return Ok(None),
+                };
+                log::info!(target: "Auto Splitter", "Hooked");
+                // TODO: Is this a good place to do this? What do we guarantee
+                // about the variables and co. here?
+                if let Some(hooked) = &self.hooked {
+                    hooked()?;
+                }
+                just_connected = true;
+            }
+            if env.update_values(just_connected).is_err() {
+                log::info!(target: "Auto Splitter", "Unhooked");
+                env.process = None;
+                if let Some(unhooked) = &self.unhooked {
+                    unhooked()?;
+                }
+                return Ok(None);
+            }
+        }
+
+        self.run_script()
+    }
+
+    pub fn set_state(&mut self, state: TimerState) {
+        self.timer_state = state;
+    }
+
+    fn run_script(&mut self) -> anyhow::Result<Option<TimerAction>> {
+        if let Some(update) = &self.update {
+            update()?;
+        }
+
+        match self.timer_state {
+            TimerState::NotRunning => {
+                if let Some(should_start) = &self.should_start {
+                    if should_start()? != 0 {
+                        return Ok(Some(TimerAction::Start));
+                    }
+                }
+            }
+            TimerState::Running => {
+                if let Some(is_loading) = &self.is_loading {
+                    self.is_loading_val = Some(is_loading()? != 0);
+                }
+                if let Some(game_time) = &self.game_time {
+                    self.game_time_val = Some(game_time()?).filter(|v| !v.is_nan());
+                }
+
+                if let Some(should_split) = &self.should_split {
+                    if should_split()? != 0 {
+                        return Ok(Some(TimerAction::Split));
+                    }
+                }
+                if let Some(should_reset) = &self.should_reset {
+                    if should_reset()? != 0 {
+                        return Ok(Some(TimerAction::Reset));
+                    }
+                }
+            }
+            TimerState::Finished => {
+                if let Some(should_reset) = &self.should_reset {
+                    if should_reset()? != 0 {
+                        return Ok(Some(TimerAction::Reset));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn is_loading(&self) -> Option<bool> {
+        self.is_loading_val
+    }
+
+    pub fn game_time(&self) -> Option<f64> {
+        self.game_time_val
+    }
+
+    pub fn drain_variable_changes(&mut self) -> impl Iterator<Item = (String, String)> {
+        // TODO: This is kind of stupid. We lose all the capacity this way.
+        mem::take(&mut self.env.borrow_mut().variable_changes).into_iter()
+    }
+}

--- a/crates/livesplit-auto-splitting/src/std_stream.rs
+++ b/crates/livesplit-auto-splitting/src/std_stream.rs
@@ -1,7 +1,8 @@
 use bstr::ByteSlice;
 use log::Level;
 use std::io::{self, IoSlice, IoSliceMut, LineWriter, Write};
-use wasi_common::{wasi, FileContents, Filesize};
+use wasi::types::Filesize;
+use wasi_common::{wasi, FileContents};
 
 struct Log(Level);
 

--- a/crates/livesplit-auto-splitting/src/std_stream.rs
+++ b/crates/livesplit-auto-splitting/src/std_stream.rs
@@ -1,0 +1,51 @@
+use bstr::ByteSlice;
+use log::Level;
+use std::io::{self, IoSlice, IoSliceMut, LineWriter, Write};
+use wasi_common::{wasi, FileContents, Filesize};
+
+struct Log(Level);
+
+impl Write for Log {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        log::log!(target: "Auto Splitter", self.0, "{}", buf.trim_end().as_bstr());
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct StdStream(LineWriter<Log>);
+
+impl StdStream {
+    pub fn stdout() -> Self {
+        Self(LineWriter::new(Log(Level::Info)))
+    }
+    pub fn stderr() -> Self {
+        Self(LineWriter::new(Log(Level::Error)))
+    }
+}
+
+impl FileContents for StdStream {
+    fn max_size(&self) -> Filesize {
+        usize::MAX as Filesize
+    }
+    fn size(&self) -> Filesize {
+        0
+    }
+    fn resize(&mut self, _new_size: Filesize) -> wasi::Result<()> {
+        Ok(())
+    }
+    fn pwritev(&mut self, iovs: &[IoSlice], _offset: Filesize) -> wasi::Result<usize> {
+        Ok(self.0.write_vectored(iovs)?)
+    }
+    fn preadv(&self, _iovs: &mut [IoSliceMut], _offset: Filesize) -> wasi::Result<usize> {
+        Ok(0)
+    }
+    fn pwrite(&mut self, buf: &[u8], _offset: Filesize) -> wasi::Result<usize> {
+        Ok(self.0.write(buf)?)
+    }
+    fn pread(&self, _buf: &mut [u8], _offset: Filesize) -> wasi::Result<usize> {
+        Ok(0)
+    }
+}

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,0 +1,142 @@
+use bstr::BStr;
+use livesplit_auto_splitting::Runtime;
+use log::Log;
+use std::{
+    cell::RefCell,
+    ffi::OsStr,
+    fmt::Write,
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+thread_local! {
+    static BUF: RefCell<Option<String>> = RefCell::new(None);
+}
+struct Logger;
+static LOGGER: Logger = Logger;
+
+impl Log for Logger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        if record.target() != "Auto Splitter" {
+            return;
+        }
+        BUF.with(|b| {
+            if let Some(b) = &mut *b.borrow_mut() {
+                let _ = writeln!(b, "{}", record.args());
+            }
+        });
+    }
+    fn flush(&self) {}
+}
+
+fn compile(crate_name: &str) -> anyhow::Result<Runtime> {
+    let mut path = PathBuf::from("tests");
+    path.push("test-cases");
+    path.push(crate_name);
+
+    let output = Command::new("cargo")
+        .current_dir(&path)
+        .arg("build")
+        .arg("--target")
+        .arg("wasm32-wasi")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .output()
+        .unwrap();
+
+    if !output.status.success() {
+        let output: &BStr = output.stderr.as_slice().into();
+        panic!("{}", output);
+    }
+
+    path.push("target");
+    path.push("wasm32-wasi");
+    path.push("debug");
+    let wasm_path = fs::read_dir(path)
+        .unwrap()
+        .find_map(|e| {
+            let path = e.unwrap().path();
+            if path.extension() == Some(OsStr::new("wasm")) {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    Runtime::new(&fs::read(wasm_path).unwrap())
+}
+
+#[test]
+fn empty() {
+    compile("empty").unwrap();
+}
+
+#[test]
+fn proc_exit() {
+    assert!(compile("proc-exit").is_err());
+}
+
+#[test]
+fn create_file() {
+    compile("create-file").unwrap();
+}
+
+#[test]
+fn stdout() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Trace);
+    BUF.with(|b| *b.borrow_mut() = Some(String::new()));
+    compile("stdout").unwrap();
+    let output = BUF.with(|b| b.borrow_mut().take());
+    assert_eq!(
+        output.unwrap(),
+        "Printing from the auto splitter\nError printing from the auto splitter\n",
+    );
+}
+
+#[test]
+fn segfault() {
+    assert!(compile("segfault").is_err());
+}
+
+#[test]
+fn env() {
+    compile("env").unwrap();
+    assert!(std::env::var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS").is_err());
+}
+
+#[test]
+fn threads() {
+    // There's no threads in WASI / WASM yet, so this is expected to trap.
+    assert!(compile("threads").is_err());
+}
+
+#[test]
+fn sleep() {
+    // TODO: Sleeping can basically deadlock the code. We should have a limit on
+    // how long it can sleep.
+    compile("sleep").unwrap();
+}
+
+#[test]
+fn time() {
+    compile("time").unwrap();
+}
+
+#[test]
+fn random() {
+    compile("random").unwrap();
+}
+
+#[test]
+fn poll() {
+    // TODO: This is basically what happens at the lower levels of sleeping. You
+    // can block on file descriptors and have a timeout with this. Both of which
+    // could deadlock the script.
+    compile("poll").unwrap();
+}

--- a/crates/livesplit-auto-splitting/tests/test-cases/create-file/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/create-file/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "create-file"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/create-file/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/create-file/src/main.rs
@@ -1,0 +1,10 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    assert!(std::fs::write(
+        "shouldnt_exist.txt",
+        "This file should never exist. File a bug if you see this.",
+    )
+    .is_err());
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/empty/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/empty/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "empty"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/empty/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/empty/src/main.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn configure() {}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/env/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/env/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "env"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/env/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/env/src/main.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+#[no_mangle]
+pub extern "C" fn configure() {
+    assert!(env::args().next().is_none());
+    assert!(env::current_exe().is_err());
+    assert!(env::current_dir().is_err());
+    assert!(env::vars().next().is_none());
+
+    env::set_var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS", "YES");
+
+    // but auto splitter should
+    assert_eq!(
+        env::var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS").unwrap(),
+        "YES",
+    );
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "infinite-loop"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/src/main.rs
@@ -1,0 +1,8 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    loop {
+        std::thread::yield_now();
+    }
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/poll/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/poll/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "poll"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]
+wasi = "0.9.0+wasi-snapshot-preview1"

--- a/crates/livesplit-auto-splitting/tests/test-cases/poll/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/poll/src/main.rs
@@ -1,0 +1,32 @@
+#[no_mangle]
+pub unsafe extern "C" fn configure() {
+    let mut out: wasi::Event = std::mem::zeroed();
+
+    wasi::poll_oneoff(
+        &wasi::Subscription {
+            userdata: 0,
+            r#type: wasi::EVENTTYPE_FD_READ,
+            u: wasi::SubscriptionU {
+                fd_readwrite: wasi::SubscriptionFdReadwrite { file_descriptor: 0 },
+            },
+        },
+        &mut out,
+        1,
+    )
+    .unwrap();
+
+    wasi::poll_oneoff(
+        &wasi::Subscription {
+            userdata: 1,
+            r#type: wasi::EVENTTYPE_FD_WRITE,
+            u: wasi::SubscriptionU {
+                fd_readwrite: wasi::SubscriptionFdReadwrite { file_descriptor: 1 },
+            },
+        },
+        &mut out,
+        1,
+    )
+    .unwrap();
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "proc-exit"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/src/main.rs
@@ -1,0 +1,6 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    std::process::exit(-1);
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/random/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/random/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "random"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]
+getrandom = "0.1.14"

--- a/crates/livesplit-auto-splitting/tests/test-cases/random/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/random/src/main.rs
@@ -1,0 +1,8 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    let mut buf = [0; 32];
+    getrandom::getrandom(&mut buf).unwrap();
+    assert_ne!(buf, [0; 32]);
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/segfault/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/segfault/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "segfault"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/segfault/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/segfault/src/main.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+pub unsafe extern "C" fn configure() {
+    let some_large_ptr = (usize::MAX / 2) as *mut u64;
+    *some_large_ptr = !0;
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/sleep/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/sleep/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sleep"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/sleep/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/sleep/src/main.rs
@@ -1,0 +1,9 @@
+use std::{thread, time};
+
+#[no_mangle]
+pub extern "C" fn configure() {
+    thread::yield_now();
+    thread::sleep(time::Duration::from_secs(10));
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/stdout/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/stdout/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "stdout"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/stdout/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/stdout/src/main.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    println!("Printing from the auto splitter");
+    eprintln!("Error printing from the auto splitter");
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/threads/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/threads/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "threads"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/threads/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/threads/src/main.rs
@@ -1,0 +1,6 @@
+#[no_mangle]
+pub extern "C" fn configure() {
+    assert!(std::thread::spawn(|| {}).join().is_err());
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/time/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/time/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "time"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/time/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/time/src/main.rs
@@ -1,0 +1,15 @@
+use std::{
+    thread,
+    time::{Duration, Instant, SystemTime},
+};
+
+#[no_mangle]
+pub extern "C" fn configure() {
+    assert!(SystemTime::now() > SystemTime::UNIX_EPOCH);
+
+    let earlier = Instant::now();
+    thread::sleep(Duration::from_secs(1));
+    assert_ne!(earlier.elapsed(), Duration::from_secs(0));
+}
+
+fn main() {}

--- a/crates/livesplit-exec/Cargo.toml
+++ b/crates/livesplit-exec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "livesplit-exec"
+version = "0.1.0"
+authors = ["Dark <dark@volatile.bz>"]
+edition = "2018"
+
+[lib]
+name = "livesplit_exec"
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
+[dependencies]
+libc = "0.2.77"

--- a/crates/livesplit-exec/README.md
+++ b/crates/livesplit-exec/README.md
@@ -1,0 +1,46 @@
+# livesplit-exec
+
+`livesplit-exec` is a Linux-only tool needed for auto splitting to work
+correctly due to Yama's `ptrace_scope` setting blocking access to 
+`/proc/$pid/mem` as non-root by default. This tool works around that by calling
+`prctl()` before launching the specified program to allow for the auto splitter
+to read memory.
+
+
+**NOTE:** This will not work if `sysctl kernel.yama.ptrace_scope` is greater
+than 1. If this value is 0 or doesn't exist, then this tool isn't needed.
+
+# Usage
+
+## Initial Setup
+
+First, you will need to install the rust toolchains for `i686-unknown-linux-gnu`
+and `x86_64-unknown-linux-gnu`. Afterwards, run `./build.sh`
+
+After running `./build.sh`, you'll have some directories in `./out`. The files
+in `./out/bin` need to be placed in your `$PATH`, and the files in `./out/lib` need
+to be placed in your `$LD_LIBRARY_PATH`. If this was installed from a package
+rather than built from source, this step isn't needed.
+
+## Non-Steam 
+
+If your game is launched outside of Steam, your game can be launched by placing
+`livesplit-exec` in front of the command to launch it.
+
+```
+# As sort of an example, if your game is launched like this:
+./portal2.sh -game portal2
+# you would instead launch it like this
+livesplit-exec ./portal2.sh -game portal2
+```
+
+## Steam
+
+If your game is launched from Steam, you'll just need to set your launch options
+for the game to the following:
+```
+livesplit-exec %command%
+```
+
+Any additional options for your game can be placed after this.
+

--- a/crates/livesplit-exec/build.sh
+++ b/crates/livesplit-exec/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cargo build --release
+cargo build --release --target i686-unknown-linux-gnu
+mkdir -p out/bin out/lib
+cp ../../target/release/livesplit-exec out/bin
+cp ../../target/release/liblivesplit_exec.so out/lib/liblivesplit-exec.so
+cp ../../target/i686-unknown-linux-gnu/release/liblivesplit_exec.so out/lib/liblivesplit-exec32.so

--- a/crates/livesplit-exec/src/lib.rs
+++ b/crates/livesplit-exec/src/lib.rs
@@ -1,0 +1,37 @@
+use libc::{c_int, c_ulong, dlsym};
+
+#[no_mangle]
+pub unsafe extern "C" fn fork() -> c_int {
+    let real_fork: extern "C" fn() -> c_int =
+        std::mem::transmute(dlsym(libc::RTLD_NEXT, "fork\0".as_ptr().cast()));
+    // Get the real prctl as we don't want to call our hooked version.
+    let real_prctl: extern "C" fn(option: c_int, ...) -> c_int =
+        std::mem::transmute(dlsym(libc::RTLD_NEXT, "prctl\0".as_ptr().cast()));
+
+    let pid = real_fork();
+
+    if pid == 0 {
+        real_prctl(libc::PR_SET_PTRACER, -1 /*PR_SET_PTRACER_ANY*/);
+    }
+
+    pid
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn prctl(
+    option: c_int,
+    arg1: c_ulong,
+    arg2: c_ulong,
+    arg3: c_ulong,
+    arg4: c_ulong,
+    arg5: c_ulong,
+) -> c_int {
+    let real_prctl: extern "C" fn(option: c_int, ...) -> c_int =
+        std::mem::transmute(dlsym(libc::RTLD_NEXT, "prctl\0".as_ptr().cast()));
+
+    if option == libc::PR_SET_PTRACER {
+        real_prctl(libc::PR_SET_PTRACER, -1 /*PR_SET_PTRACER_ANY*/)
+    } else {
+        real_prctl(option, arg1, arg2, arg3, arg4, arg5)
+    }
+}

--- a/crates/livesplit-exec/src/main.rs
+++ b/crates/livesplit-exec/src/main.rs
@@ -1,0 +1,25 @@
+use libc::prctl;
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process;
+
+fn main() {
+    unsafe {
+        prctl(libc::PR_SET_PTRACER, -1 /*PR_SET_PTRACER_ANY*/);
+    }
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() == 1 {
+        println!("usage: livesplit-exec <command>");
+        process::exit(1);
+    }
+
+    env::set_var("LD_PRELOAD", {
+        match env::var("LD_PRELOAD") {
+            Ok(val) => "liblivesplit-exec.so:liblivesplit-exec32.so:".to_owned() + &val,
+            Err(_) => "liblivesplit-exec.so:liblivesplit-exec32.so".to_owned(),
+        }
+    });
+
+    process::Command::new(&args[1]).args(&args[2..]).exec();
+}

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -1,0 +1,115 @@
+use {
+    crate::{timing::SharedTimer, TimeSpan, TimerPhase},
+    crossbeam_channel::{unbounded, Receiver, Sender},
+    livesplit_auto_splitting::{Runtime as ScriptRuntime, TimerAction, TimerState},
+    std::{
+        error::Error,
+        thread::{self, Thread},
+    },
+};
+
+pub struct Runtime {
+    sender: Sender<Request>,
+}
+
+impl Runtime {
+    pub fn new(timer: SharedTimer) -> Self {
+        let (sender, receiver) = unbounded();
+        // TODO: Store the join handle
+        thread::spawn(move || {
+            'back_to_not_having_a_runtime: loop {
+                let mut runtime = loop {
+                    let message = receiver.recv().unwrap(); // TODO: No unwrap
+                    match message {
+                        Request::LoadScript(script) => {
+                            break ScriptRuntime::new(&script).unwrap();
+                            // TODO: Send back result instead of unwrapping
+                        }
+                        Request::UnloadScript => {
+                            // TODO: Nothing to do. Send back a result?
+                        }
+                    }
+                };
+                log::info!(target: "Auto Splitter", "Loaded script");
+                loop {
+                    // TODO: Handle the different kinds of errors here, such as
+                    // needing to end
+                    if let Ok(message) = receiver.try_recv() {
+                        match message {
+                            Request::LoadScript(script) => {
+                                runtime = ScriptRuntime::new(&script).unwrap();
+                                log::info!(target: "Auto Splitter", "Loaded script");
+                                // TODO: Send back result instead of unwrapping
+                            }
+                            Request::UnloadScript => {
+                                log::info!(target: "Auto Splitter", "Unloaded script");
+                                continue 'back_to_not_having_a_runtime;
+                            }
+                        }
+                    }
+                    let phase = timer.read().current_phase();
+                    runtime.set_state(match phase {
+                        TimerPhase::NotRunning => TimerState::NotRunning,
+                        TimerPhase::Running | TimerPhase::Paused => TimerState::Running,
+                        TimerPhase::Ended => TimerState::Finished,
+                    });
+                    // TODO: No unwrap
+                    let action = match runtime.step() {
+                        Ok(action) => action,
+                        Err(e) => {
+                            log::error!(target: "Auto Splitter", "Unloaded the auto splitter because it failed executing: {}", e);
+                            continue 'back_to_not_having_a_runtime;
+                        }
+                    };
+                    for (key, value) in runtime.drain_variable_changes() {
+                        timer.write().set_custom_variable(key, value);
+                    }
+                    if let Some(is_loading) = runtime.is_loading() {
+                        if is_loading {
+                            timer.write().pause_game_time();
+                        } else {
+                            timer.write().resume_game_time();
+                        }
+                    }
+                    if let Some(game_time) = runtime.game_time() {
+                        timer
+                            .write()
+                            .set_game_time(TimeSpan::from_seconds(game_time));
+                    }
+                    if let Some(action) = action {
+                        let mut timer = timer.write();
+                        match action {
+                            TimerAction::Start => timer.start(),
+                            TimerAction::Split => timer.split(),
+                            TimerAction::Reset => timer.reset(true),
+                        }
+                    }
+                    runtime.sleep();
+                }
+            }
+        });
+
+        Self { sender }
+    }
+
+    // TODO: Fix this error type
+    // TODO: Futures based API
+    pub fn load_script(&self, script: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        // TODO: unwrap
+        self.sender.send(Request::LoadScript(script)).unwrap();
+        // TODO: receive result
+        Ok(())
+    }
+
+    pub fn unload_script(&self) -> Result<(), Box<dyn Error>> {
+        // TODO: unwrap
+        self.sender.send(Request::UnloadScript).unwrap();
+        // TODO: receive result
+        Ok(())
+    }
+}
+
+enum Request {
+    LoadScript(Vec<u8>),
+    UnloadScript,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ macro_rules! catch {
 }
 
 pub mod analysis;
+#[cfg(feature = "auto-splitting")]
+pub mod auto_splitting;
 pub mod clear_vec;
 pub mod comparison;
 pub mod component;


### PR DESCRIPTION
This adds a crate called `livesplit-exec` which is a small tool needed for Auto Splitting to work correctly on Linux.

A script called `build.sh` is provided for convenience but I can remove this if desired.