### PR TITLE
Add fallback for the restrict keyword being unavailable to bind_gen

### DIFF
--- a/capi/bind_gen/src/c.rs
+++ b/capi/bind_gen/src/c.rs
@@ -45,8 +45,16 @@ pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Resu
         r#"#ifndef LIVESPLIT_CORE_H
 #define LIVESPLIT_CORE_H
 
-#ifdef __cplusplus
+/**
+Most C/C++ compilers support __restrict, and it's been standardized in C99 by
+adding the restrict keyword.
+If not compiled in C99 (or higher) modes, try to use __restrict instead.
+*/
+#if __STDC_VERSION__ < 199901L
 #define restrict __restrict
+#endif
+
+#ifdef __cplusplus
 namespace LiveSplit {
 extern "C" {
 #endif


### PR DESCRIPTION
Pretty much every compiler already supports `restrict` when compiling C, but for the ones that don't, this should improve compatibility. Additionally, using the generated `livesplit_core.h` in a CMake project with a minimal target feature requirement setting (`c_restrict`) causes IDE syntax highlighting errors when Visual Studio is used as the generator, because it lacks a `c99` option. This ends up fixed too.

I didn't add a generic fallback (`#define restrict `) as I doubt there's a standard way to query compiler extensions like that, especially not at gen-time, and a lot of things support `__restrict`. I can make it overridable for odd toolchains, if you'd like:
```c
#if !defined(restrict) && __STDC_VERSION__ < 199901L
```

There theoretically could be issues with other language bindings if they're generated from `livesplit_core.h`, though I imagine that's unlikely, as `cargo run` in `bind_gen` seems to generate all of the languages, and I encounted no errors during that. This PR should also have identical semantics for most compilers (everything but C in a mode earlier than C99 should be the same).

P.S. I haven't made many PRs so I hope this is up to standard!