### PR TITLE
Fixing hotkey drops in Linux

### DIFF
--- a/capi/src/hotkey_system.rs
+++ b/capi/src/hotkey_system.rs
@@ -40,15 +40,15 @@ pub extern "C" fn HotkeySystem_drop(this: OwnedHotkeySystem) {
 /// Deactivates the Hotkey System. No hotkeys will go through until it gets
 /// activated again. If it's already deactivated, nothing happens.
 #[no_mangle]
-pub extern "C" fn HotkeySystem_deactivate(this: &mut HotkeySystem) {
-    this.deactivate();
+pub extern "C" fn HotkeySystem_deactivate(this: &mut HotkeySystem) -> bool {
+    this.deactivate().is_ok()
 }
 
 /// Activates a previously deactivated Hotkey System. If it's already
 /// active, nothing happens.
 #[no_mangle]
-pub extern "C" fn HotkeySystem_activate(this: &mut HotkeySystem) {
-    this.activate();
+pub extern "C" fn HotkeySystem_activate(this: &mut HotkeySystem) -> bool {
+    this.activate().is_ok()
 }
 
 /// Returns the hotkey configuration currently in use by the Hotkey System.

--- a/capi/src/hotkey_system.rs
+++ b/capi/src/hotkey_system.rs
@@ -40,14 +40,14 @@ pub extern "C" fn HotkeySystem_drop(this: OwnedHotkeySystem) {
 /// Deactivates the Hotkey System. No hotkeys will go through until it gets
 /// activated again. If it's already deactivated, nothing happens.
 #[no_mangle]
-pub extern "C" fn HotkeySystem_deactivate(this: &HotkeySystem) {
+pub extern "C" fn HotkeySystem_deactivate(this: &mut HotkeySystem) {
     this.deactivate();
 }
 
 /// Activates a previously deactivated Hotkey System. If it's already
 /// active, nothing happens.
 #[no_mangle]
-pub extern "C" fn HotkeySystem_activate(this: &HotkeySystem) {
+pub extern "C" fn HotkeySystem_activate(this: &mut HotkeySystem) {
     this.activate();
 }
 

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -18,7 +18,7 @@ winapi = { version = "0.3.2", features = [
 parking_lot = { version = "0.11.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-x11-dl = { version = "2.18.3", optional = true }
+x11-dl = { version = "2.18.5", optional = true }
 mio = { version = "0.6.16", optional = true }
 promising-future = { version = "0.2.4", optional = true }
 

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -5,15 +5,15 @@ use mio::unix::EventedFd;
 use mio::{Events, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
 use promising_future::{future_promise, Promise};
 use std::collections::hash_map::{Entry, HashMap};
-use std::os::raw::{c_int, c_uint, c_ulong};
+use std::os::raw::{c_int, c_uint};
 use std::sync::mpsc::{channel, Sender};
 use std::thread::{self, JoinHandle};
 use std::{mem, ptr};
 use x11_dl::xlib::{
-    Display, GrabModeAsync, KeyPress, KeyPressMask, Mod2Mask, XErrorEvent, XKeyEvent, Xlib,
+    Display, GrabModeAsync, AnyKey, KeyPress, AnyModifier, XErrorEvent, XKeyEvent, Xlib,
 };
 
-#[derive(Debug, snafu::Snafu)]
+#[derive(Debug,Copy,Clone, snafu::Snafu)]
 pub enum Error {
     NoXLib,
     OpenXServerConnection,
@@ -35,6 +35,10 @@ enum Message {
     End,
 }
 
+const X_TOKEN: Token = Token(0);
+const PING_TOKEN: Token = Token(1);
+
+
 pub struct Hook {
     sender: Sender<Message>,
     ping: SetReadiness,
@@ -52,9 +56,27 @@ impl Drop for Hook {
     }
 }
 
-unsafe fn unregister(xlib: &Xlib, display: *mut Display, window: c_ulong, code: c_uint) {
-    (xlib.XUngrabKey)(display, code as _, 0, window);
-    (xlib.XUngrabKey)(display, code as _, Mod2Mask, window);
+unsafe fn ungrab_all(xlib: &Xlib, display: *mut Display) {
+    let screencount = (xlib.XScreenCount)(display);
+    for screen in 0..screencount {
+        let rootwindow = (xlib.XRootWindow)(display, screen);
+        for _i in 0..rootwindow {
+            // FIXME: This loop looks very stupid, but it somehow it prevents
+            // button presses getting lost.
+            (xlib.XUngrabKey)(display, AnyKey, AnyModifier, rootwindow);
+        }
+    }
+}
+
+unsafe fn grab_all(xlib: &Xlib, display: *mut Display, keylist: Vec<c_uint>) {
+    ungrab_all(xlib, display);
+    let screencount = (xlib.XScreenCount)(display);
+    for screen in 0..screencount {
+        let rootwindow = (xlib.XRootWindow)(display, screen);
+        for code in &keylist {
+            (xlib.XGrabKey)(display, *code as _, AnyModifier, rootwindow, false as _, GrabModeAsync, GrabModeAsync);
+        }
+    }
 }
 
 unsafe extern "C" fn handle_error(_: *mut Display, _: *mut XErrorEvent) -> c_int {
@@ -74,16 +96,10 @@ impl Hook {
                 return Err(Error::OpenXServerConnection);
             }
 
-            let window = (xlib.XDefaultRootWindow)(display);
-            (xlib.XSelectInput)(display, window, KeyPressMask);
-
             let fd = (xlib.XConnectionNumber)(display);
             let poll = Poll::new().map_err(|_| Error::EPoll)?;
 
             let (registration, ping) = Registration::new2();
-
-            const X_TOKEN: Token = Token(0);
-            const PING_TOKEN: Token = Token(1);
 
             poll.register(
                 &EventedFd(&fd),
@@ -101,12 +117,12 @@ impl Hook {
             )
             .map_err(|_| Error::EPoll)?;
 
-            struct XData(Xlib, *mut Display, c_ulong);
+            struct XData(Xlib, *mut Display);
             unsafe impl Send for XData {}
-            let xdata = XData(xlib, display, window);
+            let xdata = XData(xlib, display);
 
             let join_handle = thread::spawn(move || -> Result<()> {
-                let XData(xlib, display, window) = xdata;
+                let XData(xlib, display) = xdata;
 
                 let mut result = Ok(());
                 let mut events = Events::with_capacity(1024);
@@ -127,42 +143,24 @@ impl Hook {
                                             (xlib.XKeysymToKeycode)(display, key as _) as c_uint;
 
                                         if let Entry::Vacant(vacant) = hotkeys.entry(code) {
-                                            (xlib.XGrabKey)(
-                                                display,
-                                                code as _,
-                                                0,
-                                                window,
-                                                false as _,
-                                                GrabModeAsync,
-                                                GrabModeAsync,
-                                            );
-
-                                            (xlib.XGrabKey)(
-                                                display,
-                                                code as _,
-                                                Mod2Mask,
-                                                window,
-                                                false as _,
-                                                GrabModeAsync,
-                                                GrabModeAsync,
-                                            );
-
                                             vacant.insert(callback);
                                             promise.set(Ok(()));
                                         } else {
                                             promise.set(Err(Error::AlreadyRegistered));
                                         }
+                                        let keys = hotkeys.keys().map(|x| *x).collect();
+                                        grab_all(&xlib, display, keys);
                                     }
                                     Message::Unregister(key, promise) => {
-                                        let code =
-                                            (xlib.XKeysymToKeycode)(display, key as _) as c_uint;
+                                        let code = (xlib.XKeysymToKeycode)(display, key as _) as c_uint;
 
                                         if hotkeys.remove(&code).is_some() {
-                                            unregister(&xlib, display, window, code);
                                             promise.set(Ok(()));
                                         } else {
                                             promise.set(Err(Error::NotRegistered));
                                         }
+                                        let keys = hotkeys.keys().map(|x| *x).collect();
+                                        grab_all(&xlib, display, keys);
                                     }
                                     Message::End => {
                                         break 'event_loop;
@@ -179,15 +177,15 @@ impl Hook {
                                     if let Some(callback) = hotkeys.get_mut(&event.keycode) {
                                         callback();
                                     }
+                                    // FIXME: We should check else here: these amount to lost
+                                    // keypresses.
                                 }
                             }
                         }
                     }
                 }
 
-                for (code, _) in hotkeys {
-                    unregister(&xlib, display, window, code);
-                }
+                ungrab_all(&xlib, display);
 
                 (xlib.XCloseDisplay)(display);
 

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -237,9 +237,16 @@ impl Hook {
 #[test]
 fn test() {
     let hook = Hook::new().unwrap();
-    hook.register(KeyCode::NumPad0, || println!("A")).unwrap();
+    hook.register(KeyCode::NumPad1, || println!("A")).unwrap();
+    println!("Press NumPad1");
     thread::sleep(std::time::Duration::from_secs(5));
-    hook.unregister(KeyCode::NumPad0).unwrap();
-    hook.register(KeyCode::NumPad1, || println!("B")).unwrap();
+    hook.unregister(KeyCode::NumPad1).unwrap();
+    hook.register(KeyCode::NumPad4, || println!("B")).unwrap();
+    println!("Press NumPad4");
     thread::sleep(std::time::Duration::from_secs(5));
+    hook.unregister(KeyCode::NumPad4).unwrap();
+    hook.register(KeyCode::NumPad1, || println!("C")).unwrap();
+    println!("Press NumPad1");
+    thread::sleep(std::time::Duration::from_secs(5));
+    hook.unregister(KeyCode::NumPad1).unwrap();
 }

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -155,7 +155,7 @@ impl Hook {
                                         } else {
                                             promise.set(Err(Error::AlreadyRegistered));
                                         }
-                                        let keys = hotkeys.keys().map(|x| *x).collect();
+                                        let keys = hotkeys.keys().copied().collect();
                                         grab_all(&xlib, display, keys);
                                     }
                                     Message::Unregister(key, promise) => {
@@ -167,7 +167,7 @@ impl Hook {
                                         } else {
                                             promise.set(Err(Error::NotRegistered));
                                         }
-                                        let keys = hotkeys.keys().map(|x| *x).collect();
+                                        let keys = hotkeys.keys().copied().collect();
                                         grab_all(&xlib, display, keys);
                                     }
                                     Message::End => {

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -10,10 +10,10 @@ use std::sync::mpsc::{channel, Sender};
 use std::thread::{self, JoinHandle};
 use std::{mem, ptr};
 use x11_dl::xlib::{
-    Display, GrabModeAsync, AnyKey, KeyPress, AnyModifier, XErrorEvent, XKeyEvent, Xlib,
+    AnyKey, AnyModifier, Display, GrabModeAsync, KeyPress, XErrorEvent, XKeyEvent, Xlib,
 };
 
-#[derive(Debug,Copy,Clone, snafu::Snafu)]
+#[derive(Debug, Copy, Clone, snafu::Snafu)]
 pub enum Error {
     NoXLib,
     OpenXServerConnection,
@@ -37,7 +37,6 @@ enum Message {
 
 const X_TOKEN: Token = Token(0);
 const PING_TOKEN: Token = Token(1);
-
 
 pub struct Hook {
     sender: Sender<Message>,
@@ -74,7 +73,15 @@ unsafe fn grab_all(xlib: &Xlib, display: *mut Display, keylist: Vec<c_uint>) {
     for screen in 0..screencount {
         let rootwindow = (xlib.XRootWindow)(display, screen);
         for code in &keylist {
-            (xlib.XGrabKey)(display, *code as _, AnyModifier, rootwindow, false as _, GrabModeAsync, GrabModeAsync);
+            (xlib.XGrabKey)(
+                display,
+                *code as _,
+                AnyModifier,
+                rootwindow,
+                false as _,
+                GrabModeAsync,
+                GrabModeAsync,
+            );
         }
     }
 }
@@ -152,7 +159,8 @@ impl Hook {
                                         grab_all(&xlib, display, keys);
                                     }
                                     Message::Unregister(key, promise) => {
-                                        let code = (xlib.XKeysymToKeycode)(display, key as _) as c_uint;
+                                        let code =
+                                            (xlib.XKeysymToKeycode)(display, key as _) as c_uint;
 
                                         if hotkeys.remove(&code).is_some() {
                                             promise.set(Ok(()));

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -1,9 +1,73 @@
 use crate::hotkey::{Hook, KeyCode};
 use crate::{HotkeyConfig, SharedTimer};
-use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use crate::hotkey::{Error, Result};
+
+// This enum might be better situated in hotkey_config, but the last method should stay in this file
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Hotkey {
+    Split,
+    /// The key to use for resetting the current attempt.
+    Reset,
+    /// The key to use for undoing the last split.
+    Undo,
+    /// The key to use for skipping the current split.
+    Skip,
+    /// The key to use for pausing the current attempt and starting a new
+    /// attempt.
+    Pause,
+    /// The key to use for removing all the pause times from the current time.
+    UndoAllPauses,
+    /// The key to use for switching to the previous comparison.
+    PreviousComparison,
+    /// The key to use for switching to the next comparison.
+    NextComparison,
+    /// The key to use for toggling between the `Real Time` and `Game Time`
+    /// timing methods.
+    ToggleTimingMethod,
+}
+
+impl Hotkey {
+    fn set_keycode(self, config: &mut HotkeyConfig, keycode: Option<KeyCode>) {
+        match self {
+            Hotkey::Split => config.split = keycode,
+            Hotkey::Reset => config.reset = keycode,
+            Hotkey::Undo => config.undo = keycode,
+            Hotkey::Skip => config.skip = keycode,
+            Hotkey::Pause => config.pause = keycode,
+            Hotkey::UndoAllPauses => config.undo_all_pauses = keycode,
+            Hotkey::PreviousComparison => config.previous_comparison = keycode,
+            Hotkey::NextComparison => config.next_comparison = keycode,
+            Hotkey::ToggleTimingMethod => config.toggle_timing_method = keycode,
+        }
+    }
+    fn get_keycode(self, config: &HotkeyConfig) -> Option<KeyCode> {
+        match self {
+            Hotkey::Split => config.split,
+            Hotkey::Reset => config.reset,
+            Hotkey::Undo => config.undo,
+            Hotkey::Skip => config.skip,
+            Hotkey::Pause => config.pause,
+            Hotkey::UndoAllPauses => config.undo_all_pauses,
+            Hotkey::PreviousComparison => config.previous_comparison,
+            Hotkey::NextComparison => config.next_comparison,
+            Hotkey::ToggleTimingMethod => config.toggle_timing_method,
+        }
+    }
+    fn callback(self, timer: SharedTimer) -> Box<dyn FnMut() + Send + 'static>{
+        match self {
+            Hotkey::Split => Box::new(move || timer.write().split_or_start()),
+            Hotkey::Reset => Box::new(move || timer.write().reset(true)),
+            Hotkey::Undo => Box::new(move || timer.write().undo_split()),
+            Hotkey::Skip => Box::new(move || timer.write().skip_split()),
+            Hotkey::Pause => Box::new(move || timer.write().toggle_pause_or_start()),
+            Hotkey::UndoAllPauses => Box::new(move || timer.write().undo_all_pauses()),
+            Hotkey::PreviousComparison => Box::new(move || timer.write().switch_to_previous_comparison()),
+            Hotkey::NextComparison => Box::new(move || timer.write().switch_to_next_comparison()),
+            Hotkey::ToggleTimingMethod => Box::new(move || timer.write().toggle_timing_method()),
+        }
+    }
+}
 
 /// With a Hotkey System the runner can use hotkeys on their keyboard to control
 /// the Timer. The hotkeys are global, so the application doesn't need to be in
@@ -14,7 +78,7 @@ pub struct HotkeySystem {
     config: HotkeyConfig,
     hook: Hook,
     timer: SharedTimer,
-    is_active: Arc<AtomicBool>,
+    is_active: bool,
 }
 
 impl HotkeySystem {
@@ -26,310 +90,145 @@ impl HotkeySystem {
     /// Creates a new Hotkey System for a Timer with a custom configuration for
     /// the hotkeys.
     pub fn with_config(timer: SharedTimer, config: HotkeyConfig) -> Result<Self> {
-        let hook = Hook::new()?;
-
-        let is_active = Arc::new(AtomicBool::new(true));
-
-        if let Some(split) = config.split {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(split, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().split_or_start();
-                }
-            })?;
+        let mut hotkey_system = Self {
+            config : config,
+            hook : Hook::new()?,
+            timer : timer,
+            is_active : false,
+        };
+        hotkey_system.activate()?;
+        Ok(hotkey_system)
+    }
+    // This method should never be public, because it might mess up the internal state and we might
+    // leak a registered hotkey
+    unsafe fn register_raw(&mut self, hotkey: Hotkey) -> Result<()> {
+        let inner = self.timer.clone();
+        if let Some(keycode) = hotkey.get_keycode(&self.config) {
+            println!("Registering Keycode {:?} as {:?}", keycode, hotkey);
+            self.hook.register(keycode, hotkey.callback(inner))?;
         }
-
-        if let Some(reset) = config.reset {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(reset, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().reset(true);
-                }
-            })?;
+        Ok(())
+    }
+    fn register(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {
+        hotkey.set_keycode(&mut self.config, keycode);
+        unsafe { self.register_raw(hotkey) }
+    }
+    // This method should never be public, because it might mess up the internal state and we might
+    // leak a registered hotkey
+    unsafe fn unregister_raw(&mut self, hotkey: Hotkey) -> Result<()> {
+        if let Some(keycode) = hotkey.get_keycode(&self.config) {
+            println!("Unregistering Keycode {:?} as {:?}", keycode, hotkey);
+            self.hook.unregister(keycode)?;
         }
-
-        if let Some(undo) = config.undo {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(undo, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().undo_split();
-                }
-            })?;
+        Ok(())
+    }
+    fn unregister(&mut self, hotkey: Hotkey) -> Result<()> {
+        hotkey.set_keycode(&mut self.config, None);
+        unsafe { self.unregister_raw(hotkey) }
+    }
+    fn set_hotkey(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {
+        // FixMe: We do not check whether the keycode is already in use
+        if hotkey.get_keycode(&self.config) == keycode {
+            return Ok(());
         }
-
-        if let Some(skip) = config.skip {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(skip, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().skip_split();
-                }
-            })?;
+        if self.is_active {
+            self.unregister(hotkey)?;
+            self.register(hotkey, keycode)?;
         }
-
-        if let Some(pause) = config.pause {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(pause, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().toggle_pause_or_start();
-                }
-            })?;
-        }
-
-        if let Some(previous_comparison) = config.previous_comparison {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(previous_comparison, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().switch_to_previous_comparison();
-                }
-            })?;
-        }
-
-        if let Some(next_comparison) = config.next_comparison {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(next_comparison, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().switch_to_next_comparison();
-                }
-            })?;
-        }
-
-        if let Some(undo_all_pauses) = config.undo_all_pauses {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(undo_all_pauses, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().undo_all_pauses();
-                }
-            })?;
-        }
-
-        if let Some(toggle_timing_method) = config.toggle_timing_method {
-            let inner = timer.clone();
-            let active = is_active.clone();
-            hook.register(toggle_timing_method, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().toggle_timing_method();
-                }
-            })?;
-        }
-
-        Ok(Self {
-            config,
-            hook,
-            timer,
-            is_active,
-        })
+        Ok(())
     }
 
     /// Sets the key to use for splitting and starting a new attempt.
     pub fn set_split(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.split == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().split_or_start();
-                }
-            })?;
-        }
-        if let Some(split) = self.config.split {
-            self.hook.unregister(split)?;
-        }
-        self.config.split = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::Split, hotkey)
     }
 
     /// Sets the key to use for resetting the current attempt.
     pub fn set_reset(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.reset == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().reset(true);
-                }
-            })?;
-        }
-        if let Some(reset) = self.config.reset {
-            self.hook.unregister(reset)?;
-        }
-        self.config.reset = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::Reset, hotkey)
     }
 
     /// Sets the key to use for pausing the current attempt and starting a new
     /// attempt.
     pub fn set_pause(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.pause == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().toggle_pause_or_start();
-                }
-            })?;
-        }
-        if let Some(pause) = self.config.pause {
-            self.hook.unregister(pause)?;
-        }
-        self.config.pause = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::Pause, hotkey)
     }
 
     /// Sets the key to use for skipping the current split.
     pub fn set_skip(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.skip == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().skip_split();
-                }
-            })?;
-        }
-        if let Some(skip) = self.config.skip {
-            self.hook.unregister(skip)?;
-        }
-        self.config.skip = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::Skip, hotkey)
     }
 
     /// Sets the key to use for undoing the last split.
     pub fn set_undo(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.undo == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().undo_split();
-                }
-            })?;
-        }
-        if let Some(undo) = self.config.undo {
-            self.hook.unregister(undo)?;
-        }
-        self.config.undo = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::Undo, hotkey)
     }
 
     /// Sets the key to use for switching to the previous comparison.
     pub fn set_previous_comparison(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.previous_comparison == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().switch_to_previous_comparison();
-                }
-            })?;
-        }
-        if let Some(previous_comparison) = self.config.previous_comparison {
-            self.hook.unregister(previous_comparison)?;
-        }
-        self.config.previous_comparison = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::PreviousComparison, hotkey)
     }
 
     /// Sets the key to use for switching to the next comparison.
     pub fn set_next_comparison(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.next_comparison == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().switch_to_next_comparison();
-                }
-            })?;
-        }
-        if let Some(next_comparison) = self.config.next_comparison {
-            self.hook.unregister(next_comparison)?;
-        }
-        self.config.next_comparison = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::NextComparison, hotkey)
     }
 
     /// Sets the key to use for removing all the pause times from the current
     /// time.
     pub fn set_undo_all_pauses(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.undo_all_pauses == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().undo_all_pauses();
-                }
-            })?;
-        }
-        if let Some(undo_all_pauses) = self.config.undo_all_pauses {
-            self.hook.unregister(undo_all_pauses)?;
-        }
-        self.config.undo_all_pauses = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::UndoAllPauses, hotkey)
     }
 
     /// Sets the key to use for toggling between the `Real Time` and `Game Time`
     /// timing methods.
     pub fn set_toggle_timing_method(&mut self, hotkey: Option<KeyCode>) -> Result<()> {
-        if self.config.toggle_timing_method == hotkey {
-            return Ok(());
-        }
-        let inner = self.timer.clone();
-        let active = self.is_active.clone();
-        if let Some(hotkey) = hotkey {
-            self.hook.register(hotkey, move || {
-                if active.load(Ordering::Acquire) {
-                    inner.write().toggle_timing_method();
-                }
-            })?;
-        }
-        if let Some(toggle_timing_method) = self.config.toggle_timing_method {
-            self.hook.unregister(toggle_timing_method)?;
-        }
-        self.config.toggle_timing_method = hotkey;
-        Ok(())
+        self.set_hotkey(Hotkey::ToggleTimingMethod, hotkey)
     }
 
     /// Deactivates the Hotkey System. No hotkeys will go through until it gets
     /// activated again. If it's already deactivated, nothing happens.
