### PR TITLE
Use Rust 1.53 Features

### DIFF
--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -130,11 +130,11 @@ impl Hook {
             loop {
                 let mut msg = mem::MaybeUninit::uninit();
                 let ret = unsafe { GetMessageW(msg.as_mut_ptr(), ptr::null_mut(), 0, 0) };
-                let msg = unsafe { msg.assume_init() };
-                if msg.message == MSG_EXIT {
-                    break;
-                } else if ret < 0 {
+                if ret < 0 {
                     return Err(Error::MessageLoop);
+                }
+                if unsafe { msg.assume_init().message } == MSG_EXIT {
+                    break;
                 }
             }
 

--- a/src/comparison/best_segments.rs
+++ b/src/comparison/best_segments.rs
@@ -1,9 +1,10 @@
 //! Defines the Comparison Generator for calculating the Best Segments of a Run.
 
 use super::ComparisonGenerator;
-use crate::analysis::sum_of_segments::best::calculate;
-use crate::platform::prelude::*;
-use crate::{Attempt, Segment, Time, TimingMethod};
+use crate::{
+    analysis::sum_of_segments::best::calculate, platform::prelude::*, Attempt, Segment, Time,
+    TimingMethod,
+};
 
 /// The Comparison Generator for calculating the Best Segments of a Run.
 #[derive(Copy, Clone, Debug)]
@@ -27,7 +28,7 @@ impl ComparisonGenerator for BestSegments {
             .iter_mut()
             .for_each(|s| *s.comparison_mut(NAME) = Time::new());
 
-        for &method in &TimingMethod::all() {
+        for method in TimingMethod::all() {
             predictions.clear();
             predictions.resize(segments.len() + 1, None);
 

--- a/src/comparison/worst_segments.rs
+++ b/src/comparison/worst_segments.rs
@@ -1,9 +1,10 @@
 //! Defines the Comparison Generator for calculating the Worst Segments of a Run.
 
 use super::ComparisonGenerator;
-use crate::analysis::sum_of_segments::worst::calculate;
-use crate::platform::prelude::*;
-use crate::{Attempt, Segment, Time, TimingMethod};
+use crate::{
+    analysis::sum_of_segments::worst::calculate, platform::prelude::*, Attempt, Segment, Time,
+    TimingMethod,
+};
 
 /// The Comparison Generator for calculating the Worst Segments of a Run.
 #[derive(Copy, Clone, Debug)]
@@ -27,7 +28,7 @@ impl ComparisonGenerator for WorstSegments {
             .iter_mut()
             .for_each(|s| *s.comparison_mut(NAME) = Time::new());
 
-        for &method in &TimingMethod::all() {
+        for method in TimingMethod::all() {
             predictions.clear();
             predictions.resize(segments.len() + 1, None);
 

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -273,7 +273,7 @@ fn column_update_value(
             ColumnFormatter::Time,
         ),
 
-        (Delta, false) | (DeltaWithFallback, false) => {
+        (Delta | DeltaWithFallback, false) => {
             let split_time = segment.split_time()[method];
             let delta = catch! {
                 split_time? -
@@ -290,7 +290,7 @@ fn column_update_value(
                 formatter,
             )
         }
-        (Delta, true) | (DeltaWithFallback, true) => (
+        (Delta | DeltaWithFallback, true) => (
             catch! {
                 timer.current_time()[method]? -
                 segment.comparison(comparison)[method]?
@@ -310,7 +310,7 @@ fn column_update_value(
             ColumnFormatter::Time,
         ),
 
-        (SegmentDelta, false) | (SegmentDeltaWithFallback, false) => {
+        (SegmentDelta | SegmentDeltaWithFallback, false) => {
             let delta = analysis::previous_segment_delta(timer, segment_index, comparison, method);
             let (value, formatter) = if delta.is_none() && column.update_with.has_fallback() {
                 (
@@ -326,7 +326,7 @@ fn column_update_value(
                 formatter,
             )
         }
-        (SegmentDelta, true) | (SegmentDeltaWithFallback, true) => (
+        (SegmentDelta | SegmentDeltaWithFallback, true) => (
             analysis::live_segment_delta(timer, segment_index, comparison, method),
             SemanticColor::Default,
             ColumnFormatter::Delta,

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
+use core::array;
+
 use crate::{
     hotkey::KeyCode,
     platform::prelude::*,
@@ -118,7 +120,7 @@ impl HotkeyConfig {
         let value: Option<KeyCode> = value.into();
 
         if value.is_some() {
-            let any = [
+            let any = array::IntoIter::new([
                 self.split,
                 self.reset,
                 self.undo,
@@ -128,11 +130,10 @@ impl HotkeyConfig {
                 self.previous_comparison,
                 self.next_comparison,
                 self.toggle_timing_method,
-            ]
-            .iter()
+            ])
             .enumerate()
             .filter(|&(i, _)| i != index)
-            .any(|(_, &v)| v == value);
+            .any(|(_, v)| v == value);
 
             if any {
                 return Err(());

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -521,7 +521,7 @@ impl Run {
     /// comparison times and history, removing duplicates in the segment
     /// histories and removing empty times.
     pub fn fix_splits(&mut self) {
-        for &method in &TimingMethod::all() {
+        for method in TimingMethod::all() {
             self.fix_comparison_times_and_history(method);
         }
         self.remove_duplicates();
@@ -676,7 +676,7 @@ impl Run {
     /// Personal Best times and adding those to the Segment History.
     pub fn import_pb_into_segment_history(&mut self) {
         if let Some(mut index) = self.min_segment_history_index() {
-            for &timing_method in &TimingMethod::all() {
+            for timing_method in TimingMethod::all() {
                 index -= 1;
                 let mut prev_time = TimeSpan::zero();
 


### PR DESCRIPTION
In Rust 1.53 that just released, you can directly iterate over arrays and `or patterns` are now allowed anywhere within a pattern. This cleans up our code a bit.