### PR TITLE
Introduce a per component cache in the renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ ttf-parser = { version = "0.12.0", optional = true }
 font-kit = { version = "0.10.0", optional = true }
 
 # Software Rendering
-tiny-skia = { version = "0.6.0", optional = true }
+tiny-skia = { version = "0.6.0", default-features = false, features = ["std", "simd"], optional = true }
 
 # Networking
 splits-io-api = { version = "0.2.0", optional = true }

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -11,12 +11,22 @@ use crate::{
     },
 };
 
+pub struct Cache<I> {
+    icon: Option<Icon<I>>,
+}
+
+impl<I> Cache<I> {
+    pub const fn new() -> Self {
+        Self { icon: None }
+    }
+}
+
 pub(in crate::rendering) fn render<B: ResourceAllocator>(
+    cache: &mut Cache<B::Image>,
     context: &mut RenderContext<'_, B>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,
-    detailed_timer_icon: &mut Option<Icon<B::Image>>,
 ) {
     context.render_rectangle([0.0, 0.0], [width, height], &component.background);
 
@@ -26,10 +36,10 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     let icon_size = height - 2.0 * vertical_padding;
 
     if let Some(icon) = &component.icon_change {
-        *detailed_timer_icon = context.create_icon(icon);
+        cache.icon = context.create_icon(icon);
     }
 
-    let left_side = if let Some(icon) = detailed_timer_icon {
+    let left_side = if let Some(icon) = &cache.icon {
         context.render_icon([PADDING, vertical_padding], [icon_size, icon_size], icon);
         BOTH_PADDINGS + icon_size
     } else {

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -12,22 +12,32 @@ use crate::{
     },
 };
 
+pub struct Cache<I> {
+    game_icon: Option<Icon<I>>,
+}
+
+impl<I> Cache<I> {
+    pub const fn new() -> Self {
+        Self { game_icon: None }
+    }
+}
+
 pub(in crate::rendering) fn render<B: ResourceAllocator>(
+    cache: &mut Cache<B::Image>,
     context: &mut RenderContext<'_, B>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,
-    game_icon: &mut Option<Icon<B::Image>>,
 ) {
     context.render_rectangle([0.0, 0.0], [width, height], &component.background);
     let text_color = component.text_color.unwrap_or(layout_state.text_color);
     let text_color = solid(&text_color);
 
     if let Some(icon) = &component.icon_change {
-        *game_icon = context.create_icon(icon);
+        cache.game_icon = context.create_icon(icon);
     }
 
-    let left_bound = if let Some(icon) = game_icon {
+    let left_bound = if let Some(icon) = &cache.game_icon {
         let vertical_padding = vertical_padding(height);
         let icon_size = height - 2.0 * vertical_padding;
         context.render_icon([PADDING, vertical_padding], [icon_size, icon_size], icon);

--- a/src/rendering/entity.rs
+++ b/src/rendering/entity.rs
@@ -33,14 +33,12 @@ pub fn calculate_hash<P, I>(background: &Option<FillShader>, entities: &[Entity<
     hasher.finish()
 }
 
-fn hash_float(x: f32, state: &mut impl Hasher) {
-    u32::from_ne_bytes(x.to_ne_bytes()).hash(state);
+fn hash_float(f: f32, state: &mut impl Hasher) {
+    u32::hash(&bytemuck::cast(f), state);
 }
 
 fn hash_floats(f: &[f32], state: &mut impl Hasher) {
-    for &f in f {
-        hash_float(f, state);
-    }
+    u32::hash_slice(bytemuck::cast_slice(f), state);
 }
 
 fn hash_shader(shader: &FillShader, state: &mut impl Hasher) {


### PR DESCRIPTION
At the moment the scene manager completely recalculates everything on every update. This is really expensive, especially for the labels where text shaping is apparently a pretty slow process. We want to do a lot more caching to improve the performance. Here we introduce a per component cache where each component can cache whatever it needs to. We used to globally store icons in the scene manager to cache them, but now these move into the individual component caches. Text shaping is still done on each frame, but it's now possible to start moving these into the component caches in further pull requests.

Works towards #432 and #431