### PR TITLE
Properly propagate web features to `parking_lot`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = ["std", "more-image-formats", "euclid", "ttf-parser", "rustybuzz", "bytemuck/derive"]
 font-loading = ["std", "rendering", "font-kit"]
 software-rendering = ["rendering", "tiny-skia"]
-wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web"]
+wasm-web = ["std", "web-sys", "chrono/wasmbind", "livesplit-hotkey/wasm-web", "parking_lot/wasm-bindgen"]
 networking = ["std", "splits-io-api"]
 
 # FIXME: Some targets don't have atomics, but we can't test for this properly

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -168,10 +168,7 @@ unsafe fn release_file(file: File) {
 unsafe fn release_file(_: File) {}
 
 /// Allocate memory.
-#[cfg(all(
-    target_arch = "wasm32",
-    not(any(target_os = "wasi", feature = "wasm-web")),
-))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 #[no_mangle]
 pub extern "C" fn alloc(size: usize) -> *mut u8 {
     let mut buf = Vec::with_capacity(size);
@@ -181,10 +178,7 @@ pub extern "C" fn alloc(size: usize) -> *mut u8 {
 }
 
 /// Deallocate memory.
-#[cfg(all(
-    target_arch = "wasm32",
-    not(any(target_os = "wasi", feature = "wasm-web")),
-))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 #[no_mangle]
 pub extern "C" fn dealloc(ptr: *mut u8, cap: usize) {
     unsafe {

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -38,4 +38,4 @@ snafu = { version = "0.6.0", default-features = false }
 [features]
 default = ["std"]
 std = ["snafu/std", "serde/std", "parking_lot", "x11-dl", "mio", "promising-future", "winapi", "bitflags"]
-wasm-web = ["wasm-bindgen", "web-sys"]
+wasm-web = ["wasm-bindgen", "web-sys", "parking_lot/wasm-bindgen"]


### PR DESCRIPTION
If we are compiling to WASM with wasm-bindgen, then we need to propagate these features to `parking_lot` so it can use wasm-bindgen to query for time stamps which it internally needs to do.

Fixes #426 