### PR TITLE
Fix Bug when unregistering Hotkey

### DIFF
--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -131,8 +131,11 @@ impl HotkeySystem {
     }
 
     fn unregister(&mut self, hotkey: Hotkey) -> Result<()> {
+        unsafe {
+            self.unregister_raw(hotkey)?;
+        }
         hotkey.set_keycode(&mut self.config, None);
-        unsafe { self.unregister_raw(hotkey) }
+        Ok(())
     }
 
     fn set_hotkey(&mut self, hotkey: Hotkey, keycode: Option<KeyCode>) -> Result<()> {


### PR DESCRIPTION
It used to set the hotkey to `None` first and then try to unregister that, which doesn't do anything. Not sure how we never noticed that.