### PR TITLE
Always add content after parentheses in extended category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.10", default-features = false, features = ["serde", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["not", "add", "from", "deref"] }
-hashbrown = "0.10.0"
+hashbrown = "0.9.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.5.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.1.0" }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -924,9 +924,7 @@ impl fmt::Display for ExtendedCategoryName<'_> {
         }
 
         if !after_parenthesis.is_empty() {
-            if has_pushed {
-                f.write_str(after_parenthesis)?;
-            }
+            f.write_str(after_parenthesis)?;
         } else if !is_empty {
             f.write_str(")")?;
         }

--- a/src/run/tests/extended_category_name.rs
+++ b/src/run/tests/extended_category_name.rs
@@ -1,0 +1,50 @@
+use crate::run::Run;
+
+#[test]
+fn no_parentheses() {
+    let mut run = Run::new();
+    run.set_category_name("100% Speedrun");
+
+    let name = run.extended_category_name(false, false, false).to_string();
+    assert_eq!(name, "100% Speedrun");
+}
+
+#[test]
+fn ends_with_parentheses() {
+    let mut run = Run::new();
+    run.set_category_name("Any% (No Tuner)");
+
+    let name = run.extended_category_name(false, false, false).to_string();
+    assert_eq!(name, "Any% (No Tuner)");
+}
+
+#[test]
+fn has_parentheses() {
+    let mut run = Run::new();
+    run.set_category_name("Any% (Tuner) Speedrun");
+
+    let name = run.extended_category_name(false, false, false).to_string();
+    assert_eq!(name, "Any% (Tuner) Speedrun");
+}
+
+#[test]
+fn no_parentheses_with_additional_info() {
+    let mut run = Run::new();
+    run.set_category_name("100% Speedrun");
+    let metadata = run.metadata_mut();
+    metadata.set_region_name("REGION");
+
+    let name = run.extended_category_name(true, false, false).to_string();
+    assert_eq!(name, "100% Speedrun (REGION)");
+}
+
+#[test]
+fn has_parentheses_with_additional_info() {
+    let mut run = Run::new();
+    run.set_category_name("Any% (Tuner) Speedrun");
+    let metadata = run.metadata_mut();
+    metadata.set_region_name("REGION");
+
+    let name = run.extended_category_name(true, false, false).to_string();
+    assert_eq!(name, "Any% (Tuner, REGION) Speedrun");
+}

--- a/src/run/tests/mod.rs
+++ b/src/run/tests/mod.rs
@@ -1,4 +1,5 @@
 mod comparison;
 mod empty_run;
+mod extended_category_name;
 mod fixing;
 mod metadata;


### PR DESCRIPTION
I'm not sure if I'm missing an edge case with this fix, but this should only impact situations where `has_pushed` is `false`, which only happens when no additional information is added to the extended category name.

Fix #391 