### PR TITLE
Add layout settings for time formatters

### DIFF
--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -8,6 +8,7 @@ use crate::{
         formatter::{Delta, Regular, SegmentTime, TimeFormatter},
         Snapshot,
     },
+    component::splits::Settings as SplitsSettings,
     GeneralLayoutSettings, Segment, TimeSpan, TimingMethod,
 };
 use core::fmt::Write;
@@ -145,6 +146,7 @@ pub fn update_state(
     state: &mut ColumnState,
     column: &ColumnSettings,
     timer: &Snapshot<'_>,
+    splits: &SplitsSettings,
     layout_settings: &GeneralLayoutSettings,
     segment: &Segment,
     segment_index: usize,
@@ -206,14 +208,14 @@ pub fn update_state(
             ColumnFormatter::Time => write!(
                 state.value,
                 "{}",
-                Regular::with_accuracy(layout_settings.split_time_accuracy).format(column_value)
+                Regular::with_accuracy(splits.split_time_accuracy).format(column_value)
             ),
             ColumnFormatter::Delta => write!(
                 state.value,
                 "{}",
                 Delta::custom(
-                    layout_settings.delta_drop_decimals,
-                    layout_settings.delta_time_accuracy,
+                    splits.delta_drop_decimals,
+                    splits.delta_time_accuracy,
                 )
                 .format(column_value)
             ),
@@ -221,7 +223,7 @@ pub fn update_state(
                 write!(
                     state.value,
                     "{}",
-                    SegmentTime::with_accuracy(layout_settings.segment_time_accuracy)
+                    SegmentTime::with_accuracy(splits.segment_time_accuracy)
                         .format(column_value)
                 )
             }

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -203,14 +203,27 @@ pub fn update_state(
     state.value.clear();
     if !is_empty {
         let _ = match formatter {
-            ColumnFormatter::Time => write!(state.value, "{}", Regular::new().format(column_value)),
+            ColumnFormatter::Time => write!(
+                state.value,
+                "{}",
+                Regular::with_accuracy(layout_settings.split_time_accuracy).format(column_value)
+            ),
             ColumnFormatter::Delta => write!(
                 state.value,
                 "{}",
-                Delta::with_decimal_dropping().format(column_value)
+                Delta::custom(
+                    layout_settings.delta_drop_decimals,
+                    layout_settings.delta_time_accuracy,
+                )
+                .format(column_value)
             ),
             ColumnFormatter::SegmentTime => {
-                write!(state.value, "{}", SegmentTime::new().format(column_value))
+                write!(
+                    state.value,
+                    "{}",
+                    SegmentTime::with_accuracy(layout_settings.segment_time_accuracy)
+                        .format(column_value)
+                )
             }
         };
     }

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -493,7 +493,7 @@ impl Component {
                 self.settings.delta_time_accuracy.into(),
             ),
             Field::new(
-                "Drop Decimals When More Than 1 Minute".into(),
+                "Drop Delta Decimals When Showing Minutes".into(),
                 self.settings.delta_drop_decimals.into(),
             ),
             Field::new(

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     settings::{
         CachedImageId, Color, Field, Gradient, ImageData, ListGradient, SettingsDescription, Value,
     },
-    timing::Snapshot,
+    timing::{formatter::Accuracy, Snapshot},
     GeneralLayoutSettings,
 };
 use core::cmp::{max, min};
@@ -26,7 +26,7 @@ pub use column::{
     ColumnSettings, ColumnStartWith, ColumnState, ColumnUpdateTrigger, ColumnUpdateWith,
 };
 
-const SETTINGS_BEFORE_COLUMNS: usize = 11;
+const SETTINGS_BEFORE_COLUMNS: usize = 15;
 const SETTINGS_PER_COLUMN: usize = 6;
 
 /// The Splits Component is the main component for visualizing all the split
@@ -83,6 +83,15 @@ pub struct Settings {
     /// The gradient to show behind the current segment as an indicator of it
     /// being the current segment.
     pub current_split_gradient: Gradient,
+    /// Specifies the display accuracy of split times.
+    pub split_time_accuracy: Accuracy,
+    /// Specifies the display accuracy of segment times.
+    pub segment_time_accuracy: Accuracy,
+    /// Specifies the display accuracy of delta times.
+    pub delta_time_accuracy: Accuracy,
+    /// Whether to drop the fractional part of a delta time once it goes past
+    /// one minute.
+    pub delta_drop_decimals: bool,
     /// Specifies whether to show the names of the columns above the splits.
     pub show_column_labels: bool,
     /// The columns to show on the splits. These can be configured in various
@@ -185,6 +194,10 @@ impl Default for Settings {
                 Color::rgba(51.0 / 255.0, 115.0 / 255.0, 244.0 / 255.0, 1.0),
                 Color::rgba(21.0 / 255.0, 53.0 / 255.0, 116.0 / 255.0, 1.0),
             ),
+            split_time_accuracy: Accuracy::Seconds,
+            segment_time_accuracy: Accuracy::Hundredths,
+            delta_time_accuracy: Accuracy::Tenths,
+            delta_drop_decimals: true,
             show_column_labels: false,
             columns: vec![
                 ColumnSettings {
@@ -384,6 +397,7 @@ impl Component {
                     }),
                     column,
                     timer,
+                    &self.settings,
                     layout_settings,
                     segment,
                     i,
@@ -467,6 +481,22 @@ impl Component {
                 self.settings.current_split_gradient.into(),
             ),
             Field::new(
+                "Split Time Accuracy".into(),
+                self.settings.split_time_accuracy.into(),
+            ),
+            Field::new(
+                "Segment Time Accuracy".into(),
+                self.settings.segment_time_accuracy.into(),
+            ),
+            Field::new(
+                "Delta Time Accuracy".into(),
+                self.settings.delta_time_accuracy.into(),
+            ),
+            Field::new(
+                "Drop Decimals When More Than 1 Minute".into(),
+                self.settings.delta_drop_decimals.into(),
+            ),
+            Field::new(
                 "Show Column Labels".into(),
                 self.settings.show_column_labels.into(),
             ),
@@ -530,6 +560,10 @@ impl Component {
                 let new_len = value.into_uint().unwrap() as usize;
                 self.settings.columns.resize(new_len, Default::default());
             }
+            11 => self.settings.split_time_accuracy = value.into(),
+            12 => self.settings.segment_time_accuracy = value.into(),
+            13 => self.settings.delta_time_accuracy = value.into(),
+            14 => self.settings.delta_drop_decimals = value.into(),
             index => {
                 let index = index - SETTINGS_BEFORE_COLUMNS;
                 let column_index = index / SETTINGS_PER_COLUMN;

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -2,6 +2,7 @@ use super::LayoutDirection;
 use crate::{
     platform::prelude::*,
     settings::{Color, Field, Font, Gradient, SettingsDescription, Value},
+    timing::formatter::Accuracy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +49,15 @@ pub struct GeneralSettings {
     pub separators_color: Color,
     /// The text color to use for text that doesn't specify its own color.
     pub text_color: Color,
+    /// Specifies the display accuracy of split times.
+    pub split_time_accuracy: Accuracy,
+    /// Specifies the display accuracy of segment times.
+    pub segment_time_accuracy: Accuracy,
+    /// Specifies the display accuracy of delta times.
+    pub delta_time_accuracy: Accuracy,
+    /// Whether to drop the fractional part of a delta time once it goes past
+    /// one minute.
+    pub delta_drop_decimals: bool,
 }
 
 impl Default for GeneralSettings {
@@ -69,6 +79,10 @@ impl Default for GeneralSettings {
             thin_separators_color: Color::hsla(0.0, 0.0, 1.0, 0.09),
             separators_color: Color::hsla(0.0, 0.0, 1.0, 0.35),
             text_color: Color::hsla(0.0, 0.0, 1.0, 1.0),
+            split_time_accuracy: Accuracy::Seconds,
+            segment_time_accuracy: Accuracy::Hundredths,
+            delta_time_accuracy: Accuracy::Tenths,
+            delta_drop_decimals: true,
         }
     }
 }

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -2,7 +2,6 @@ use super::LayoutDirection;
 use crate::{
     platform::prelude::*,
     settings::{Color, Field, Font, Gradient, SettingsDescription, Value},
-    timing::formatter::Accuracy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -49,15 +48,6 @@ pub struct GeneralSettings {
     pub separators_color: Color,
     /// The text color to use for text that doesn't specify its own color.
     pub text_color: Color,
-    /// Specifies the display accuracy of split times.
-    pub split_time_accuracy: Accuracy,
-    /// Specifies the display accuracy of segment times.
-    pub segment_time_accuracy: Accuracy,
-    /// Specifies the display accuracy of delta times.
-    pub delta_time_accuracy: Accuracy,
-    /// Whether to drop the fractional part of a delta time once it goes past
-    /// one minute.
-    pub delta_drop_decimals: bool,
 }
 
 impl Default for GeneralSettings {
@@ -79,10 +69,6 @@ impl Default for GeneralSettings {
             thin_separators_color: Color::hsla(0.0, 0.0, 1.0, 0.09),
             separators_color: Color::hsla(0.0, 0.0, 1.0, 0.35),
             text_color: Color::hsla(0.0, 0.0, 1.0, 1.0),
-            split_time_accuracy: Accuracy::Seconds,
-            segment_time_accuracy: Accuracy::Hundredths,
-            delta_time_accuracy: Accuracy::Tenths,
-            delta_drop_decimals: true,
         }
     }
 }

--- a/src/layout/parser/splits.rs
+++ b/src/layout/parser/splits.rs
@@ -1,6 +1,7 @@
 use super::{
-    accuracy, comparison_override, end_tag, parse_bool, parse_children, text, text_err, text_parsed,
-    timing_method_override, Error, GradientBuilder, GradientKind, ListGradientKind, Result,
+    accuracy, comparison_override, end_tag, parse_bool, parse_children, text, text_err,
+    text_parsed, timing_method_override, Error, GradientBuilder, GradientKind, ListGradientKind,
+    Result,
 };
 use quick_xml::Reader;
 use std::io::BufRead;
@@ -156,7 +157,10 @@ where
                         }
                     })
                 } else if tag.name() == b"SplitTimesAccuracy" {
-                    accuracy(reader, tag.into_buf(), |v| settings.split_time_accuracy = v)
+                    accuracy(reader, tag.into_buf(), |v| {
+                        settings.split_time_accuracy = v;
+                        settings.segment_time_accuracy = v;
+                    })
                 } else if tag.name() == b"DeltasAccuracy" {
                     accuracy(reader, tag.into_buf(), |v| settings.delta_time_accuracy = v)
                 } else if tag.name() == b"DropDecimals" {

--- a/src/layout/parser/splits.rs
+++ b/src/layout/parser/splits.rs
@@ -1,5 +1,5 @@
 use super::{
-    comparison_override, end_tag, parse_bool, parse_children, text, text_err, text_parsed,
+    accuracy, comparison_override, end_tag, parse_bool, parse_children, text, text_err, text_parsed,
     timing_method_override, Error, GradientBuilder, GradientKind, ListGradientKind, Result,
 };
 use quick_xml::Reader;
@@ -155,11 +155,16 @@ where
                             });
                         }
                     })