-    pub fn deactivate(&self) {
-        self.is_active.store(false, Ordering::Release);
+    pub fn deactivate(&mut self) -> Result<()> {
+        if self.is_active {
+            unsafe {
+                self.unregister_raw(Hotkey::Split)?;
+                self.unregister_raw(Hotkey::Reset)?;
+                self.unregister_raw(Hotkey::Undo)?;
+                self.unregister_raw(Hotkey::Skip)?;
+                self.unregister_raw(Hotkey::Pause)?;
+                self.unregister_raw(Hotkey::UndoAllPauses)?;
+                self.unregister_raw(Hotkey::PreviousComparison)?;
+                self.unregister_raw(Hotkey::NextComparison)?;
+                self.unregister_raw(Hotkey::ToggleTimingMethod)?;
+            }
+        }
+        self.is_active = false;
+        Ok(())
     }
 
     /// Activates a previously deactivated Hotkey System. If it's already
     /// active, nothing happens.
-    pub fn activate(&self) {
-        self.is_active.store(true, Ordering::Release);
+    pub fn activate(&mut self) -> Result<()> {
+        if !self.is_active {
+            unsafe {
+                self.register_raw(Hotkey::Split)?;
+                self.register_raw(Hotkey::Reset)?;
+                self.register_raw(Hotkey::Undo)?;
+                self.register_raw(Hotkey::Skip)?;
+                self.register_raw(Hotkey::Pause)?;
+                self.register_raw(Hotkey::UndoAllPauses)?;
+                self.register_raw(Hotkey::PreviousComparison)?;
+                self.register_raw(Hotkey::NextComparison)?;
+                self.register_raw(Hotkey::ToggleTimingMethod)?;
+            }
+        }
+        self.is_active = true;
+        Ok(())
+    }
+
+    /// Returns true if the Hotkey System is active, false otherwise.
+    pub fn is_active(&self) -> bool {
+        self.is_active
     }
 
     /// Returns the hotkey configuration currently in use by the Hotkey System.

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -93,9 +93,9 @@ impl HotkeySystem {
     /// the hotkeys.
     pub fn with_config(timer: SharedTimer, config: HotkeyConfig) -> Result<Self> {
         let mut hotkey_system = Self {
-            config: config,
+            config,
             hook: Hook::new()?,
-            timer: timer,
+            timer,
             is_active: false,
         };
         hotkey_system.activate()?;

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -106,7 +106,6 @@ impl HotkeySystem {
     unsafe fn register_raw(&mut self, hotkey: Hotkey) -> Result<()> {
         let inner = self.timer.clone();
         if let Some(keycode) = hotkey.get_keycode(&self.config) {
-            println!("Registering Keycode {:?} as {:?}", keycode, hotkey);
             self.hook.register(keycode, hotkey.callback(inner))?;
         }
         Ok(())
@@ -119,7 +118,6 @@ impl HotkeySystem {
     // leak a registered hotkey
     unsafe fn unregister_raw(&mut self, hotkey: Hotkey) -> Result<()> {
         if let Some(keycode) = hotkey.get_keycode(&self.config) {
-            println!("Unregistering Keycode {:?} as {:?}", keycode, hotkey);
             self.hook.unregister(keycode)?;
         }
         Ok(())

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -54,7 +54,7 @@ impl Hotkey {
             Hotkey::ToggleTimingMethod => config.toggle_timing_method,
         }
     }
-    fn callback(self, timer: SharedTimer) -> Box<dyn FnMut() + Send + 'static>{
+    fn callback(self, timer: SharedTimer) -> Box<dyn FnMut() + Send + 'static> {
         match self {
             Hotkey::Split => Box::new(move || timer.write().split_or_start()),
             Hotkey::Reset => Box::new(move || timer.write().reset(true)),
@@ -62,7 +62,9 @@ impl Hotkey {
             Hotkey::Skip => Box::new(move || timer.write().skip_split()),
             Hotkey::Pause => Box::new(move || timer.write().toggle_pause_or_start()),
             Hotkey::UndoAllPauses => Box::new(move || timer.write().undo_all_pauses()),
-            Hotkey::PreviousComparison => Box::new(move || timer.write().switch_to_previous_comparison()),
+            Hotkey::PreviousComparison => {
+                Box::new(move || timer.write().switch_to_previous_comparison())
+            }
             Hotkey::NextComparison => Box::new(move || timer.write().switch_to_next_comparison()),
             Hotkey::ToggleTimingMethod => Box::new(move || timer.write().toggle_timing_method()),
         }
@@ -91,10 +93,10 @@ impl HotkeySystem {
     /// the hotkeys.
     pub fn with_config(timer: SharedTimer, config: HotkeyConfig) -> Result<Self> {
         let mut hotkey_system = Self {
-            config : config,
-            hook : Hook::new()?,
-            timer : timer,
-            is_active : false,
+            config: config,
+            hook: Hook::new()?,
+            timer: timer,
+            is_active: false,
         };
         hotkey_system.activate()?;
         Ok(hotkey_system)


### PR DESCRIPTION
This PR addresses issue #302 .
hotkey_system.rs was rewritten so that the activation and deactivation of the hotkey system registers and unregisters the grabbing of the keys. Moreover, I added an (private) enum Hotkey that makes it possible to reduce the large amount of copy&paste code.
In the livesplit-hotkey crate, the linux module was slightly modified: the old functions register and unregister were replaced by
grab_all and ungrab_all. Also the window number is now calculated in grab_all and ungrab_all, which simplifies the Hook methods slightly.

I think that we should get rid of the set_split(keycode), set_skip, etc methods and instead make enum Hotkey public and use set_hotkey(hotkey,keycode) instead.