### PR TITLE
Remove `palette` and `odds` as dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,7 @@ hashbrown = "0.11.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.5.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.1.0" }
-odds = { version = "0.4.0", default-features = false }
 ordered-float = { version = "2.0.1", default-features = false }
-palette = { version = "0.5.0", default-features = false, features = ["libm"] }
 serde = { version = "1.0.98", default-features = false, features = ["derive", "alloc"] }
 smallstr = { version = "0.2.0", default-features = false }
 snafu = { version = "0.6.0", default-features = false }
@@ -83,7 +81,7 @@ criterion = "0.3.0"
 [features]
 default = ["image-shrinking", "std"]
 doesnt-have-atomics = []
-std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "palette/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
+std = ["byteorder", "chrono/std", "chrono/clock", "image", "indexmap", "livesplit-hotkey/std", "parking_lot", "quick-xml", "serde_json", "serde/std", "snafu/std", "utf-8"]
 more-image-formats = ["image/webp", "image/pnm", "image/ico", "image/jpeg", "image/tiff", "image/tga", "image/bmp", "image/hdr"]
 image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "ttf-parser", "rustybuzz", "bytemuck/derive"]

--- a/capi/src/analysis.rs
+++ b/capi/src/analysis.rs
@@ -2,10 +2,10 @@
 //! information about runs.
 
 use super::time_span::{NullableOwnedTimeSpan, OwnedTimeSpan};
-use livesplit_core::analysis::sum_of_segments::calculate_best;
-use livesplit_core::analysis::total_playtime::calculate;
-use livesplit_core::TimingMethod;
-use livesplit_core::{Run, Timer};
+use livesplit_core::{
+    analysis::{sum_of_segments::calculate_best, total_playtime::calculate},
+    Run, Timer, TimingMethod,
+};
 
 /// Calculates the Sum of Best Segments for the timing method provided. This is
 /// the fastest time possible to complete a run of a category, based on
@@ -24,12 +24,7 @@ pub extern "C" fn Analysis_calculate_sum_of_best(
     use_current_run: bool,
     method: TimingMethod,
 ) -> NullableOwnedTimeSpan {
-    if let Some(span) = calculate_best(run.segments(), simple_calculation, use_current_run, method)
-    {
-        Some(Box::new(span))
-    } else {
-        None
-    }
+    calculate_best(run.segments(), simple_calculation, use_current_run, method).map(Box::new)
 }
 
 /// Calculates the total playtime of the passed Run.

--- a/capi/src/attempt.rs
+++ b/capi/src/attempt.rs
@@ -3,8 +3,7 @@
 //! then reset, an Attempt describing general information about it is created.
 
 use super::{output_time, output_time_span};
-use crate::atomic_date_time::NullableOwnedAtomicDateTime;
-use crate::time_span::NullableTimeSpan;
+use crate::{atomic_date_time::NullableOwnedAtomicDateTime, time_span::NullableTimeSpan};
 use livesplit_core::{Attempt, Time};
 use std::ptr;
 
@@ -42,20 +41,12 @@ pub extern "C" fn Attempt_pause_time(this: &Attempt) -> *const NullableTimeSpan 
 /// if this information is not known.
 #[no_mangle]
 pub extern "C" fn Attempt_started(this: &Attempt) -> NullableOwnedAtomicDateTime {
-    if let Some(date_time) = this.started() {
-        Some(Box::new(date_time))
-    } else {
-        None
-    }
+    this.started().map(Box::new)
 }
 
 /// Accesses the point in time the attempt was ended at. This returns <NULL> if
 /// this information is not known.
 #[no_mangle]
 pub extern "C" fn Attempt_ended(this: &Attempt) -> NullableOwnedAtomicDateTime {
-    if let Some(date_time) = this.ended() {
-        Some(Box::new(date_time))
-    } else {
-        None
-    }
+    this.ended().map(Box::new)
 }

