### PR TITLE
Add ARM macOS target to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -468,7 +468,7 @@ jobs:
 
           # macOS
           - label: macOS aarch64
-            toolchain: stable-aarch64-apple-darwin
+            target: aarch64-apple-darwin
             os: macOS-latest
             cross: skip
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -469,12 +469,11 @@ jobs:
           # macOS
           - label: macOS aarch64
             target: aarch64-apple-darwin
-            os: macOS-11.0
+            os: macOS-latest
             cross: skip
             tests: skip
             install_target: true
-          # FIXME: Switch OS back to latest once that means 11.
-          # FIXME: Switch OS to ARM macOS once GitHub Actions provides that, 
+          # FIXME: Switch OS to ARM macOS once GitHub Actions provides that,
           # use the toolchain instead of the target and run the tests.
 
           - label: macOS x86_64
@@ -615,6 +614,13 @@ jobs:
         run: sh .github/workflows/install.sh
         env:
           OS_NAME: ${{ matrix.os }}
+          TARGET: ${{ matrix.target }}
+
+      - name: Select XCode to use
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_12.3.app"
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
 
       - name: Build Static Library
         run: sh .github/workflows/build_static.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -469,10 +469,13 @@ jobs:
           # macOS
           - label: macOS aarch64
             target: aarch64-apple-darwin
-            os: macOS-latest
+            os: macOS-11.0
             cross: skip
             tests: skip
             install_target: true
+          # FIXME: Switch OS back to latest once that means 11.
+          # FIXME: Switch OS to ARM macOS once GitHub Actions provides that, 
+          # use the toolchain instead of the target and run the tests.
 
           - label: macOS x86_64
             target: x86_64-apple-darwin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,7 @@ jobs:
           # - Linux sparc64
 
           # macOS
+          - macOS aarch64
           - macOS x86_64
 
           # iOS
@@ -466,6 +467,11 @@ jobs:
           #   tests: skip
 
           # macOS
+          - label: macOS aarch64
+            toolchain: stable-aarch64-apple-darwin
+            os: macOS-latest
+            cross: skip
+
           - label: macOS x86_64
             target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -471,6 +471,8 @@ jobs:
             target: aarch64-apple-darwin
             os: macOS-latest
             cross: skip
+            tests: skip
+            install_target: true
 
           - label: macOS x86_64
             target: x86_64-apple-darwin


### PR DESCRIPTION
Rust 1.49 just released with support for the new macs that use ARM CPUs. Let's add this to our CI.