### PR TITLE
remove derive_more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ members = ["capi", "capi/bind_gen", "capi/staticlib", "capi/cdylib", "crates/*"]
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.10", default-features = false, features = ["serde", "alloc"] }
-derive_more = { version = "0.99.1", default-features = false, features = ["not", "add", "from", "deref"] }
 hashbrown = "0.11.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.5.0", default-features = false }

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -11,7 +11,7 @@ use alloc::borrow::Cow;
 
 /// A Component provides information about a run in a way that is easy to
 /// visualize. This type can store any of the components provided by this crate.
-#[derive(derive_more::From, Clone)]
+#[derive(Clone)]
 pub enum Component {
     /// The Blank Space Component.
     BlankSpace(blank_space::Component),
@@ -47,6 +47,108 @@ pub enum Component {
     Title(title::Component),
     /// The Total Playtime Component.
     TotalPlaytime(total_playtime::Component),
+}
+
+impl From<blank_space::Component> for Component {
+    fn from(component: blank_space::Component) -> Self {
+        Self::BlankSpace(component)
+    }
+}
+
+impl From<current_comparison::Component> for Component {
+    fn from(component: current_comparison::Component) -> Self {
+        Self::CurrentComparison(component)
+    }
+}
+
+impl From<current_pace::Component> for Component {
+    fn from(component: current_pace::Component) -> Self {
+        Self::CurrentPace(component)
+    }
+}
+
+impl From<delta::Component> for Component {
+    fn from(component: delta::Component) -> Self {
+        Self::Delta(component)
+    }
+}
+
+impl From<Box<detailed_timer::Component>> for Component {
+    fn from(component: Box<detailed_timer::Component>) -> Self {
+        Self::DetailedTimer(component)
+    }
+}
+
+impl From<graph::Component> for Component {
+    fn from(component: graph::Component) -> Self {
+        Self::Graph(component)
+    }
+}
+
+impl From<pb_chance::Component> for Component {
+    fn from(component: pb_chance::Component) -> Self {
+        Self::PbChance(component)
+    }
+}
+
+impl From<possible_time_save::Component> for Component {
+    fn from(component: possible_time_save::Component) -> Self {
+        Self::PossibleTimeSave(component)
+    }
+}
+
+impl From<previous_segment::Component> for Component {
+    fn from(component: previous_segment::Component) -> Self {
+        Self::PreviousSegment(component)
+    }
+}
+
+impl From<segment_time::Component> for Component {
+    fn from(component: segment_time::Component) -> Self {
+        Self::SegmentTime(component)
+    }
+}
+
+impl From<separator::Component> for Component {
+    fn from(component: separator::Component) -> Self {
+        Self::Separator(component)
+    }
+}
+
+impl From<splits::Component> for Component {
+    fn from(component: splits::Component) -> Self {
+        Self::Splits(component)
+    }
+}
+
+impl From<sum_of_best::Component> for Component {
+    fn from(component: sum_of_best::Component) -> Self {
+        Self::SumOfBest(component)
+    }
+}
+
+impl From<text::Component> for Component {
+    fn from(component: text::Component) -> Self {
+        Self::Text(component)
+    }
+}
+
+impl From<timer::Component> for Component {
+    fn from(component: timer::Component) -> Self {
+        Self::Timer(component)
+    }
+}
+
+impl From<title::Component> for Component {
+    fn from(component: title::Component) -> Self {
+        Self::Title(component)
+    }
+}
+
+impl From<total_playtime::Component> for Component {
+    fn from(component: total_playtime::Component) -> Self {
+        Self::TotalPlaytime(component)
+    }
 }
 
 impl Component {

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -45,7 +45,7 @@ fn translate_size(v: u32) -> u32 {
 }
 
 /// The Error type for parsing layout files of the original LiveSplit.
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 pub enum Error {
     /// The underlying XML format couldn't be parsed.
     Xml {
@@ -87,6 +87,30 @@ pub enum Error {
     ParseFont,
     /// Parsed an empty layout, which is considered an invalid layout.
     Empty,
+}
+
+impl From<XmlError> for Error {
+    fn from(source: XmlError) -> Self {
+        Self::Xml { source }
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(source: core::str::Utf8Error) -> Self {
+        Self::Utf8Str { source }
+    }
+}
+
+impl From<alloc::string::FromUtf8Error> for Error {
+    fn from(source: alloc::string::FromUtf8Error) -> Self {
+        Self::Utf8String { source }
+    }
+}
+
+impl From<core::num::ParseIntError> for Error {
+    fn from(source: core::num::ParseIntError) -> Self {
+        Self::ParseInt { source }
+    }
 }
 
 /// The Result type for parsing layout files of the original LiveSplit.

--- a/src/run/parser/flitter/s_expressions.rs
+++ b/src/run/parser/flitter/s_expressions.rs
@@ -8,7 +8,7 @@ use utf8::{BufReadDecoder, BufReadDecoderError};
 
 /// The Error types for splits files that couldn't be parsed by the Flitter
 /// Parser.
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 pub enum Error {
     /// Trailing Characters
     TrailingCharacters,
@@ -46,6 +46,18 @@ impl From<BufReadDecoderError<'_>> for Error {
             BufReadDecoderError::InvalidByteSequence(_) => Error::InvalidUtf8,
             BufReadDecoderError::Io(source) => Error::Io { source },
         }
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(source: ParseIntError) -> Self {
+        Self::ParseInt { source }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(source: io::Error) -> Self {
+        Self::Io { source }
     }
 }
 

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -17,7 +17,7 @@ use chrono::ParseError as ChronoError;
 
 /// The Error type for splits files that couldn't be parsed by the LiveSplit
 /// Parser.
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 pub enum Error {
     /// The underlying XML format couldn't be parsed.
     Xml {
@@ -63,6 +63,54 @@ pub enum Error {
     ParseBool,
     /// Failed to parse the scope of a custom variable.
     Scope,
+}
+
+impl From<XmlError> for Error {
+    fn from(source: XmlError) -> Self {
+        Self::Xml { source }
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(source: core::str::Utf8Error) -> Self {
+        Self::Utf8Str { source }
+    }
+}
+
+impl From<alloc::string::FromUtf8Error> for Error {
+    fn from(source: alloc::string::FromUtf8Error) -> Self {
+        Self::Utf8String { source }
+    }
+}
+
+impl From<core::num::ParseIntError> for Error {
+    fn from(source: core::num::ParseIntError) -> Self {
+        Self::ParseInt { source }
+    }
+}
+
+impl From<core::num::ParseFloatError> for Error {
+    fn from(source: core::num::ParseFloatError) -> Self {
+        Self::ParseFloat { source }
+    }
+}
+
+impl From<crate::timing::ParseError> for Error {
+    fn from(source: crate::timing::ParseError) -> Self {
+        Self::ParseTime { source }
+    }
+}
+
+impl From<ChronoError> for Error {
+    fn from(source: ChronoError) -> Self {
+        Self::ParseDate { source }
+    }
+}
+
+impl From<ComparisonError> for Error {
+    fn from(source: ComparisonError) -> Self {
+        Self::InvalidComparisonName { source }
+    }
 }
 
 /// The Result type for the LiveSplit Parser.

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -18,7 +18,7 @@ use crate::xml_util::Error as XmlError;
 
 /// The Error type for splits files that couldn't be parsed by the Llanfair (Gered)
 /// Parser.
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 pub enum Error {
     /// The underlying XML format couldn't be parsed.
     Xml {
@@ -44,6 +44,30 @@ pub enum Error {
     LengthOutOfBounds,
     /// Failed to parse an image.
     Image,
+}
+
+impl From<XmlError> for Error {
+    fn from(source: XmlError) -> Self {
+        Self::Xml { source }
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(source: core::str::Utf8Error) -> Self {
+        Self::Utf8Str { source }
+    }
+}
+
+impl From<alloc::string::FromUtf8Error> for Error {
+    fn from(source: alloc::string::FromUtf8Error) -> Self {
+        Self::Utf8String { source }
+    }
+}
+
+impl From<core::num::ParseIntError> for Error {
+    fn from(source: core::num::ParseIntError) -> Self {
+        Self::Int { source }
+    }
 }
 
 /// The Result type for the Llanfair (Gered) Parser.

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -38,7 +38,7 @@ use std::io::Write;
 
 static LSS_IMAGE_HEADER: &[u8; 156] = include_bytes!("lss_image_header.bin");
 
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 /// The Error type for splits files that couldn't be saved by the LiveSplit
 /// Saver.
 pub enum Error {
@@ -48,6 +48,12 @@ pub enum Error {
         /// The underlying error.
         error: XmlError,
     },
+}
+
+impl From<XmlError> for Error {
+    fn from(error: XmlError) -> Self {
+        Error::Xml { error }
+    }
 }
 
 /// The Result type for the LiveSplit Saver.

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -1,6 +1,6 @@
 use crate::platform::prelude::*;
 use base64::{display::Base64Display, STANDARD};
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{ops::Deref, sync::atomic::{AtomicUsize, Ordering}};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ pub struct Image {
 /// used in state objects. It can efficiently be serialized for various formats.
 /// For binary formats it gets serialized as its raw byte representation, while
 /// for textual formats it gets serialized as a Base64 Data URL instead.
-#[derive(Debug, Clone, derive_more::Deref)]
+#[derive(Debug, Clone)]
 pub struct ImageData(pub Box<[u8]>);
 
 impl<T> From<T> for ImageData
@@ -34,6 +34,13 @@ where
 {
     fn from(value: T) -> Self {
         ImageData(value.into())
+    }
+}
+
+impl Deref for ImageData {
+    type Target = Box<[u8]>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// Describes a setting's value. Such a value can be of a variety of different
 /// types.
-#[derive(Clone, PartialEq, derive_more::From, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum Value {
     /// A boolean value.
     Bool(bool),
@@ -57,6 +57,120 @@ pub enum Value {
     /// A value describing a font to use. `None` if a default font should be
     /// used.
     Font(Option<Font>),
+}
+
+impl From<bool> for Value {
+    fn from(x: bool) -> Self {
+        Value::Bool(x)
+    }
+}
+
+impl From<u64> for Value {
+    fn from(x: u64) -> Self {
+        Value::UInt(x)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(x: i64) -> Self {
+        Value::Int(x)
+    }
+}
+
+impl From<String> for Value {
+    fn from(x: String) -> Self {
+        Value::String(x)
+    }
+}
+
+impl From<Option<String>> for Value {
+    fn from(x: Option<String>) -> Self {
+        Value::OptionalString(x)
+    }
+}
+
+impl From<Accuracy> for Value {
+    fn from(x: Accuracy) -> Self {
+        Value::Accuracy(x)
+    }
+}
+
+impl From<DigitsFormat> for Value {
+    fn from(x: DigitsFormat) -> Self {
+        Value::DigitsFormat(x)
+    }
+}
+
+impl From<Option<TimingMethod>> for Value {
+    fn from(x: Option<TimingMethod>) -> Self {
+        Value::OptionalTimingMethod(x)
+    }
+}
+
+impl From<Color> for Value {
+    fn from(x: Color) -> Self {
+        Value::Color(x)
+    }
+}
+
+impl From<Option<Color>> for Value {
+    fn from(x: Option<Color>) -> Self {
+        Value::OptionalColor(x)
+    }
+}
+
+impl From<Gradient> for Value {
+    fn from(x: Gradient) -> Self {
+        Value::Gradient(x)
+    }
+}
+
+impl From<ListGradient> for Value {
+    fn from(x: ListGradient) -> Self {
+        Value::ListGradient(x)
+    }
+}
+
+impl From<Alignment> for Value {
+    fn from(x: Alignment) -> Self {
+        Value::Alignment(x)
+    }
+}
+
+impl From<ColumnStartWith> for Value {
+    fn from(x: ColumnStartWith) -> Self {
+        Value::ColumnStartWith(x)
+    }
+}
+
+impl From<ColumnUpdateWith> for Value {
+    fn from(x: ColumnUpdateWith) -> Self {
+        Value::ColumnUpdateWith(x)
+    }
+}
+
+impl From<ColumnUpdateTrigger> for Value {
+    fn from(x: ColumnUpdateTrigger) -> Self {
+        Value::ColumnUpdateTrigger(x)
+    }
+}
+
+impl From<Option<KeyCode>> for Value {
+    fn from(x: Option<KeyCode>) -> Self {
+        Value::Hotkey(x)
+    }
+}
+
+impl From<LayoutDirection> for Value {
+    fn from(x: LayoutDirection) -> Self {
+        Value::LayoutDirection(x)
+    }
+}
+
+impl From<Option<Font>> for Value {
+    fn from(x: Option<Font>) -> Self {
+        Value::Font(x)
+    }
 }
 
 /// The Error type for values that couldn't be converted.

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -1,14 +1,13 @@
 use crate::platform::{prelude::*, Duration};
 use core::{
     num::ParseFloatError,
-    ops::{AddAssign, SubAssign},
+    ops::{Add, AddAssign, Neg, Sub, SubAssign},
     str::FromStr,
 };
-use derive_more::{Add, From, Neg, Sub};
 use snafu::ResultExt;
 
 /// A Time Span represents a certain span of time.
-#[derive(From, Add, Sub, Neg, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TimeSpan(Duration);
 
 impl TimeSpan {
@@ -106,21 +105,48 @@ impl Default for TimeSpan {
     }
 }
 
+impl From<Duration> for TimeSpan {
+    fn from(duration: Duration) -> Self {
+        TimeSpan(duration)
+    }
+}
+
 impl From<core::time::Duration> for TimeSpan {
     fn from(duration: core::time::Duration) -> Self {
         TimeSpan(Duration::from_std(duration).unwrap())
     }
 }
 
+impl Add for TimeSpan {
+    type Output = TimeSpan;
+    fn add(self, rhs: TimeSpan) -> TimeSpan {
+        TimeSpan(self.0 + rhs.0)
+    }
+}
+
+impl Sub for TimeSpan {
+    type Output = TimeSpan;
+    fn sub(self, rhs: TimeSpan) -> TimeSpan {
+        TimeSpan(self.0 - rhs.0)
+    }
+}
+
 impl AddAssign for TimeSpan {
     fn add_assign(&mut self, rhs: TimeSpan) {
-        self.0 = self.0 + rhs.0;
+        *self = *self + rhs;
     }
 }
 
 impl SubAssign for TimeSpan {
     fn sub_assign(&mut self, rhs: TimeSpan) {
-        self.0 = self.0 - rhs.0;
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for TimeSpan {
+    type Output = TimeSpan;
+    fn neg(self) -> TimeSpan {
+        TimeSpan(-self.0)
     }
 }
 

--- a/src/xml_util.rs
+++ b/src/xml_util.rs
@@ -13,7 +13,7 @@ use quick_xml::{
 use std::io::{self, BufRead};
 
 /// The Error type for XML-based splits files that couldn't be parsed.
-#[derive(Debug, snafu::Snafu, derive_more::From)]
+#[derive(Debug, snafu::Snafu)]
 pub enum Error {
     /// Failed to parse the XML.
     #[snafu(display("{}", error))]
@@ -44,6 +44,54 @@ pub enum Error {
     Time { source: timing::ParseError },
     /// Failed to parse a date.
     Date { source: ChronoError },
+}
+
+impl From<XmlError> for Error {
+    fn from(error: XmlError) -> Self {
+        Self::Xml { error }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(source: io::Error) -> Self {
+        Self::Io { source }
+    }
+}
+
+impl From<str::Utf8Error> for Error {
+    fn from(source: str::Utf8Error) -> Self {
+        Self::Utf8Str { source }
+    }
+}
+
+impl From<string::FromUtf8Error> for Error {
+    fn from(source: string::FromUtf8Error) -> Self {
+        Self::Utf8String { source }
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(source: ParseIntError) -> Self {
+        Self::Int { source }
+    }
+}
+
+impl From<ParseFloatError> for Error {
+    fn from(source: ParseFloatError) -> Self {
+        Self::Float { source }
+    }
+}
+
+impl From<timing::ParseError> for Error {
+    fn from(source: timing::ParseError) -> Self {
+        Self::Time { source }
+    }
+}
+
+impl From<ChronoError> for Error {
+    fn from(source: ChronoError) -> Self {
+        Self::Date { source }
+    }
 }
 
 /// The Result type for Parsers that parse XML-based splits files.


### PR DESCRIPTION
Issue #424 suggests removing derive_more and writing out the impls explicitly, which is what this commit does.