### PR TITLE
Fix `isize` in Bindings Generator

### DIFF
--- a/capi/bind_gen/src/c.rs
+++ b/capi/bind_gen/src/c.rs
@@ -1,7 +1,9 @@
 use crate::{Class, Type, TypeKind};
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_type(ty: &Type) -> Cow<'_, str> {
     let mut name = Cow::Borrowed(match ty.name.as_str() {
@@ -14,6 +16,7 @@ fn get_type(ty: &Type) -> Cow<'_, str> {
         "u32" => "uint32_t",
         "u64" => "uint64_t",
         "usize" => "size_t",
+        "isize" => "ssize_t",
         "f32" => "float",
         "f64" => "double",
         "bool" => "bool",

--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -1,7 +1,9 @@
 use crate::{Class, Function, Type, TypeKind};
 use heck::{CamelCase, MixedCase};
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -13,6 +15,8 @@ fn get_hl_type(ty: &Type) -> String {
     } else if ty.name == "bool" {
         "bool".to_string()
     } else if ty.name == "usize" {
+        "ulong".to_string()
+    } else if ty.name == "isize" {
         "long".to_string()
     } else {
         let ret = get_ll_type(ty, false).to_string();
@@ -38,6 +42,7 @@ fn get_ll_type(ty: &Type, output: bool) -> &str {
             "u32" => "uint",
             "u64" => "ulong",
             "usize" => "UIntPtr",
+            "isize" => "IntPtr",
             "f32" => "float",
             "f64" => "double",
             "bool" => {
@@ -183,6 +188,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         } else {
             write!(writer, "var result = ")?;
             if return_type_ll == "UIntPtr" {
+                write!(writer, "(ulong)")?;
+            } else if return_type_ll == "IntPtr" {
                 write!(writer, "(long)")?;
             }
         }
@@ -202,6 +209,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
                 "this.ptr".to_string()
             } else if ty_name == "UIntPtr" {
                 format!("(UIntPtr){}", name.to_mixed_case())
+            } else if ty_name == "IntPtr" {
+                format!("(IntPtr){}", name.to_mixed_case())
             } else if typ.is_custom {
                 format!("{}.ptr", name.to_mixed_case())
             } else {

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -1,10 +1,12 @@
 use super::write_class_comments;
 use crate::{Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufWriter, Result, Write};
-use std::path::Path;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufWriter, Result, Write},
+    path::Path,
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -15,7 +17,7 @@ fn get_hl_type(ty: &Type) -> String {
         }
     } else if ty.name == "bool" {
         "boolean".to_string()
-    } else if ty.name == "usize" {
+    } else if ty.name == "usize" || ty.name == "isize" {
         "long".to_string()
     } else {
         get_ll_type(ty).to_string()
@@ -37,6 +39,7 @@ fn get_ll_type(ty: &Type) -> &str {
                 "u32" => "int",
                 "u64" => "long",
                 "usize" => "NativeLong", // Not really correct
+                "isize" => "NativeLong", // Not really correct
                 "f32" => "float",
                 "f64" => "double",
                 "bool" => "byte",

--- a/capi/bind_gen/src/java/jni.rs
+++ b/capi/bind_gen/src/java/jni.rs
@@ -1,10 +1,12 @@
 use super::write_class_comments;
 use crate::{Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufWriter, Result, Write};
-use std::path::Path;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufWriter, Result, Write},
+    path::Path,
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -15,14 +17,14 @@ fn get_hl_type(ty: &Type) -> String {
         }
     } else if ty.name == "bool" {
         "boolean".to_string()
-    } else if ty.name == "usize" {
+    } else if ty.name == "usize" || ty.name == "isize" {
         "long".to_string()
     } else {
         get_ll_type(ty).to_string()
     }
 }
 
-fn get_ll_type<'a>(ty: &'a Type) -> &'a str {
+fn get_ll_type(ty: &Type) -> &str {
     match (ty.kind, ty.name.as_str()) {
         (TypeKind::Ref, "c_char") => "String",
         (TypeKind::Ref, _) | (TypeKind::RefMut, _) => "long",
@@ -36,6 +38,7 @@ fn get_ll_type<'a>(ty: &'a Type) -> &'a str {
             "u32" => "int",
             "u64" => "long",
             "usize" => "long",
+            "isize" => "long",
             "f32" => "float",
             "f64" => "double",
             "bool" => "boolean",

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -1,8 +1,10 @@
 use crate::{Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_c_type(ty: &Type) -> Cow<'_, str> {
     let mut name = Cow::Borrowed(match ty.name.as_str() {
@@ -15,6 +17,7 @@ fn get_c_type(ty: &Type) -> Cow<'_, str> {
         "u32" => "uint32_t",
         "u64" => "uint64_t",
         "usize" => "size_t",
+        "isize" => "ssize_t",
         "f32" => "float",
         "f64" => "double",
         "bool" => "bool",
@@ -50,6 +53,7 @@ fn get_jni_type(ty: &Type) -> &str {
             "u32" => "jint",
             "u64" => "jlong",
             "usize" => "jlong",
+            "isize" => "jlong",
             "f32" => "jfloat",
             "f64" => "jdouble",
             "bool" => "jboolean",

--- a/capi/bind_gen/src/kotlin/jni.rs
+++ b/capi/bind_gen/src/kotlin/jni.rs
@@ -1,9 +1,11 @@
 use crate::{Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufWriter, Result, Write};
-use std::path::Path;
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufWriter, Result, Write},
+    path::Path,
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -14,14 +16,14 @@ fn get_hl_type(ty: &Type) -> String {
         }
     } else if ty.name == "bool" {
         "Boolean".to_string()
-    } else if ty.name == "usize" {
+    } else if ty.name == "usize" || ty.name == "isize" {
         "Long".to_string()
     } else {
         get_ll_type(ty).to_string()
     }
 }
 
-fn get_ll_type<'a>(ty: &'a Type) -> &'a str {
+fn get_ll_type(ty: &Type) -> &str {
     match (ty.kind, ty.name.as_str()) {
         (TypeKind::Ref, "c_char") => "String",
         (TypeKind::Ref, _) | (TypeKind::RefMut, _) => "Long",
@@ -35,6 +37,7 @@ fn get_ll_type<'a>(ty: &'a Type) -> &'a str {
             "u32" => "Int",
             "u64" => "Long",
             "usize" => "Long",
+            "isize" => "Long",
             "f32" => "Float",
             "f64" => "Double",
             "bool" => "Boolean",

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -1,7 +1,9 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type_with_null(ty: &Type) -> String {
     let mut formatted = get_hl_type_without_null(ty);
@@ -32,6 +34,7 @@ fn get_hl_type_without_null(ty: &Type) -> String {
                 "u32" => "number",
                 "u64" => "number",
                 "usize" => "number",
+                "isize" => "number",
                 "f32" => "number",
                 "f64" => "number",
                 "bool" => "boolean",
@@ -60,6 +63,7 @@ fn get_ll_type(ty: &Type) -> &str {
             "u32" => "'uint32'",
             "u64" => "'uint64'",
             "usize" => "'size_t'",
+            "isize" => "'ssize_t'",
             "f32" => "'float'",
             "f64" => "'double'",
             "bool" => "'bool'",

--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -1,6 +1,8 @@
 use crate::{Class, Function, Type, TypeKind};
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -28,6 +30,7 @@ fn get_ll_type(ty: &Type) -> &str {
             "u32" => "c_uint32",
             "u64" => "c_uint64",
             "usize" => "c_size_t",
+            "isize" => "c_ssize_t",
             "f32" => "c_float",
             "f64" => "c_double",
             "bool" => "c_bool",
@@ -224,7 +227,7 @@ pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Resu
 # coding: utf-8
 
 import sys, ctypes
-from ctypes import c_char_p, c_void_p, c_int8, c_int16, c_int32, c_int64, c_uint8, c_uint16, c_uint32, c_uint64, c_size_t, c_float, c_double, c_bool, c_char, c_byte
+from ctypes import c_char_p, c_void_p, c_int8, c_int16, c_int32, c_int64, c_uint8, c_uint16, c_uint32, c_uint64, c_size_t, c_ssize_t, c_float, c_double, c_bool, c_char, c_byte
 
 prefix = {'win32': ''}.get(sys.platform, './lib')
 extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')

--- a/capi/bind_gen/src/ruby.rs
+++ b/capi/bind_gen/src/ruby.rs
@@ -1,6 +1,8 @@
 use crate::{Class, Function, Opt, Type, TypeKind};
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -23,6 +25,7 @@ fn get_hl_type(ty: &Type) -> String {
                 "u32" => "Integer",
                 "u64" => "Integer",
                 "usize" => "Integer",
+                "isize" => "Integer",
                 "f32" => "Float",
                 "f64" => "Float",
                 "bool" => "Boolean",
@@ -51,6 +54,7 @@ fn get_ll_type(ty: &Type) -> &str {
             "u32" => "uint32",
             "u64" => "uint64",
             "usize" => "size_t",
+            "isize" => "ssize_t",
             "f32" => "float",
             "f64" => "double",
             "bool" => "bool",

--- a/capi/bind_gen/src/swift/code.rs
+++ b/capi/bind_gen/src/swift/code.rs
@@ -1,7 +1,9 @@
 use crate::{Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type(ty: &Type) -> String {
     if ty.is_custom {
@@ -14,6 +16,8 @@ fn get_hl_type(ty: &Type) -> String {
         "Bool".to_string()
     } else if ty.name == "usize" {
         "size_t".to_string()
+    } else if ty.name == "isize" {
+        "ssize_t".to_string()
     } else {
         get_ll_type(ty).to_string()
     }
@@ -33,6 +37,7 @@ fn get_ll_type(ty: &Type) -> &str {
             "u32" => "UInt32",
             "u64" => "UInt64",
             "usize" => "size_t",
+            "isize" => "ssize_t",
             "f32" => "Float",
             "f64" => "Double",
             "bool" => "Bool",

--- a/capi/bind_gen/src/swift/header.rs
+++ b/capi/bind_gen/src/swift/header.rs
@@ -1,7 +1,9 @@
 use crate::{Class, Type, TypeKind};
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_type(ty: &Type) -> Cow<'_, str> {
     let mut name = Cow::Borrowed(match ty.name.as_str() {
@@ -14,6 +16,7 @@ fn get_type(ty: &Type) -> Cow<'_, str> {
         "u32" => "uint32_t",
         "u64" => "uint64_t",
         "usize" => "size_t",
+        "isize" => "ssize_t",
         "f32" => "float",
         "f64" => "double",
         "bool" => "bool",

--- a/capi/bind_gen/src/wasm.rs
+++ b/capi/bind_gen/src/wasm.rs
@@ -1,7 +1,9 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type_with_null(ty: &Type) -> String {
     let mut formatted = get_hl_type_without_null(ty);
@@ -31,6 +33,7 @@ fn get_hl_type_without_null(ty: &Type) -> String {
                 "u32" => "number",
                 "u64" => "number",
                 "usize" => "number",
+                "isize" => "number",
                 "f32" => "number",
                 "f64" => "number",
                 "bool" => "boolean",

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -1,7 +1,9 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
 use heck::MixedCase;
-use std::collections::BTreeMap;
-use std::io::{Result, Write};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+};
 
 fn get_hl_type_with_null(ty: &Type) -> String {
     let mut formatted = get_hl_type_without_null(ty);
@@ -31,6 +33,7 @@ fn get_hl_type_without_null(ty: &Type) -> String {
                 "u32" => "number",
                 "u64" => "number",
                 "usize" => "number",
+                "isize" => "number",
                 "f32" => "number",
                 "f64" => "number",
                 "bool" => "boolean",


### PR DESCRIPTION
Turns out that `isize` is a type we never used before, so all the bindings broke.