### PR TITLE
Turn functions into const fn

### DIFF
--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -61,12 +61,12 @@ impl Component {
     }
 
     /// Creates a new Blank Space Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -76,7 +76,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Blank Space"
     }
 
@@ -87,7 +87,7 @@ impl Component {
     }
 
     /// Calculates the component's state.
-    pub fn state(&self) -> State {
+    pub const fn state(&self) -> State {
         State {
             background: self.settings.background,
             size: self.settings.size,

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -50,12 +50,12 @@ impl Component {
     }
 
     /// Creates a new Current Comparison Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -65,7 +65,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Current Comparison"
     }
 

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -66,12 +66,12 @@ impl Component {
     }
 
     /// Creates a new Current Pace Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -67,12 +67,12 @@ impl Component {
     }
 
     /// Creates a new Delta Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -169,7 +169,7 @@ impl Component {
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -181,7 +181,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Detailed Timer"
     }
 

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -167,12 +167,12 @@ impl Component {
     }
 
     /// Creates a new Graph Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -55,12 +55,12 @@ impl Component {
     }
 
     /// Creates a new Possible Time Save Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -70,7 +70,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "PB Chance"
     }
 

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -73,12 +73,12 @@ impl Component {
     }
 
     /// Creates a new Possible Time Save Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -73,12 +73,12 @@ impl Component {
     }
 
     /// Creates a new Previous Segment Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -66,12 +66,12 @@ impl Component {
     }
 
     /// Creates a new Segment Time Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -32,7 +32,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Separator"
     }
 
