### PR TITLE
Upgrade to Tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ euc = { version = "0.5.2", default-features = false, features = ["libm"], option
 vek = { version = "0.12.1", default-features = false, features = ["libm"], optional = true }
 
 # Networking
-splits-io-api = { version = "0.1.2", optional = true }
+splits-io-api = { version = "0.2.0", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 # WebAssembly in the Web

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ img_hash = "3.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.3.0"
-tokio = { version = "1.0", features = ["macros"] }
 
 [features]
 default = ["image-shrinking", "std"]


### PR DESCRIPTION
All of our dependencies have been upgraded by now. There's not a lot we need to change here, as we delegate all the work to other crates.