### PR TITLE
Don't read into uninitialized buffers

### DIFF
--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -137,9 +137,8 @@ fn read_string<R: Read>(
     if str_length as u64 > max_length {
         return Err(StringError::LengthOutOfBounds);
     }
-    buf.clear();
-    buf.reserve(str_length);
-    unsafe { buf.set_len(str_length) };
+    // FIXME: Read into uninitialized buffer when we can express this safely.
+    buf.resize(str_length, 0);
     source.read_exact(buf).context(ReadData)?;
     from_utf8(buf).context(Validate)
 }
@@ -240,9 +239,8 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
                 return Err(Error::InvalidIconDimensions { width, height });
             }
 
-            buf.clear();
-            buf.reserve(len);
-            unsafe { buf.set_len(len) };
+            // FIXME: Read into uninitialized buffer when we can express this safely.
+            buf.resize(len, 0);
             source.read_exact(&mut buf).context(ReadImageData)?;
 
             if let Some(image) = ImageBuffer::<Rgba<u8>, _>::from_raw(width, height, buf.as_slice())


### PR DESCRIPTION
For performance reasons we used to read into uninitialized buffers. However this is only safe if you can prove that you won't ever read from the uninitialized memory, which isn't possible in our case since we accept any reader that implements `std::io::Read`. There's no guarantee that the reader only fills our buffer and doesn't also try to read from it. It's unlikely that any reader will actually do that, but there's a slight possibility that we can't prove away. They are currently trying to address this in std, so that you can safely express this. For now we just fall back to zero initializing the buffer. The Llanfair parsing should be rare enough that this shouldn't matter all too much anyway. There are FIXMEs in the code now that someone can eventually fix once the safe reading into uninitialized buffers is possible.

Resolves #400