### PR TITLE
C API: Expose the Layout Editor's State.

### DIFF
--- a/capi/src/layout_editor.rs
+++ b/capi/src/layout_editor.rs
@@ -6,6 +6,7 @@
 use super::{output_vec, Json};
 use crate::component::OwnedComponent;
 use crate::layout::OwnedLayout;
+use crate::layout_editor_state::OwnedLayoutEditorState;
 use crate::setting_value::OwnedSettingValue;
 use livesplit_core::{LayoutEditor, Timer};
 
@@ -36,6 +37,12 @@ pub extern "C" fn LayoutEditor_state_as_json(this: &LayoutEditor) -> Json {
     output_vec(|o| {
         this.state().write_json(o).unwrap();
     })
+}
+
+/// Returns the state of the Layout Editor.
+#[no_mangle]
+pub extern "C" fn LayoutEditor_state(this: &LayoutEditor) -> OwnedLayoutEditorState {
+    Box::new(this.state())
 }
 
 /// Encodes the layout's state as JSON based on the timer provided. You can use

--- a/capi/src/layout_editor_state.rs
+++ b/capi/src/layout_editor_state.rs
@@ -1,0 +1,96 @@
+//! Represents the current state of the Layout Editor in order to visualize it properly.
+use crate::{c_char, output_str};
+use livesplit_core::{layout::editor::State as LayoutEditorState, settings::Value as SettingValue};
+
+/// type
+pub type OwnedLayoutEditorState = Box<LayoutEditorState>;
+/// type
+pub type NullableOwnedLayoutEditorState = Option<OwnedLayoutEditorState>;
+
+/// drop
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_drop(this: OwnedLayoutEditorState) {
+    drop(this);
+}
+
+/// Returns the number of components in the layout.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_component_len(this: &LayoutEditorState) -> usize {
+    this.components.len()
+}
+
+/// Returns the name of the component at the specified index.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_component_text(
+    this: &LayoutEditorState,
+    index: usize,
+) -> *const c_char {
+    output_str(&this.components[index])
+}
+
+/// Returns a bitfield corresponding to which buttons are active.
+///
+/// The bits are as follows:
+///
+/// * `0x04` - Can remove the current component
+/// * `0x02` - Can move the current component up
+/// * `0x01` - Can move the current component down
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_buttons(this: &LayoutEditorState) -> u8 {
+    this.buttons.can_remove as u8 * 0x4
+        | this.buttons.can_move_up as u8 * 0x2
+        | this.buttons.can_move_down as u8 * 0x1
+}
+
+/// Returns the index of the currently selected component.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_selected_component(this: &LayoutEditorState) -> u32 {
+    this.selected_component
+}
+
+/// Returns the number of fields in the layout's settings.
+///
+/// Set `component_settings` to true to use the selected component's settings instead.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_field_len(
+    this: &LayoutEditorState,
+    component_settings: bool,
+) -> usize {
+    if component_settings {
+        this.component_settings.fields.len()
+    } else {
+        this.general_settings.fields.len()
+    }
+}
+
+/// Returns the name of the layout's setting at the specified index.
+///
+/// Set `component_settings` to true to use the selected component's settings instead.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_field_text(
+    this: &LayoutEditorState,
+    component_settings: bool,
+    index: usize,
+) -> *const c_char {
+    if component_settings {
+        output_str(&this.component_settings.fields[index].text)
+    } else {
+        output_str(&this.general_settings.fields[index].text)
+    }
+}
+
+/// Returns the value of the layout's setting at the specified index.
+///
+/// Set `component_settings` to true to use the selected component's settings instead.
+#[no_mangle]
+pub extern "C" fn LayoutEditorState_field_value(
+    this: &LayoutEditorState,
+    component_settings: bool,
+    index: usize,
+) -> &SettingValue {
+    if component_settings {
+        &this.component_settings.fields[index].value
+    } else {
+        &this.general_settings.fields[index].value
+    }
+}

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -34,6 +34,7 @@ pub mod hotkey_system;
 pub mod key_value_component_state;
 pub mod layout;
 pub mod layout_editor;
+pub mod layout_editor_state;
 pub mod layout_state;
 pub mod parse_run_result;
 pub mod pb_chance_component;

--- a/capi/src/setting_value.rs
+++ b/capi/src/setting_value.rs
@@ -1,7 +1,7 @@
 //! Describes a setting's value. Such a value can be of a variety of different
 //! types.
 
-use crate::str;
+use crate::{output_vec, str, Json};
 use livesplit_core::{
     component::splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith},
     layout::LayoutDirection,
@@ -23,6 +23,14 @@ pub type NullableOwnedSettingValue = Option<OwnedSettingValue>;
 #[no_mangle]
 pub extern "C" fn SettingValue_drop(this: OwnedSettingValue) {
     drop(this);
+}
+
+/// Encodes this Setting Value's state as JSON.
+#[no_mangle]
+pub extern "C" fn SettingValue_as_json(this: &SettingValue) -> Json {
+    output_vec(|o| {
+        serde_json::to_writer(o, this).unwrap();
+    })
 }
 
 /// Creates a new setting value from a boolean value.


### PR DESCRIPTION
This really doesn't need too much explaining, but do note I went the route of exposing `SettingValue` as JSON to avoid having to create 20 different getter functions.