--- a/capi/src/setting_value.rs
+++ b/capi/src/setting_value.rs
@@ -147,7 +147,7 @@ pub extern "C" fn SettingValue_from_optional_empty_timing_method() -> OwnedSetti
 /// Creates a new setting value from the color provided as RGBA.
 #[no_mangle]
 pub extern "C" fn SettingValue_from_color(r: f32, g: f32, b: f32, a: f32) -> OwnedSettingValue {
-    Box::new(Color::from((r, g, b, a)).into())
+    Box::new(Color::rgba(r, g, b, a).into())
 }
 
 /// Creates a new setting value from the color provided as RGBA with the type
@@ -159,7 +159,7 @@ pub extern "C" fn SettingValue_from_optional_color(
     b: f32,
     a: f32,
 ) -> OwnedSettingValue {
-    Box::new(Some(Color::from((r, g, b, a))).into())
+    Box::new(Some(Color::rgba(r, g, b, a)).into())
 }
 
 /// Creates a new empty setting value with the type `optional color`.
@@ -186,9 +186,7 @@ pub extern "C" fn SettingValue_from_vertical_gradient(
     b2: f32,
     a2: f32,
 ) -> OwnedSettingValue {
-    Box::new(
-        Gradient::Vertical(Color::from((r1, g1, b1, a1)), Color::from((r2, g2, b2, a2))).into(),
-    )
+    Box::new(Gradient::Vertical(Color::rgba(r1, g1, b1, a1), Color::rgba(r2, g2, b2, a2)).into())
 }
 
 /// Creates a new setting value from the horizontal gradient provided as two RGBA colors.
@@ -203,9 +201,7 @@ pub extern "C" fn SettingValue_from_horizontal_gradient(
     b2: f32,
     a2: f32,
 ) -> OwnedSettingValue {
-    Box::new(
-        Gradient::Horizontal(Color::from((r1, g1, b1, a1)), Color::from((r2, g2, b2, a2))).into(),
-    )
+    Box::new(Gradient::Horizontal(Color::rgba(r1, g1, b1, a1), Color::rgba(r2, g2, b2, a2)).into())
 }
 
 /// Creates a new setting value from the alternating gradient provided as two RGBA colors.
@@ -221,8 +217,7 @@ pub extern "C" fn SettingValue_from_alternating_gradient(
     a2: f32,
 ) -> OwnedSettingValue {
     Box::new(
-        ListGradient::Alternating(Color::from((r1, g1, b1, a1)), Color::from((r2, g2, b2, a2)))
-            .into(),
+        ListGradient::Alternating(Color::rgba(r1, g1, b1, a1), Color::rgba(r2, g2, b2, a2)).into(),
     )
 }
 

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -5,15 +5,17 @@
 //! comparisons, the segment icon, and the segment's name, can also be shown.
 
 use super::timer;