@@ -40,7 +40,7 @@ impl Component {
     pub fn update_state(&self, _state: &mut State) {}
 
     /// Calculates the component's state.
-    pub fn state(&self) -> State {
+    pub const fn state(&self) -> State {
         State
     }
 

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -326,12 +326,13 @@ fn column_update_value(
 }
 
 impl ColumnUpdateWith {
-    fn is_segment_based(self) -> bool {
-        use self::ColumnUpdateWith::*;
+    const fn is_segment_based(self) -> bool {
+        use ColumnUpdateWith::*;
         matches!(self, SegmentDelta | SegmentTime | SegmentDeltaWithFallback)
     }
-    fn has_fallback(self) -> bool {
-        use self::ColumnUpdateWith::*;
+
+    const fn has_fallback(self) -> bool {
+        use ColumnUpdateWith::*;
         matches!(self, DeltaWithFallback | SegmentDeltaWithFallback)
     }
 }

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -234,7 +234,7 @@ impl Component {
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -265,7 +265,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Splits"
     }
 

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -66,12 +66,12 @@ impl Component {
     }
 
     /// Creates a new Sum of Best Segments Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -81,7 +81,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Sum of Best Segments"
     }
 

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -78,7 +78,7 @@ impl Default for TextState {
 
 impl Text {
     /// Returns whether the text is split up into a left and right part.
-    pub fn is_split(&self) -> bool {
+    pub const fn is_split(&self) -> bool {
         match *self {
             Text::Split(_, _) => true,
             Text::Center(_) => false,
@@ -170,12 +170,12 @@ impl Component {
     }
 
     /// Creates a new Text Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -107,12 +107,12 @@ impl Component {
     }
 
     /// Creates a new Timer Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -122,7 +122,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         if self.settings.is_segment_timer {
             "Segment Timer"
         } else {

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -151,7 +151,7 @@ impl Component {
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -161,7 +161,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Title"
     }
 

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -57,12 +57,12 @@ impl Component {
     }
 
     /// Creates a new Total Playtime Component with the given settings.
-    pub fn with_settings(settings: Settings) -> Self {
+    pub const fn with_settings(settings: Settings) -> Self {
         Self { settings }
     }
 
     /// Accesses the settings of the component.
-    pub fn settings(&self) -> &Settings {
+    pub const fn settings(&self) -> &Settings {
         &self.settings
     }
 
@@ -72,7 +72,7 @@ impl Component {
     }
 
     /// Accesses the name of the component.
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         "Total Playtime"
     }
 

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -1,5 +1,7 @@
-use crate::hotkey::{Hook, KeyCode};
-use crate::{HotkeyConfig, SharedTimer};
+use crate::{
+    hotkey::{Hook, KeyCode},
+    HotkeyConfig, SharedTimer,
+};
 
 pub use crate::hotkey::{Error, Result};
 
@@ -41,7 +43,8 @@ impl Hotkey {
             Hotkey::ToggleTimingMethod => config.toggle_timing_method = keycode,
         }
     }
-    fn get_keycode(self, config: &HotkeyConfig) -> Option<KeyCode> {
+
+    const fn get_keycode(self, config: &HotkeyConfig) -> Option<KeyCode> {
         match self {
             Hotkey::Split => config.split,
             Hotkey::Reset => config.reset,
@@ -54,6 +57,7 @@ impl Hotkey {
             Hotkey::ToggleTimingMethod => config.toggle_timing_method,
         }
     }
+
     fn callback(self, timer: SharedTimer) -> Box<dyn FnMut() + Send + 'static> {
         match self {
             Hotkey::Split => Box::new(move || timer.write().split_or_start()),
@@ -101,6 +105,7 @@ impl HotkeySystem {
         hotkey_system.activate()?;
         Ok(hotkey_system)
     }
+
     // This method should never be public, because it might mess up the internal state and we might
     // leak a registered hotkey
     unsafe fn register_raw(&mut self, hotkey: Hotkey) -> Result<()> {
@@ -110,10 +115,12 @@ impl HotkeySystem {
         }
         Ok(())
     }
+
     fn register(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {
         hotkey.set_keycode(&mut self.config, keycode);
         unsafe { self.register_raw(hotkey) }
     }
+
     // This method should never be public, because it might mess up the internal state and we might
     // leak a registered hotkey
     unsafe fn unregister_raw(&mut self, hotkey: Hotkey) -> Result<()> {
@@ -122,10 +129,12 @@ impl HotkeySystem {
         }
         Ok(())
     }
+
     fn unregister(&mut self, hotkey: Hotkey) -> Result<()> {
         hotkey.set_keycode(&mut self.config, None);
         unsafe { self.unregister_raw(hotkey) }
     }
+
     fn set_hotkey(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {
         // FixMe: We do not check whether the keycode is already in use
         if hotkey.get_keycode(&self.config) == keycode {
@@ -227,12 +236,12 @@ impl HotkeySystem {
     }
 
     /// Returns true if the Hotkey System is active, false otherwise.
-    pub fn is_active(&self) -> bool {
+    pub const fn is_active(&self) -> bool {
         self.is_active
     }
 
     /// Returns the hotkey configuration currently in use by the Hotkey System.
-    pub fn config(&self) -> HotkeyConfig {
+    pub const fn config(&self) -> HotkeyConfig {
         self.config
     }
 

--- a/src/layout/editor/mod.rs
+++ b/src/layout/editor/mod.rs
@@ -52,6 +52,7 @@ impl Editor {
     /// Closes the Layout Editor and gives back access to the modified Layout.
     /// In case you want to implement a Cancel Button, just drop the Layout
     /// object you get here.
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Drop unsupported.
     pub fn close(self) -> Layout {
         self.layout
     }
@@ -102,7 +103,7 @@ impl Editor {
 
     /// Checks if the currently selected component can be moved up. If the first
     /// component is selected, it can't be moved up.
-    pub fn can_move_component_up(&self) -> bool {
+    pub const fn can_move_component_up(&self) -> bool {
         self.selected_component > 0
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -70,7 +70,7 @@ impl Layout {
 
     /// Accesses the general settings of the layout that apply to all
     /// components.
-    pub fn general_settings(&self) -> &GeneralSettings {
+    pub const fn general_settings(&self) -> &GeneralSettings {
         &self.settings
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
     clippy::correctness,
     clippy::perf,
     clippy::style,
+    clippy::missing_const_for_fn,
     missing_docs,
     rust_2018_idioms
 )]

--- a/src/rendering/font/color_font/colr.rs
+++ b/src/rendering/font/color_font/colr.rs
@@ -27,11 +27,11 @@ pub struct LayerRecord {
 }
 
 impl LayerRecord {
-    pub fn glyph_id(&self) -> u16 {
+    pub const fn glyph_id(&self) -> u16 {
         self.glyph_id.get()
     }
 
-    pub fn palette_entry_idx(&self) -> u16 {
+    pub const fn palette_entry_idx(&self) -> u16 {
         self.palette_entry_idx.get()
     }
 }

--- a/src/rendering/font/color_font/parse_util.rs
+++ b/src/rendering/font/color_font/parse_util.rs
@@ -12,11 +12,11 @@ impl fmt::Debug for U16 {
 }
 
 impl U16 {
-    pub fn get(self) -> u16 {
+    pub const fn get(self) -> u16 {
         u16::from_be_bytes(self.0)
     }
 
-    pub fn usize(self) -> usize {
+    pub const fn usize(self) -> usize {
         self.get() as usize
     }
 }
@@ -32,11 +32,11 @@ impl fmt::Debug for O32 {
 }
 
 impl O32 {
-    pub fn get(self) -> u32 {
+    pub const fn get(self) -> u32 {
         u32::from_be_bytes(self.0)
     }
 
-    pub fn usize(self) -> usize {
+    pub const fn usize(self) -> usize {
         self.get() as usize
     }
 }

--- a/src/rendering/font/mod.rs
+++ b/src/rendering/font/mod.rs
@@ -187,7 +187,7 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub fn new([x, y]: Pos) -> Self {
+    pub const fn new([x, y]: Pos) -> Self {
         Self { x, y }
     }
 }

--- a/src/run/attempt.rs
+++ b/src/run/attempt.rs
@@ -22,7 +22,7 @@ impl Attempt {
     /// provided. Both of these should be provided for unfinished attempts as
     /// well, if possible. If it is known that the attempt was paused for a
     /// certain amount of time, this can be provided as well.
-    pub fn new(
+    pub const fn new(
         index: i32,
         time: Time,
         started: Option<AtomicDateTime>,
@@ -54,14 +54,14 @@ impl Attempt {
     /// Accesses the unique index of the attempt. This index is unique for the
     /// Run, not for all of them.
     #[inline]
-    pub fn index(&self) -> i32 {
+    pub const fn index(&self) -> i32 {
         self.index
     }
 
     /// Accesses the split time of the last segment. If the attempt got reset
     /// early and didn't finish, this may be empty.
     #[inline]
-    pub fn time(&self) -> Time {
+    pub const fn time(&self) -> Time {
         self.time
     }
 
@@ -70,21 +70,21 @@ impl Attempt {
     /// be possible to differentiate whether a Run has not been paused or it
     /// simply wasn't stored.
     #[inline]
-    pub fn pause_time(&self) -> Option<TimeSpan> {
+    pub const fn pause_time(&self) -> Option<TimeSpan> {
         self.pause_time
     }
 
     /// Accesses the point in time the attempt was started at. This returns
     /// `None` if this information is not known.
     #[inline]
-    pub fn started(&self) -> Option<AtomicDateTime> {
+    pub const fn started(&self) -> Option<AtomicDateTime> {
         self.started
     }
 
     /// Accesses the point in time the attempt was ended at. This returns `None`
     /// if this information is not known.
     #[inline]
-    pub fn ended(&self) -> Option<AtomicDateTime> {
+    pub const fn ended(&self) -> Option<AtomicDateTime> {
         self.ended
     }
 }

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -106,19 +106,20 @@ impl Editor {
     /// Closes the Run Editor and gives back access to the modified Run object.
     /// In case you want to implement a Cancel Button, just drop the Run object
     /// you get here.
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Drop is unsupported.
     pub fn close(self) -> Run {
         self.run
     }
 
     /// Accesses the Run being edited by the Run Editor.
     #[inline]
-    pub fn run(&self) -> &Run {
+    pub const fn run(&self) -> &Run {
         &self.run
     }
 
     /// Accesses the timing method that is currently selected for being
     /// modified.
-    pub fn selected_timing_method(&self) -> TimingMethod {
+    pub const fn selected_timing_method(&self) -> TimingMethod {
         self.selected_method
     }
 
@@ -216,7 +217,7 @@ impl Editor {
 
     /// Accesses the timer offset. The timer offset specifies the time, the
     /// timer starts at when starting a new attempt.
-    pub fn offset(&self) -> TimeSpan {
+    pub const fn offset(&self) -> TimeSpan {
         self.run.offset()
     }
 
@@ -239,7 +240,7 @@ impl Editor {
     }
 
     /// Accesses the attempt count.
-    pub fn attempt_count(&self) -> u32 {
+    pub const fn attempt_count(&self) -> u32 {
         self.run.attempt_count()
     }
 
@@ -263,7 +264,7 @@ impl Editor {
     }
 
     /// Accesses the game's icon.
-    pub fn game_icon(&self) -> &Image {
+    pub const fn game_icon(&self) -> &Image {
         self.run.game_icon()
     }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -143,7 +143,7 @@ impl Run {
 
     /// Accesses the game's icon.
     #[inline]
-    pub fn game_icon(&self) -> &Image {
+    pub const fn game_icon(&self) -> &Image {
         &self.game_icon
     }
 
@@ -171,7 +171,7 @@ impl Run {
 
     /// Returns the path of the associated splits file in the file system.
     #[inline]
-    pub fn path(&self) -> &Option<PathBuf> {
+    pub const fn path(&self) -> &Option<PathBuf> {
         &self.path
     }
 
@@ -183,7 +183,7 @@ impl Run {
 
     /// Returns the amount of runs that have been attempted with these splits.
     #[inline]
-    pub fn attempt_count(&self) -> u32 {
+    pub const fn attempt_count(&self) -> u32 {
         self.attempt_count
     }
 
@@ -196,7 +196,7 @@ impl Run {
     /// Accesses additional metadata of this Run, like the platform and region
     /// of the game.
     #[inline]
-    pub fn metadata(&self) -> &RunMetadata {
+    pub const fn metadata(&self) -> &RunMetadata {
         &self.metadata
     }
 
@@ -215,7 +215,7 @@ impl Run {
 
     /// Accesses the time an attempt of this Run should start at.
     #[inline]
-    pub fn offset(&self) -> TimeSpan {
+    pub const fn offset(&self) -> TimeSpan {
         self.offset
     }
 
@@ -362,7 +362,7 @@ impl Run {
     /// Returns whether the Run has been modified and should be saved so that
     /// the changes don't get lost.
     #[inline]
-    pub fn has_been_modified(&self) -> bool {
+    pub const fn has_been_modified(&self) -> bool {
         self.has_been_modified
     }
 
@@ -494,7 +494,7 @@ impl Run {
     /// extended category name. An extended category name may look like this:
     ///
     /// Any% (No Tuner, JPN, Wii Emulator)
-    pub fn extended_category_name(
+    pub const fn extended_category_name(
         &self,
         show_region: bool,
         show_platform: bool,

--- a/src/run/parser/composite.rs
+++ b/src/run/parser/composite.rs
@@ -68,7 +68,7 @@ pub struct ParsedRun {
     pub kind: TimerKind,
 }
 
-fn parsed(run: Run, kind: TimerKind) -> ParsedRun {
+const fn parsed(run: Run, kind: TimerKind) -> ParsedRun {
     ParsedRun { run, kind }
 }
 

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -70,7 +70,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 // FIXME: Generalized Type Ascription (GTA 6)
 #[inline]
-fn type_hint<T>(v: Result<T>) -> Result<T> {
+const fn type_hint<T>(v: Result<T>) -> Result<T> {
     v
 }
 
@@ -193,7 +193,7 @@ where
     time_span_opt(reader, buf, |t| f(Time::new().with_real_time(t)))
 }
 
-fn parse_bool(value: &[u8]) -> Result<bool> {
+const fn parse_bool(value: &[u8]) -> Result<bool> {
     match value {
         b"True" => Ok(true),
         b"False" => Ok(false),

--- a/src/run/parser/llanfair2.rs
+++ b/src/run/parser/llanfair2.rs
@@ -45,7 +45,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 // FIXME: Generalized Type Ascription (GTA 6)
 #[inline]
-fn type_hint<T>(v: Result<T>) -> Result<T> {
+const fn type_hint<T>(v: Result<T>) -> Result<T> {
     v
 }
 

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -51,7 +51,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 // FIXME: Generalized Type Ascription (GTA 6)
 #[inline]
-fn type_hint<T>(v: Result<T>) -> Result<T> {
+const fn type_hint<T>(v: Result<T>) -> Result<T> {
     v
 }
 

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -124,7 +124,7 @@ impl RunMetadata {
     /// Returns `true` if this speedrun is done on an emulator. However `false`
     /// may also indicate that this information is simply not known.
     #[inline]
-    pub fn uses_emulator(&self) -> bool {
+    pub const fn uses_emulator(&self) -> bool {
         self.uses_emulator
     }
 

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -74,7 +74,7 @@ fn split_tag<'a>(tag: &'a BytesStart<'a>) -> (BytesStart<'a>, BytesEnd<'a>) {
     )
 }
 
-fn bool(value: bool) -> &'static [u8] {
+const fn bool(value: bool) -> &'static [u8] {
     if value {
         b"True"
     } else {

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -57,7 +57,7 @@ impl Segment {
 
     /// Accesses the icon of the segment.
     #[inline]
-    pub fn icon(&self) -> &Image {
+    pub const fn icon(&self) -> &Image {
         &self.icon
     }
 
@@ -125,7 +125,7 @@ impl Segment {
 
     /// Accesses the Best Segment Time.
     #[inline]
-    pub fn best_segment_time(&self) -> Time {
+    pub const fn best_segment_time(&self) -> Time {
         self.best_segment_time
     }
 
@@ -143,7 +143,7 @@ impl Segment {
 
     /// Accesses the split time of the current attempt.
     #[inline]
-    pub fn split_time(&self) -> Time {
+    pub const fn split_time(&self) -> Time {
         self.split_time
     }
 
@@ -167,7 +167,7 @@ impl Segment {
 
     /// Accesses the Segment History of this segment.
     #[inline]
-    pub fn segment_history(&self) -> &SegmentHistory {
+    pub const fn segment_history(&self) -> &SegmentHistory {
         &self.segment_history
     }
 

--- a/src/settings/field.rs
+++ b/src/settings/field.rs
@@ -13,7 +13,7 @@ pub struct Field {
 
 impl Field {
     /// Creates a new field.
-    pub fn new(text: String, value: Value) -> Self {
+    pub const fn new(text: String, value: Value) -> Self {
         Self { text, value }
     }
 }

--- a/src/settings/font.rs
+++ b/src/settings/font.rs
@@ -42,7 +42,7 @@ pub enum Style {
 
 impl Style {
     /// The value to assign to the `ital` variation axis.
-    pub fn value_for_italic(self) -> f32 {
+    pub const fn value_for_italic(self) -> f32 {
         match self {
             Style::Normal => 0.0,
             Style::Italic => 1.0,
@@ -83,7 +83,7 @@ pub enum Weight {
 
 impl Weight {
     /// The numeric value of the weight.
-    pub fn value(self) -> f32 {
+    pub const fn value(self) -> f32 {
         match self {
             Weight::Thin => 100.0,
             Weight::ExtraLight => 200.0,
@@ -129,7 +129,7 @@ pub enum Stretch {
 
 impl Stretch {
     /// The percentage the font is stretched by (50% to 200%).
-    pub fn percentage(self) -> f32 {
+    pub const fn percentage(self) -> f32 {
         match self {
             Stretch::UltraCondensed => 50.0,
             Stretch::ExtraCondensed => 62.5,
@@ -144,7 +144,7 @@ impl Stretch {
     }
 
     /// The factor the font is stretched by (0x to 2x).
-    pub fn factor(self) -> f32 {
+    pub const fn factor(self) -> f32 {
         match self {
             Stretch::UltraCondensed => 0.5,
             Stretch::ExtraCondensed => 0.625,

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -139,7 +139,7 @@ impl Image {
 
     /// Accesses the unique ID for this image.
     #[inline]
-    pub fn id(&self) -> usize {
+    pub const fn id(&self) -> usize {
         self.id
     }
 

--- a/src/settings/semantic_color.rs
+++ b/src/settings/semantic_color.rs
@@ -48,7 +48,7 @@ impl SemanticColor {
     /// The General Settings store actual Color values for each of the different
     /// events. Using this method, you can use these to convert a Semantic Color
     /// to an actual Color.
-    pub fn visualize(self, settings: &layout::GeneralSettings) -> Color {
+    pub const fn visualize(self, settings: &layout::GeneralSettings) -> Color {
         match self {
             SemanticColor::Default => settings.text_color,
             SemanticColor::AheadGainingTime => settings.ahead_gaining_time_color,

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -71,6 +71,7 @@ pub enum Error {
 /// The Result type for conversions from Values to other types.
 pub type Result<T> = StdResult<T, Error>;
 
+#[allow(clippy::missing_const_for_fn)] // FIXME: Drop is unsupported.
 impl Value {
     /// Tries to convert the value into a boolean.
     pub fn into_bool(self) -> Result<bool> {
@@ -242,122 +243,122 @@ impl Value {
     }
 }
 
-impl Into<bool> for Value {
-    fn into(self) -> bool {
-        self.into_bool().unwrap()
+impl From<Value> for bool {
+    fn from(value: Value) -> Self {
+        value.into_bool().unwrap()
     }
 }
 
-impl Into<u64> for Value {
-    fn into(self) -> u64 {
-        self.into_uint().unwrap()
+impl From<Value> for u64 {
+    fn from(value: Value) -> Self {
+        value.into_uint().unwrap()
     }
 }
 
-impl Into<i64> for Value {
-    fn into(self) -> i64 {
-        self.into_int().unwrap()
+impl From<Value> for i64 {
+    fn from(value: Value) -> Self {
+        value.into_int().unwrap()
     }
 }
 
-impl Into<String> for Value {
-    fn into(self) -> String {
-        self.into_string().unwrap()
+impl From<Value> for String {
+    fn from(value: Value) -> Self {
+        value.into_string().unwrap()
     }
 }
 
-impl Into<Option<String>> for Value {
-    fn into(self) -> Option<String> {
-        self.into_optional_string().unwrap()
+impl From<Value> for Option<String> {
+    fn from(value: Value) -> Self {
+        value.into_optional_string().unwrap()
     }
 }
 
-impl Into<f64> for Value {
-    fn into(self) -> f64 {
-        self.into_float().unwrap()
+impl From<Value> for f64 {
+    fn from(value: Value) -> Self {
+        value.into_float().unwrap()
     }
 }
 
-impl Into<Accuracy> for Value {
-    fn into(self) -> Accuracy {
-        self.into_accuracy().unwrap()
+impl From<Value> for Accuracy {
+    fn from(value: Value) -> Self {
+        value.into_accuracy().unwrap()
     }
 }
 
-impl Into<DigitsFormat> for Value {
-    fn into(self) -> DigitsFormat {
-        self.into_digits_format().unwrap()
+impl From<Value> for DigitsFormat {
+    fn from(value: Value) -> Self {
+        value.into_digits_format().unwrap()
     }
 }
 
-impl Into<Option<TimingMethod>> for Value {
-    fn into(self) -> Option<TimingMethod> {
-        self.into_optional_timing_method().unwrap()
+impl From<Value> for Option<TimingMethod> {
+    fn from(value: Value) -> Self {
+        value.into_optional_timing_method().unwrap()
     }
 }
 
-impl Into<Color> for Value {
-    fn into(self) -> Color {
-        self.into_color().unwrap()
+impl From<Value> for Color {
+    fn from(value: Value) -> Self {
+        value.into_color().unwrap()
     }
 }
 
-impl Into<Option<Color>> for Value {
-    fn into(self) -> Option<Color> {
-        self.into_optional_color().unwrap()
+impl From<Value> for Option<Color> {
+    fn from(value: Value) -> Self {
+        value.into_optional_color().unwrap()
     }
 }
 
-impl Into<Gradient> for Value {
-    fn into(self) -> Gradient {
-        self.into_gradient().unwrap()
+impl From<Value> for Gradient {
+    fn from(value: Value) -> Self {
+        value.into_gradient().unwrap()
     }
 }
 
-impl Into<ListGradient> for Value {
-    fn into(self) -> ListGradient {
-        self.into_list_gradient().unwrap()
+impl From<Value> for ListGradient {
+    fn from(value: Value) -> Self {
+        value.into_list_gradient().unwrap()
     }
 }
 
-impl Into<Alignment> for Value {
-    fn into(self) -> Alignment {
-        self.into_alignment().unwrap()
+impl From<Value> for Alignment {
+    fn from(value: Value) -> Self {
+        value.into_alignment().unwrap()
     }
 }
 
-impl Into<ColumnStartWith> for Value {
-    fn into(self) -> ColumnStartWith {
-        self.into_column_start_with().unwrap()
+impl From<Value> for ColumnStartWith {
+    fn from(value: Value) -> Self {
+        value.into_column_start_with().unwrap()
     }
 }
 
-impl Into<ColumnUpdateWith> for Value {
-    fn into(self) -> ColumnUpdateWith {
-        self.into_column_update_with().unwrap()
+impl From<Value> for ColumnUpdateWith {
+    fn from(value: Value) -> Self {
+        value.into_column_update_with().unwrap()
     }
 }
 
-impl Into<ColumnUpdateTrigger> for Value {
-    fn into(self) -> ColumnUpdateTrigger {
-        self.into_column_update_trigger().unwrap()
+impl From<Value> for ColumnUpdateTrigger {
+    fn from(value: Value) -> Self {
+        value.into_column_update_trigger().unwrap()
     }
 }
 
-impl Into<Option<KeyCode>> for Value {
-    fn into(self) -> Option<KeyCode> {
-        self.into_hotkey().unwrap()
+impl From<Value> for Option<KeyCode> {
+    fn from(value: Value) -> Self {
+        value.into_hotkey().unwrap()
     }
 }
 
-impl Into<LayoutDirection> for Value {
-    fn into(self) -> LayoutDirection {
-        self.into_layout_direction().unwrap()
+impl From<Value> for LayoutDirection {
+    fn from(value: Value) -> Self {
+        value.into_layout_direction().unwrap()
     }
 }
 
-impl Into<Option<Font>> for Value {
-    fn into(self) -> Option<Font> {
-        self.into_font().unwrap()
+impl From<Value> for Option<Font> {
+    fn from(value: Value) -> Self {
+        value.into_font().unwrap()
     }
 }

--- a/src/timing/atomic_date_time.rs
+++ b/src/timing/atomic_date_time.rs
@@ -1,6 +1,7 @@
-use crate::platform::utc_now;
-use crate::platform::{DateTime, Utc};
-use crate::TimeSpan;
+use crate::{
+    platform::{utc_now, DateTime, Utc},
+    TimeSpan,
+};
 use core::ops::Sub;
 
 /// An Atomic Date Time represents a UTC Date Time that tries to be as close to
@@ -19,7 +20,7 @@ impl AtomicDateTime {
     /// Creates a new Atomic Date Time from the UTC Date Time and the
     /// information of whether this Date Time is derived from an atomic clock or
     /// the local system that may be out of sync with the atomic clock.
-    pub fn new(time: DateTime<Utc>, synced_with_atomic_clock: bool) -> Self {
+    pub const fn new(time: DateTime<Utc>, synced_with_atomic_clock: bool) -> Self {
         Self {
             time,
             synced_with_atomic_clock,

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -18,7 +18,7 @@ impl Accuracy {
     /// Formats the seconds provided with the chosen accuracy. If there should
     /// be a zero prefix, the seconds are prefixed with a 0, if they are less
     /// than 10s.
-    pub fn format_seconds(self, seconds: f64, zero_prefix: bool) -> FormattedSeconds {
+    pub const fn format_seconds(self, seconds: f64, zero_prefix: bool) -> FormattedSeconds {
         FormattedSeconds {
             accuracy: self,
             seconds,

--- a/src/timing/formatter/complete.rs
+++ b/src/timing/formatter/complete.rs
@@ -25,7 +25,7 @@ pub struct Complete;
 
 impl Complete {
     /// Creates a new Complete Time Formatter.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Complete
     }
 }

--- a/src/timing/formatter/days.rs
+++ b/src/timing/formatter/days.rs
@@ -24,7 +24,7 @@ pub struct Days;
 
 impl Days {
     /// Creates a new Days Time Formatter.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Days
     }
 }

--- a/src/timing/formatter/delta.rs
+++ b/src/timing/formatter/delta.rs
@@ -29,27 +29,27 @@ pub struct Delta(bool, Accuracy);
 impl Delta {
     /// Creates a new default Delta Time Formatter that drops the fractional
     /// part and uses tenths when showing the fractional part.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Delta(true, Accuracy::Tenths)
     }
 
     /// Creates a new custom Delta Time Formatter where you can specify whether
     /// the fractional part should be dropped for deltas that are larger than 1
     /// minute and how many digits to show for the fractional part.
-    pub fn custom(drop_decimals: bool, accuracy: Accuracy) -> Self {
+    pub const fn custom(drop_decimals: bool, accuracy: Accuracy) -> Self {
         Delta(drop_decimals, accuracy)
     }
 
     /// Creates a new Delta Time Formatter that drops the fractional part and
     /// uses tenths when showing the fractional part.
-    pub fn with_decimal_dropping() -> Self {
+    pub const fn with_decimal_dropping() -> Self {
         Delta(true, Accuracy::Tenths)
     }
 }
 
 impl Default for Delta {
     fn default() -> Self {
-        Delta(true, Accuracy::Tenths)
+        Self::new()
     }
 }
 

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -29,22 +29,22 @@ pub struct Regular {
 impl Regular {
     /// Creates a new default Regular Time Formatter that doesn't show a
     /// fractional part.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Regular {
+            accuracy: Accuracy::Seconds,
+        }
     }
 
     /// Creates a new custom Regular Time Formatter where you can specify how
     /// many digits to show for the fractional part.
-    pub fn with_accuracy(accuracy: Accuracy) -> Self {
+    pub const fn with_accuracy(accuracy: Accuracy) -> Self {
         Regular { accuracy }
     }
 }
 
 impl Default for Regular {
     fn default() -> Self {
-        Regular {
-            accuracy: Accuracy::Seconds,
-        }
+        Self::new()
     }
 }
 

--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -28,22 +28,22 @@ pub struct SegmentTime {
 impl SegmentTime {
     /// Creates a new Segment Time Formatter that uses hundredths for showing
     /// the fractional part.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        SegmentTime {
+            accuracy: Accuracy::Hundredths,
+        }
     }
 
     /// Creates a new Segment Time Formatter that uses the accuracy provided for
     /// showing the fractional part.
-    pub fn with_accuracy(accuracy: Accuracy) -> Self {
+    pub const fn with_accuracy(accuracy: Accuracy) -> Self {
         SegmentTime { accuracy }
     }
 }
 
 impl Default for SegmentTime {
     fn default() -> Self {
-        SegmentTime {
-            accuracy: Accuracy::Hundredths,
-        }
+        Self::new()
     }
 }
 

--- a/src/timing/formatter/short.rs
+++ b/src/timing/formatter/short.rs
@@ -27,22 +27,22 @@ pub struct Short {
 impl Short {
     /// Creates a new Short Time Formatter that uses hundredths for showing the
     /// fractional part.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Short {
+            accuracy: Accuracy::Hundredths,
+        }
     }
 
     /// Creates a new Short Time Formatter that uses the accuracy provided for
     /// showing the fractional part.
-    pub fn with_accuracy(accuracy: Accuracy) -> Self {
+    pub const fn with_accuracy(accuracy: Accuracy) -> Self {
         Short { accuracy }
     }
 }
 
 impl Default for Short {
     fn default() -> Self {
-        Short {
-            accuracy: Accuracy::Hundredths,
-        }
+        Self::new()
     }
 }
 

--- a/src/timing/formatter/timer.rs
+++ b/src/timing/formatter/timer.rs
@@ -32,23 +32,23 @@ pub struct Time {
 
 impl Time {
     /// Creates a new default Time Formatter that doesn't prefix any zeros.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Time {
+            digits_format: DigitsFormat::SingleDigitSeconds,
+        }
     }
 
     /// Creates a new Time Formatter that uses the digits format specified to
     /// determine how many digits to always show. Zeros are prefixed to fill up
     /// the missing digits.
-    pub fn with_digits_format(digits_format: DigitsFormat) -> Self {
+    pub const fn with_digits_format(digits_format: DigitsFormat) -> Self {
         Time { digits_format }
     }
 }
 
 impl Default for Time {
     fn default() -> Self {
-        Time {
-            digits_format: DigitsFormat::SingleDigitSeconds,
-        }
+        Self::new()
     }
 }
 
@@ -122,22 +122,22 @@ pub struct Fraction {
 impl Fraction {
     /// Creates a new default Time Formatter that uses hundredths for showing
     /// the fractional part.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Fraction {
+            accuracy: Accuracy::Hundredths,
+        }
     }
 
     /// Creates a new Time Formatter that uses the accuracy provided for showing
     /// the fractional part.
-    pub fn with_accuracy(accuracy: Accuracy) -> Self {
+    pub const fn with_accuracy(accuracy: Accuracy) -> Self {
         Fraction { accuracy }
     }
 }
 
 impl Default for Fraction {
     fn default() -> Self {
-        Fraction {
-            accuracy: Accuracy::Hundredths,
-        }
+        Self::new()
     }
 }
 

--- a/src/timing/time.rs
+++ b/src/timing/time.rs
@@ -32,14 +32,14 @@ impl Time {
     /// Creates a new Time based on the current one where the Real Time is
     /// replaced by the given Time Span.
     #[inline]
-    pub fn with_real_time(self, real_time: Option<TimeSpan>) -> Self {
+    pub const fn with_real_time(self, real_time: Option<TimeSpan>) -> Self {
         Time { real_time, ..self }
     }
 
     /// Creates a new Time based on the current one where the Game Time is
     /// replaced by the given Time Span.
     #[inline]
-    pub fn with_game_time(self, game_time: Option<TimeSpan>) -> Self {
+    pub const fn with_game_time(self, game_time: Option<TimeSpan>) -> Self {
         Time { game_time, ..self }
     }
 

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -1,8 +1,9 @@
-use crate::platform::prelude::*;
-use crate::platform::Duration;
-use core::num::ParseFloatError;
-use core::ops::{AddAssign, SubAssign};
-use core::str::FromStr;
+use crate::platform::{prelude::*, Duration};
+use core::{
+    num::ParseFloatError,
+    ops::{AddAssign, SubAssign},
+    str::FromStr,
+};
 use derive_more::{Add, From, Neg, Sub};
 use snafu::ResultExt;
 
@@ -34,7 +35,7 @@ impl TimeSpan {
     }
 
     /// Converts the Time Span to a Duration from the `chrono` crate.
-    pub fn to_duration(&self) -> Duration {
+    pub const fn to_duration(&self) -> Duration {
         self.0
     }
 

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -1,7 +1,7 @@
-use crate::comparison::personal_best;
-use crate::platform::prelude::*;
-use crate::TimerPhase::*;
-use crate::{AtomicDateTime, Run, Segment, Time, TimeSpan, TimeStamp, TimerPhase, TimingMethod};
+use crate::{
+    comparison::personal_best, platform::prelude::*, AtomicDateTime, Run, Segment, Time, TimeSpan,
+    TimeStamp, TimerPhase, TimerPhase::*, TimingMethod,
+};
 use core::{mem, ops::Deref};
 
 #[cfg(test)]
@@ -69,7 +69,7 @@ pub struct Snapshot<'timer> {
 impl Snapshot<'_> {
     /// Returns the time the timer was at when the snapshot was taken. The Game
     /// Time is None if the Game Time has not been initialized.
-    pub fn current_time(&self) -> Time {
+    pub const fn current_time(&self) -> Time {
         self.time
     }
 }
@@ -174,7 +174,7 @@ impl Timer {
 
     /// Accesses the Run in use by the Timer.
     #[inline]
-    pub fn run(&self) -> &Run {
+    pub const fn run(&self) -> &Run {
         &self.run
     }
 
@@ -187,7 +187,7 @@ impl Timer {
 
     /// Returns the current Timer Phase.
     #[inline]
-    pub fn current_phase(&self) -> TimerPhase {
+    pub const fn current_phase(&self) -> TimerPhase {
         self.phase
     }
 
@@ -231,7 +231,7 @@ impl Timer {
 
     /// Returns the currently selected Timing Method.
     #[inline]
-    pub fn current_timing_method(&self) -> TimingMethod {
+    pub const fn current_timing_method(&self) -> TimingMethod {
         self.current_timing_method
     }
 
@@ -289,7 +289,7 @@ impl Timer {
     /// finished, but has not been reset. So you need to be careful when using
     /// this value for indexing.
     #[inline]
-    pub fn current_split_index(&self) -> Option<usize> {
+    pub const fn current_split_index(&self) -> Option<usize> {
         self.current_split_index
     }
 
@@ -558,7 +558,7 @@ impl Timer {
     /// Returns whether Game Time is currently initialized. Game Time
     /// automatically gets uninitialized for each new attempt.
     #[inline]
-    pub fn is_game_time_initialized(&self) -> bool {
+    pub const fn is_game_time_initialized(&self) -> bool {
         self.loading_times.is_some()
     }
 
@@ -578,7 +578,7 @@ impl Timer {
     /// Returns whether the Game Timer is currently paused. If the Game Timer is
     /// not paused, it automatically increments similar to Real Time.
     #[inline]
-    pub fn is_game_time_paused(&self) -> bool {
+    pub const fn is_game_time_paused(&self) -> bool {
         self.is_game_time_paused
     }
 

--- a/src/timing/timing_method.rs
+++ b/src/timing/timing_method.rs
@@ -16,7 +16,7 @@ pub enum TimingMethod {
 
 impl TimingMethod {
     /// Returns an array of all the timing methods.
-    pub fn all() -> [TimingMethod; 2] {
+    pub const fn all() -> [TimingMethod; 2] {
         [TimingMethod::RealTime, TimingMethod::GameTime]
     }
 }

--- a/src/xml_util.rs
+++ b/src/xml_util.rs
@@ -60,7 +60,7 @@ impl<'a> Deref for Tag<'a> {
 }
 
 impl<'a> Tag<'a> {
-    pub unsafe fn new(tag: BytesStart<'a>, buf: *mut Vec<u8>) -> Self {
+    pub const unsafe fn new(tag: BytesStart<'a>, buf: *mut Vec<u8>) -> Self {
         Tag(tag, buf)
     }
 


### PR DESCRIPTION
This activates a clippy lint that warns if a function can be converted to const fn. All those functions (minus a few false positives) are now const fn.