### PR TITLE
Adds cache to github actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - 'master'
@@ -607,6 +608,17 @@ jobs:
         with:
           rust-version: ${{ matrix.toolchain || 'stable' }}
 
+      - name: Manually generate Cargo lockfile
+        run: cargo generate-lockfile
+
+      - name: Cache Build/Deps
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: target-${{ matrix.target }}-cache-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            target-${{ matrix.target }}-cache-
+
       - name: Install Target
         if: matrix.install_target != ''
         run: rustup target add ${{ matrix.target }}
@@ -677,6 +689,17 @@ jobs:
         with:
           components: clippy
 
+      - name: Manually generate Cargo lockfile
+        run: cargo generate-lockfile
+
+      - name: Cache Build/Deps
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: target-lint-cache-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            target-lint-cache-
+
       - name: Run Clippy
         run: cargo clippy --all-features
 
@@ -706,6 +729,17 @@ jobs:
 
       - name: Install Rust
         uses: hecrj/setup-rust-action@v1
+
+      - name: Manually generate Cargo lockfile
+        run: cargo generate-lockfile
+
+      - name: Cache Build/Deps
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: target-bench-cache-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            target-bench-cache-
 
       - name: Run benchmarks
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -615,9 +615,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: target
-          key: target-${{ matrix.target }}-cache-${{ hashFiles('Cargo.lock') }}
+          key: target-${{ matrix.target }}-${{ matrix.toolchain }}-cache-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            target-${{ matrix.target }}-cache-
+            target-${{ matrix.target }}-${{ matrix.toolchain }}-cache-
 
       - name: Install Target
         if: matrix.install_target != ''


### PR DESCRIPTION
This PR adds the following:

- Generates a Cargo.lock file manually
- Adds a cache for the matrixed builds using the matrix name alongside the lockfile
- Adds a cache for clippy lint 
- Adds a cache for benchmark
- adds restore_keys array to retrieve cache from most recent build if one does not exist for current lock
- Adds workflow dispatch, which allows manually triggering the build on branches or just replaying an existing build; can remove this if asked

Time gains can be seen from:

https://github.com/Eein/livesplit-core/actions/runs/1392897119

to

https://github.com/Eein/livesplit-core/actions/runs/1392944530

Edit: allowing a build to complete here:

https://github.com/Eein/livesplit-core/actions/runs/1393008609

Edit 2: Run with more unique cache keys

https://github.com/Eein/livesplit-core/actions/runs/1393099509

Notes:
- There was some issues with mac builds in my branch, but I do not think its related to this PR and likely some licensing/secrets.
- There's some windows builds are very inconsistent in how long they may take and recompile anyways. Keys may need to be more specific to avoid using caches with the same target name that aren't useful to their context
- cargo packages loaded from git must be recompiled

closes #297
