### PR TITLE
Use `SegmentTime` Formatter for Segment Time Columns

### DIFF
--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -138,7 +138,7 @@ impl Clear for ColumnState {
 enum ColumnFormatter {
     Time,
     Delta,
-    PossibleTimeSave,
+    SegmentTime,
 }
 
 pub fn update_state(
@@ -184,12 +184,12 @@ pub fn update_state(
                         method,
                     ),
                     SemanticColor::Default,
-                    ColumnFormatter::Time,
+                    ColumnFormatter::SegmentTime,
                 ),
                 ColumnStartWith::PossibleTimeSave => (
                     possible_time_save::calculate(timer, segment_index, comparison, false),
                     SemanticColor::Default,
-                    ColumnFormatter::PossibleTimeSave,
+                    ColumnFormatter::SegmentTime,
                 ),
             },
             false,
@@ -209,7 +209,7 @@ pub fn update_state(
                 "{}",
                 Delta::with_decimal_dropping().format(column_value)
             ),
-            ColumnFormatter::PossibleTimeSave => {
+            ColumnFormatter::SegmentTime => {
                 write!(state.value, "{}", SegmentTime::new().format(column_value))
             }
         };
@@ -302,12 +302,12 @@ fn column_update_value(
         (SegmentTime, false) => (
             analysis::previous_segment_time(timer, segment_index, method),
             SemanticColor::Default,
-            ColumnFormatter::Time,
+            ColumnFormatter::SegmentTime,
         ),
         (SegmentTime, true) => (
             analysis::live_segment_time(timer, segment_index, method),
             SemanticColor::Default,
-            ColumnFormatter::Time,
+            ColumnFormatter::SegmentTime,
         ),
 
         (SegmentDelta | SegmentDeltaWithFallback, false) => {
@@ -315,7 +315,7 @@ fn column_update_value(
             let (value, formatter) = if delta.is_none() && column.update_with.has_fallback() {
                 (
                     analysis::previous_segment_time(timer, segment_index, method),
-                    ColumnFormatter::Time,
+                    ColumnFormatter::SegmentTime,
                 )
             } else {
                 (delta, ColumnFormatter::Delta)

--- a/src/component/splits/tests/mod.rs
+++ b/src/component/splits/tests/mod.rs
@@ -102,7 +102,7 @@ fn negative_segment_times() {
     timer.set_game_time(TimeSpan::from_seconds(-1.0));
 
     let state = component.state(&timer.snapshot(), &layout_settings);
-    assert_eq!(state.splits[0].columns[0].value, "−0:01");
+    assert_eq!(state.splits[0].columns[0].value, "−1.00");
 }
 
 #[test]


### PR DESCRIPTION
When we introduced `Possible Time Save` columns we also added its formatter. This formatter is the `SegmentTime` formatter. However the actual column types that show various kinds of segment times still kept using the `General` formatter that we use for split times. This changes all of them to use the `SegmentTime` formatter.