### PR TITLE
Properly support extended scan codes on Windows

### DIFF
--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -21,7 +21,7 @@ use winapi::{
         processthreadsapi::GetCurrentThreadId,
         winuser::{
             CallNextHookEx, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
-            UnhookWindowsHookEx, KBDLLHOOKSTRUCT, WH_KEYBOARD_LL, WM_KEYDOWN,
+            UnhookWindowsHookEx, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, WH_KEYBOARD_LL, WM_KEYDOWN,
         },
     },
 };
@@ -233,7 +233,9 @@ unsafe extern "system" fn callback_proc(code: c_int, wparam: WPARAM, lparam: LPA
             let hook_struct = *(lparam as *const KBDLLHOOKSTRUCT);
             let event = wparam as UINT;
             if event == WM_KEYDOWN {
-                if let Some(key_code) = parse_scan_code(hook_struct.scanCode) {
+                let scan_code =
+                    hook_struct.scanCode + ((hook_struct.flags & LLKHF_EXTENDED) * 0xE000);
+                if let Some(key_code) = parse_scan_code(scan_code) {
                     state
                         .events
                         .send(key_code)


### PR DESCRIPTION
Recently we switched to scan codes from the virtual key codes that were keyboard layout specific. However it seems like originally Windows only supported 8-bit scan codes and later extended those. Those scan codes have the following shape: `E0xy`. However the low level keyboard hook API by default only returns the old 8-bit `00xy` scan codes. There however is a `flags` field you can look at to determine if it was meant to be an extended scan code.

Some references:
https://stackoverflow.com/questions/18900831/setwindowshookex-wh-keyboard-ll-not-responding-on-right-shift
https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-kbdllhookstruct?redirectedfrom=MSDN#members
https://kbdlayout.info/kbdgr/scancodes