+                } else if tag.name() == b"SplitTimesAccuracy" {
+                    accuracy(reader, tag.into_buf(), |v| settings.split_time_accuracy = v)
+                } else if tag.name() == b"DeltasAccuracy" {
+                    accuracy(reader, tag.into_buf(), |v| settings.delta_time_accuracy = v)
+                } else if tag.name() == b"DropDecimals" {
+                    parse_bool(reader, tag.into_buf(), |v| settings.delta_drop_decimals = v)
                 } else {
                     // FIXME:
                     // DisplayIcons
                     // SplitWidth
-                    // SplitTimesAccuracy
                     // AutomaticAbbreviations
                     // BeforeNamesColor // Version >= 1.3
                     // CurrentNamesColor // Version >= 1.3
@@ -175,8 +180,6 @@ where
                     // IconSize
                     // IconShadows
                     // SplitHeight
-                    // DeltasAccuracy
-                    // DropDecimals
                     // OverrideDeltasColor
                     // DeltasColor
                     // LabelsColor


### PR DESCRIPTION
This PR exposes settings for time accuracy and delta time's "drop decimals past one minute" thing.

I don't know if having the settings layout-global is ideal (probably not), but I wasn't sure what else to pass in column's `update_state` if it were local to each `Splits` component.
I also didn't change any parsing code for the original LiveSplit layouts, as I'm not sure where my changes would even be...

Tests seem to pass too.

(feel free to give suggestions if i should change anything)