### PR TITLE
Fix setting hotkeys when `HotkeySystem` is disabled

### DIFF
--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -136,13 +136,15 @@ impl HotkeySystem {
     }
 
     fn set_hotkey(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {
-        // FixMe: We do not check whether the keycode is already in use
+        // FIXME: We do not check whether the keycode is already in use
         if hotkey.get_keycode(&self.config) == keycode {
             return Ok(());
         }
         if self.is_active {
             self.unregister(hotkey)?;
             self.register(hotkey, keycode)?;
+        } else {
+            hotkey.set_keycode(&mut self.config, keycode);
         }
         Ok(())
     }


### PR DESCRIPTION
Turns out that in a refactor that we merged, a bug got introduced that made it so that hotkeys were not being set anymore when the `HotkeySystem` is disabled. This is fixed now.