### PR TITLE
Implement Resolving Hotkeys on Windows

### DIFF
--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -2,37 +2,39 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "std"))] {
         mod other;
-        pub use self::other::*;
+        use self::other as platform;
     } else if #[cfg(windows)] {
         mod windows;
-        pub use self::windows::*;
+        use self::windows as platform;
     } else if #[cfg(target_os = "linux")] {
         mod linux;
-        pub use self::linux::*;
+        use self::linux as platform;
     } else if #[cfg(target_os = "macos")] {
         mod macos;
-        pub use self::macos::*;
+        use self::macos as platform;
     } else if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
         cfg_if::cfg_if! {
             if #[cfg(feature = "wasm-web")] {
                 mod wasm_web;
-                pub use self::wasm_web::*;
+                use self::wasm_web as platform;
             } else {
                 mod wasm_unknown;
-                pub use self::wasm_unknown::*;
+                use self::wasm_unknown as platform;
             }
         }
     } else {
         mod other;
-        pub use self::other::*;
+        use self::other as platform;
     }
 }
 
 mod key_code;
-pub use self::key_code::*;
+pub use self::{key_code::*, platform::*};
 
 #[cfg(test)]
 mod tests {
@@ -55,5 +57,22 @@ mod tests {
         println!("Press Numpad1");
         thread::sleep(Duration::from_secs(5));
         hook.unregister(KeyCode::Numpad1).unwrap();
+    }
+
+    #[test]
+    fn resolve() {
+        // Based on German keyboard layout.
+        println!("ß: {}", KeyCode::Minus.resolve());
+        println!("ü: {}", KeyCode::BracketLeft.resolve());
+        println!("#: {}", KeyCode::Backslash.resolve());
+        println!("+: {}", KeyCode::BracketRight.resolve());
+        println!("z: {}", KeyCode::KeyY.resolve());
+        println!("^: {}", KeyCode::Backquote.resolve());
+        println!("<: {}", KeyCode::IntlBackslash.resolve());
+        println!("Yen: {}", KeyCode::IntlYen.resolve());
+        println!("Enter: {}", KeyCode::Enter.resolve());
+        println!("Space: {}", KeyCode::Space.resolve());
+        println!("Tab: {}", KeyCode::Tab.resolve());
+        println!("Numpad0: {}", KeyCode::Numpad0.resolve());
     }
 }

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -421,3 +421,7 @@ impl Hook {
         future.value().ok_or(Error::ThreadStopped)?
     }
 }
+
+pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
+    None
+}

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -292,3 +292,7 @@ unsafe extern "C" fn callback(
     }
     event
 }
+
+pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
+    None
+}

--- a/crates/livesplit-hotkey/src/other/mod.rs
+++ b/crates/livesplit-hotkey/src/other/mod.rs
@@ -1,4 +1,5 @@
 use crate::KeyCode;
+use alloc::string::String;
 
 #[derive(Debug, snafu::Snafu)]
 pub enum Error {}
@@ -22,4 +23,8 @@ impl Hook {
     pub fn unregister(&self, _: KeyCode) -> Result<()> {
         Ok(())
     }
+}
+
+pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
+    None
 }

--- a/crates/livesplit-hotkey/src/wasm_unknown/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm_unknown/mod.rs
@@ -91,3 +91,7 @@ impl Hook {
         }
     }
 }
+
+pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
+    None
+}

--- a/crates/livesplit-hotkey/src/wasm_web/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm_web/mod.rs
@@ -3,7 +3,6 @@ use wasm_bindgen::{prelude::*, JsCast};
 use web_sys::{window, Gamepad, GamepadButton, KeyboardEvent};
 
 use std::{
-    array,
     cell::Cell,
     collections::hash_map::{Entry, HashMap},
     sync::{Arc, Mutex},
@@ -82,10 +81,7 @@ impl Hook {
         }) as Box<dyn FnMut(KeyboardEvent)>);
 
         window
-            .add_event_listener_with_callback(
-                "keydown",
-                keyboard_callback.as_ref().unchecked_ref(),
-            )
+            .add_event_listener_with_callback("keydown", keyboard_callback.as_ref().unchecked_ref())
             .map_err(|_| Error::FailedToCreateHook)?;
 
         let hotkey_map = hotkeys.clone();
@@ -161,4 +157,8 @@ impl Hook {
             Err(Error::NotRegistered)
         }
     }
+}
+
+pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
+    None
 }

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -1,6 +1,9 @@
 use crate::platform::prelude::*;
 use base64::{display::Base64Display, STANDARD};
-use core::{ops::Deref, sync::atomic::{AtomicUsize, Ordering}};
+use core::{
+    ops::Deref,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(test)]


### PR DESCRIPTION
This allows resolving a `KeyCode` to the key on the user's current keyboard layout. This is useful for visualizing the hotkeys in a user
interface. For now this is only the implementation for Windows. On all other platforms it falls back to the US keyboard layout.

Partially addresses #456 