-use crate::analysis::comparison_single_segment_time;
-use crate::comparison::{self, best_segments, none};
-use crate::platform::prelude::*;
-use crate::settings::{CachedImageId, Field, Gradient, ImageData, SettingsDescription, Value};
-use crate::timing::{
-    formatter::{Accuracy, DigitsFormat, SegmentTime, TimeFormatter},
-    Snapshot,
+use crate::{
+    analysis::comparison_single_segment_time,
+    comparison::{self, best_segments, none},
+    platform::prelude::*,
+    settings::{CachedImageId, Color, Field, Gradient, ImageData, SettingsDescription, Value},
+    timing::{
+        formatter::{Accuracy, DigitsFormat, SegmentTime, TimeFormatter},
+        Snapshot,
+    },
+    GeneralLayoutSettings, Segment, TimeSpan, TimerPhase,
 };
-use crate::{GeneralLayoutSettings, Segment, TimeSpan, TimerPhase};
 use core::fmt::Write;
 use serde::{Deserialize, Serialize};
 
@@ -123,7 +125,12 @@ impl Default for Settings {
             segment_timer: timer::Settings {
                 height: 25,
                 is_segment_timer: true,
-                color_override: Some((170.0 / 255.0, 170.0 / 255.0, 170.0 / 255.0, 1.0).into()),
+                color_override: Some(Color::rgba(
+                    170.0 / 255.0,
+                    170.0 / 255.0,
+                    170.0 / 255.0,
+                    1.0,
+                )),
                 ..Default::default()
             },
             display_icon: false,

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -129,12 +129,12 @@ impl Default for Settings {
             show_best_segments: false,
             live_graph: true,
             flip_graph: false,
-            behind_background_color: (115.0 / 255.0, 40.0 / 255.0, 40.0 / 255.0, 1.0).into(),
-            ahead_background_color: (40.0 / 255.0, 115.0 / 255.0, 52.0 / 255.0, 1.0).into(),
-            grid_lines_color: (0.0, 0.0, 0.0, 0.15).into(),
-            graph_lines_color: (1.0, 1.0, 1.0, 1.0).into(),
-            partial_fill_color: (1.0, 1.0, 1.0, 0.25).into(),
-            complete_fill_color: (1.0, 1.0, 1.0, 0.4).into(),
+            behind_background_color: Color::rgba(115.0 / 255.0, 40.0 / 255.0, 40.0 / 255.0, 1.0),
+            ahead_background_color: Color::rgba(40.0 / 255.0, 115.0 / 255.0, 52.0 / 255.0, 1.0),
+            grid_lines_color: Color::rgba(0.0, 0.0, 0.0, 0.15),
+            graph_lines_color: Color::rgba(1.0, 1.0, 1.0, 1.0),
+            partial_fill_color: Color::rgba(1.0, 1.0, 1.0, 0.25),
+            complete_fill_color: Color::rgba(1.0, 1.0, 1.0, 0.4),
             height: 80,
         }
     }

--- a/src/component/key_value.rs
+++ b/src/component/key_value.rs
@@ -3,12 +3,11 @@
 //! components. They all share the same visual appearance and thus use the same
 //! state object representation.
 
-use crate::platform::prelude::*;
-use crate::settings::{Color, Gradient, SemanticColor};
+use crate::{
+    platform::prelude::*,
+    settings::{Color, Gradient, SemanticColor},
+};
 use alloc::borrow::Cow;
-use core::marker::PhantomData;
-use palette::rgb::Rgb;
-use palette::Alpha;
 use serde::{Deserialize, Serialize};
 
 /// The state object describes the information to visualize for a key value
@@ -49,25 +48,15 @@ impl State {
 
 pub(super) const DEFAULT_GRADIENT: Gradient = Gradient::Vertical(
     Color {
-        rgba: Alpha {
-            alpha: 0.06,
-            color: Rgb {
-                red: 1.0,
-                green: 1.0,
-                blue: 1.0,
-                standard: PhantomData,
-            },
-        },
+        red: 1.0,
+        green: 1.0,
+        blue: 1.0,
+        alpha: 0.06,
     },
     Color {
-        rgba: Alpha {
-            alpha: 0.005,
-            color: Rgb {
-                red: 1.0,
-                green: 1.0,
-                blue: 1.0,
-                standard: PhantomData,
-            },
-        },
+        red: 1.0,
+        green: 1.0,
+        blue: 1.0,
+        alpha: 0.005,
     },
 );

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -172,7 +172,7 @@ impl Default for Settings {
         Settings {
             background: ListGradient::Alternating(
                 Color::transparent(),
-                Color::from((1.0, 1.0, 1.0, 0.04)),
+                Color::rgba(1.0, 1.0, 1.0, 0.04),
             ),
             visual_split_count: 16,
             split_preview_count: 1,
@@ -182,8 +182,8 @@ impl Default for Settings {
             fill_with_blank_space: true,
             display_two_rows: false,
             current_split_gradient: Gradient::Vertical(
-                Color::from((51.0 / 255.0, 115.0 / 255.0, 244.0 / 255.0, 1.0)),
-                Color::from((21.0 / 255.0, 53.0 / 255.0, 116.0 / 255.0, 1.0)),
+                Color::rgba(51.0 / 255.0, 115.0 / 255.0, 244.0 / 255.0, 1.0),
+                Color::rgba(21.0 / 255.0, 53.0 / 255.0, 116.0 / 255.0, 1.0),
             ),
             show_column_labels: false,
             columns: vec![

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -3,15 +3,16 @@
 //! a digital clock. The color of the time shown is based on a how well the
 //! current attempt is doing compared to the chosen comparison.
 
-use crate::analysis::split_color;
-use crate::palette::{rgb::LinSrgb, Hsv};
-use crate::platform::prelude::*;
-use crate::settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value};
-use crate::timing::{
-    formatter::{timer as formatter, Accuracy, DigitsFormat, TimeFormatter},
-    Snapshot,
+use crate::{
+    analysis::split_color,
+    platform::prelude::*,
+    settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
+    timing::{
+        formatter::{timer as formatter, Accuracy, DigitsFormat, TimeFormatter},
+        Snapshot,
+    },
+    GeneralLayoutSettings, TimeSpan, TimerPhase, TimingMethod,
 };
-use crate::{GeneralLayoutSettings, TimeSpan, TimerPhase, TimingMethod};
 use core::fmt::Write;
 use serde::{Deserialize, Serialize};
 
@@ -289,29 +290,10 @@ impl Component {
 /// Calculates the top and bottom color the Timer Component would use for the
 /// gradient of the times it is showing.
 pub fn top_and_bottom_color(color: Color) -> (Color, Color) {
-    let hsv: Hsv = color.rgba.into();
+    let [h, s, v, a] = color.to_hsva();
 
-    let h = f64::from(hsv.hue.to_degrees());
-    let s = f64::from(hsv.saturation);
-    let v = f64::from(hsv.value);
-    let a = color.rgba.alpha;
-
-    let top_color = LinSrgb::from(Hsv::new(h, 0.5 * s, (1.5 * v + 0.1).min(1.0)));
-    let bottom_color = LinSrgb::from(Hsv::new(h, s, 0.8 * v));
-
-    let top_color = Color::from((
-        top_color.red as f32,
-        top_color.green as f32,
-        top_color.blue as f32,
-        a,
-    ));
-
-    let bottom_color = Color::from((
-        bottom_color.red as f32,
-        bottom_color.green as f32,
-        bottom_color.blue as f32,
-        a,
-    ));
+    let top_color = Color::hsva(h, 0.5 * s, (1.5 * v + 0.1).min(1.0), a);
+    let bottom_color = Color::hsva(h, s, 0.8 * v, a);
 
     (top_color, bottom_color)
 }

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -131,7 +131,7 @@ impl GradientType for GradientKind {
         match self {
             GradientKind::Transparent => Gradient::Transparent,
             GradientKind::Plain => {
-                if first.rgba.alpha == 0.0 {
+                if first.alpha == 0.0 {
                     Gradient::Transparent
                 } else {
                     Gradient::Plain(first)
@@ -238,8 +238,8 @@ where
     text_err(reader, buf, |text| {
         let number = u32::from_str_radix(&text, 16)?;
         let [a, r, g, b] = number.to_be_bytes();
-        let mut color = Color::from([r, g, b, a]);
-        let (r, g, b, a) = color.rgba.into_components();
+        let mut color = Color::rgba8(r, g, b, a);
+        let [r, g, b, a] = color.to_array();
 
         // Adjust alpha based on the lightness of the color. The formula is
         // based on two sRGB curves measured for white on top of a black
@@ -251,7 +251,7 @@ where
         // black. Because of that, we use 1.75 as the exponent denominator for
         // the white on black case instead of the usual 2.2 for sRGB.
         let lightness = (r + g + b) / 3.0;
-        color.rgba.alpha =
+        color.alpha =
             (1.0 - lightness) * (1.0 - (1.0 - a).powf(1.0 / 2.2)) + lightness * a.powf(1.0 / 1.75);
 
         func(color);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@ pub use crate::{
     },
 };
 pub use livesplit_hotkey as hotkey;
-pub use palette;
 
 #[cfg(not(feature = "std"))]
 pub use crate::platform::{register_clock, Clock, Duration};

--- a/src/platform/math.rs
+++ b/src/platform/math.rs
@@ -11,9 +11,20 @@ cfg_if::cfg_if! {
                 x.floor()
             }
         }
+
+        pub mod f32 {
+            #[inline(always)]
+            pub fn abs(x: f32) -> f32 {
+                x.abs()
+            }
+        }
     } else {
         pub mod f64 {
             pub use libm::{fabs as abs, floor as floor};
+        }
+
+        pub mod f32 {
+            pub use libm::fabsf as abs;
         }
     }
 }

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::timer::State,
-    rendering::{decode_color, Backend, FillShader, RenderContext, PADDING},
+    rendering::{Backend, FillShader, RenderContext, PADDING},
 };
 
 pub(in crate::rendering) fn render(
@@ -10,8 +10,8 @@ pub(in crate::rendering) fn render(
 ) -> f32 {
     context.render_rectangle([0.0, 0.0], [width, height], &component.background);
     let shader = FillShader::VerticalGradient(
-        decode_color(&component.top_color),
-        decode_color(&component.bottom_color),
+        component.top_color.to_array(),
+        component.bottom_color.to_array(),
     );
     let x = context.render_timer(
         &component.fraction,

--- a/src/rendering/font/color_font/mod.rs
+++ b/src/rendering/font/color_font/mod.rs
@@ -29,7 +29,7 @@ impl<'f> ColorTables<'f> {
             let entry_idx = layer.palette_entry_idx();
             let color = if entry_idx != 0xFFFF {
                 cpal::look_up(self.cpal, palette, entry_idx)
-                    .map(|col| [col.red, col.green, col.blue, col.alpha].into())
+                    .map(|c| Color::rgba8(c.red, c.green, c.blue, c.alpha))
             } else {
                 None
             };

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -639,7 +639,7 @@ impl<B: Backend> RenderContext<'_, B> {
 
     fn render_stroke_path(&mut self, path: &B::Path, color: Color, stroke_width: f32) {
         self.backend
-            .render_stroke_path(path, stroke_width, decode_color(&color), self.transform)
+            .render_stroke_path(path, stroke_width, color.to_array(), self.transform)
     }
 
     fn create_icon(&mut self, image_data: &[u8]) -> Option<Icon<B::Image>> {
@@ -987,33 +987,21 @@ impl<B: Backend> RenderContext<'_, B> {
     }
 }
 
-fn decode_gradient(gradient: &Gradient) -> Option<FillShader> {
+const fn decode_gradient(gradient: &Gradient) -> Option<FillShader> {
     Some(match gradient {
         Gradient::Transparent => return None,
         Gradient::Horizontal(left, right) => {
-            let left = decode_color(left);
-            let right = decode_color(right);
-            FillShader::HorizontalGradient(left, right)
+            FillShader::HorizontalGradient(left.to_array(), right.to_array())
         }
         Gradient::Vertical(top, bottom) => {
-            let top = decode_color(top);
-            let bottom = decode_color(bottom);
-            FillShader::VerticalGradient(top, bottom)
+            FillShader::VerticalGradient(top.to_array(), bottom.to_array())
         }
-        Gradient::Plain(plain) => {
-            let plain = decode_color(plain);
-            FillShader::SolidColor(plain)
-        }
+        Gradient::Plain(plain) => FillShader::SolidColor(plain.to_array()),
     })
 }
 
-fn decode_color(color: &Color) -> [f32; 4] {
-    let (r, g, b, a) = color.rgba.into();
-    [r, g, b, a]
-}
-
-fn solid(color: &Color) -> FillShader {
-    FillShader::SolidColor(decode_color(color))
+const fn solid(color: &Color) -> FillShader {
+    FillShader::SolidColor(color.to_array())
 }
 
 fn component_width(component: &ComponentState) -> f32 {

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use core::mem::swap;
 use core::num::ParseIntError;
-use odds::slice::rotate_left;
 use snafu::{OptionExt, ResultExt};
 
 pub mod cleaning;
@@ -840,12 +839,9 @@ impl Editor {
         }
 
         if src_index > dst_index {
-            rotate_left(
-                &mut comparisons[dst_index..=src_index],
-                src_index - dst_index,
-            );
+            comparisons[dst_index..=src_index].rotate_left(src_index - dst_index);
         } else {
-            rotate_left(&mut comparisons[src_index..=dst_index], 1);
+            comparisons[src_index..=dst_index].rotate_left(1);
         }
 
         self.raise_run_edited();

--- a/src/settings/color.rs
+++ b/src/settings/color.rs
@@ -1,62 +1,210 @@
-use crate::palette::{Hsla, LinSrgba, Pixel};
+use crate::platform::math::f32::abs;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Colors can be used to describe what color to use for visualizing
+/// [`Color`]s can be used to describe what [`Color`] to use for visualizing
 /// backgrounds, texts, lines and various other elements that are being shown.
-/// They are stored as RGBA colors with 32-bit float point numbers ranging from
+/// They are stored as RGBA [`Color`]s with 32-bit float point numbers ranging from
 /// 0.0 to 1.0 per channel.
-#[derive(Debug, Copy, Clone, Default, PartialEq, derive_more::From)]
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[repr(C)]
 pub struct Color {
-    /// The Red, Green, Blue, Alpha (RGBA) encoding of the color.
-    pub rgba: LinSrgba,
+    /// The red component (0 - 1) of the [`Color`].
+    pub red: f32,
+    /// The green component (0 - 1) of the [`Color`].
+    pub green: f32,
+    /// The blue component (0 - 1) of the [`Color`].
+    pub blue: f32,
+    /// The alpha component (0 - 1) of the [`Color`].
+    pub alpha: f32,
 }
 
 impl Color {
-    /// Creates a new transparent color.
-    pub fn transparent() -> Self {
-        (0.0, 0.0, 0.0, 0.0).into()
-    }
-
-    /// Creates a new white color.
-    pub fn white() -> Self {
-        (1.0, 1.0, 1.0, 1.0).into()
-    }
-
-    /// Creates a new black color.
-    pub fn black() -> Self {
-        (0.0, 0.0, 0.0, 1.0).into()
-    }
-
-    /// Creates a new color by providing the Hue, Saturation, Lightness and
-    /// Alpha (HSLA) for it.
-    pub fn hsla(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
+    /// Creates a new [`Color`] from red (0 - 1), green (0 - 1), blue (0 - 1)
+    /// and alpha (0 - 1) components.
+    pub const fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
         Self {
-            rgba: Hsla::new(hue, saturation, lightness, alpha).into(),
+            red,
+            green,
+            blue,
+            alpha,
         }
+    }
+
+    /// Creates a new [`Color`] from red, green, blue and alpha byte components.
+    pub fn rgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Self {
+        const RECIP_255: f32 = 1.0 / 255.0;
+
+        Self {
+            red: RECIP_255 * red as f32,
+            green: RECIP_255 * green as f32,
+            blue: RECIP_255 * blue as f32,
+            alpha: RECIP_255 * alpha as f32,
+        }
+    }
+
+    /// Converts the [`Color`] into red, green, blue and alpha byte components.
+    pub fn to_rgba8(&self) -> [u8; 4] {
+        [
+            (255.0 * self.red + 0.5) as u8,
+            (255.0 * self.green + 0.5) as u8,
+            (255.0 * self.blue + 0.5) as u8,
+            (255.0 * self.alpha + 0.5) as u8,
+        ]
+    }
+
+    /// Creates a new transparent [`Color`].
+    pub const fn transparent() -> Self {
+        Self {
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        }
+    }
+
+    /// Creates a new white [`Color`].
+    pub const fn white() -> Self {
+        Self {
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        }
+    }
+
+    /// Creates a new black [`Color`].
+    pub const fn black() -> Self {
+        Self {
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        }
+    }
+
+    /// Converts the [`Color`] into an array of red (0 - 1), green (0 - 1), blue
+    /// (0 - 1) and alpha (0 - 1).
+    pub const fn to_array(&self) -> [f32; 4] {
+        [self.red, self.green, self.blue, self.alpha]
+    }
+
+    /// Creates a new [`Color`] by providing the hue (0 - 360), saturation (0 -
+    /// 1), lightness (0 - 1) and alpha (0 - 1) for it.
+    pub fn hsla(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
+        const RECIP_60: f32 = 1.0 / 60.0;
+
+        let c = (1.0 - abs(2.0 * lightness - 1.0)) * saturation;
+        let x = c * (1.0 - abs((hue * RECIP_60) % 2.0 - 1.0));
+        let m = lightness - 0.5 * c;
+
+        let (red, green, blue) = if hue < 60.0 {
+            (m + c, m + x, m)
+        } else if hue < 120.0 {
+            (m + x, m + c, m)
+        } else if hue < 180.0 {
+            (m, m + c, m + x)
+        } else if hue < 240.0 {
+            (m, m + x, m + c)
+        } else if hue < 300.0 {
+            (m + x, m, m + c)
+        } else {
+            (m + c, m, m + x)
+        };
+
+        Self {
+            red,
+            green,
+            blue,
+            alpha,
+        }
+    }
+
+    /// Creates a new [`Color`] by providing the hue (0 - 360), saturation (0 -
+    /// 1), value (0 - 1) and alpha (0 - 1) for it.
+    pub fn hsva(hue: f32, saturation: f32, value: f32, alpha: f32) -> Self {
+        const RECIP_60: f32 = 1.0 / 60.0;
+
+        let c = value * saturation;
+        let x = c * (1.0 - abs((hue * RECIP_60) % 2.0 - 1.0));
+        let m = value - c;
+
+        let (red, green, blue) = if hue < 60.0 {
+            (m + c, m + x, m)
+        } else if hue < 120.0 {
+            (m + x, m + c, m)
+        } else if hue < 180.0 {
+            (m, m + c, m + x)
+        } else if hue < 240.0 {
+            (m, m + x, m + c)
+        } else if hue < 300.0 {
+            (m + x, m, m + c)
+        } else {
+            (m + c, m, m + x)
+        };
+
+        Self {
+            red,
+            green,
+            blue,
+            alpha,
+        }
+    }
+
+    /// Converts the [`Color`] into hue (0 - 360), saturation (0 - 1), value (0
+    /// - 1) and alpha (0 - 1).
+    pub fn to_hsva(&self) -> [f32; 4] {
+        let [r, g, b, a] = self.to_array();
+
+        let (shift, max, diff, min) = if r > g {
+            if r > b {
+                if b > g {
+                    (360.0, r, g - b, g)
+                } else {
+                    (0.0, r, g - b, b)
+                }
+            } else {
+                (240.0, b, r - g, g)
+            }
+        } else if b > g {
+            (240.0, b, r - g, r)
+        } else {
+            (120.0, g, b - r, if r > b { b } else { r })
+        };
+
+        let delta = max - min;
+
+        let hue = if delta == 0.0 {
+            0.0
+        } else {
+            60.0 * diff / delta + shift
+        };
+        let saturation = if max == 0.0 { 0.0 } else { delta / max };
+        let value = max;
+
+        [hue, saturation, value, a]
     }
 }
 
 impl From<[f32; 4]> for Color {
-    fn from(rgba: [f32; 4]) -> Self {
+    fn from([red, green, blue, alpha]: [f32; 4]) -> Self {
         Self {
-            rgba: LinSrgba::from_components((rgba[0], rgba[1], rgba[2], rgba[3])),
+            red,
+            green,
+            blue,
+            alpha,
         }
+    }
+}
+
+impl From<Color> for [f32; 4] {
+    fn from(c: Color) -> Self {
+        c.to_array()
     }
 }
 
 impl From<[u8; 4]> for Color {
-    fn from(rgba: [u8; 4]) -> Self {
-        Self {
-            rgba: LinSrgba::from_raw(&rgba).into_format(),
-        }
-    }
-}
-
-impl From<(f32, f32, f32, f32)> for Color {
-    fn from(rgba: (f32, f32, f32, f32)) -> Self {
-        Self {
-            rgba: LinSrgba::from_components(rgba),
-        }
+    fn from([red, green, blue, alpha]: [u8; 4]) -> Self {
+        Self::rgba8(red, green, blue, alpha)
     }
 }
 
@@ -65,9 +213,7 @@ impl Serialize for Color {
     where
         S: Serializer,
     {
-        let (r, g, b, a) = self.rgba.into_components();
-        let rgba: [f32; 4] = [r, g, b, a];
-        rgba.serialize(serializer)
+        self.to_array().serialize(serializer)
     }
 }
 
@@ -78,5 +224,64 @@ impl<'de> Deserialize<'de> for Color {
     {
         let rgba = <[f32; 4]>::deserialize(deserializer)?;
         Ok(rgba.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::float_cmp)]
+    #[test]
+    fn to_hsva() {
+        assert_eq!(
+            Color::from([1.0, 0.0, 0.0, 1.0]).to_hsva(),
+            [0.0, 1.0, 1.0, 1.0],
+        );
+        assert_eq!(
+            Color::from([1.0, 1.0, 0.0, 1.0]).to_hsva(),
+            [60.0, 1.0, 1.0, 1.0],
+        );
+        assert_eq!(
+            Color::from([0.0, 1.0, 0.0, 1.0]).to_hsva(),
+            [120.0, 1.0, 1.0, 1.0],
+        );
+        assert_eq!(
+            Color::from([0.0, 1.0, 1.0, 1.0]).to_hsva(),
+            [180.0, 1.0, 1.0, 1.0],
+        );
+        assert_eq!(
+            Color::from([0.0, 0.0, 1.0, 1.0]).to_hsva(),
+            [240.0, 1.0, 1.0, 1.0],
+        );
+        assert_eq!(
+            Color::from([1.0, 0.0, 1.0, 1.0]).to_hsva(),
+            [300.0, 1.0, 1.0, 1.0],
+        );
+    }
+
+    #[test]
+    fn from_hsva() {
+        assert_eq!(Color::hsva(0.0, 1.0, 1.0, 1.0).to_rgba8(), [255, 0, 0, 255]);
+        assert_eq!(
+            Color::hsva(60.0, 1.0, 1.0, 1.0).to_rgba8(),
+            [255, 255, 0, 255],
+        );
+        assert_eq!(
+            Color::hsva(120.0, 1.0, 1.0, 1.0).to_rgba8(),
+            [0, 255, 0, 255],
+        );
+        assert_eq!(
+            Color::hsva(180.0, 1.0, 1.0, 1.0).to_rgba8(),
+            [0, 255, 255, 255],
+        );
+        assert_eq!(
+            Color::hsva(240.0, 1.0, 1.0, 1.0).to_rgba8(),
+            [0, 0, 255, 255],
+        );
+        assert_eq!(
+            Color::hsva(300.0, 1.0, 1.0, 1.0).to_rgba8(),
+            [255, 0, 255, 255],
+        );
     }
 }


### PR DESCRIPTION
We only needed `odds` for a single function that seems to be in `std` by now and `palette` didn't provide all too much benefit for us either. We initially used it for cleanly handling linear colors and gamma compressed colors. However most UI frameworks don't actually implement this correctly, so we ended up handling it like most UI frameworks do as well, completely disregarding all correctness. It also is a slightly heavy dependency because it has a proc macro dependency. So for these reasons we will simply handle the colors ourselves.