### PR TITLE
Cache Labels in Scene Manager

### DIFF
--- a/src/clear_vec.rs
+++ b/src/clear_vec.rs
@@ -28,28 +28,33 @@ pub trait Clear {
 /// them later on again with all their capacity retained. The elements are only
 /// dropped once the ClearVec itself gets dropped.
 #[derive(Clone, Debug)]
-pub struct ClearVec<T: Clear> {
+pub struct ClearVec<T> {
     vec: Vec<T>,
     len: usize,
 }
 
-impl<T: Clear> ClearVec<T> {
+impl<T> ClearVec<T> {
     /// Creates an empty ClearVec.
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Self {
+            vec: Vec::new(),
+            len: 0,
+        }
     }
 
     /// Returns the number of elements in the ClearVec, also referred to as its
     /// 'length'.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns `true` if the ClearVec contains no elements.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
+}
 
+impl<T: Clear> ClearVec<T> {
     /// Pushes an element into the ClearVec by either reusing an unused element
     /// or constructing a new one via the Default trait if there is no unused
     /// element available.
@@ -94,7 +99,7 @@ impl<T: Clear> ClearVec<T> {
 
 impl<T: Clear> Default for ClearVec<T> {
     fn default() -> Self {
-        Vec::default().into()
+        Vec::new().into()
     }
 }
 

--- a/src/rendering/component/key_value.rs
+++ b/src/rendering/component/key_value.rs
@@ -1,11 +1,34 @@
+use std::marker::PhantomData;
+
 use crate::{
     component::key_value::State,
     layout::{LayoutDirection, LayoutState},
-    rendering::{resource::ResourceAllocator, RenderContext},
+    rendering::{
+        font::{AbbreviatedLabel, Label},
+        resource::ResourceAllocator,
+        RenderContext,
+    },
 };
 
-pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+pub struct Cache<I> {
+    key: AbbreviatedLabel,
+    value: Label,
+    _image: PhantomData<I>,
+}
+
+impl<I> Cache<I> {
+    pub const fn new() -> Self {
+        Self {
+            key: AbbreviatedLabel::new(),
+            value: Label::new(),
+            _image: PhantomData,
+        }
+    }
+}
+
+pub(in crate::rendering) fn render<B: ResourceAllocator>(
+    cache: &mut Cache<B::Image>,
+    context: &mut RenderContext<'_, B>,
     dim: [f32; 2],
     component: &State,
     layout_state: &LayoutState,
@@ -14,7 +37,9 @@ pub(in crate::rendering) fn render(
     context.render_key_value_component(
         &component.key,
         &component.key_abbreviations,
+        &mut cache.key,
         &component.value,
+        &mut cache.value,
         component.updates_frequently,
         dim,
         component.key_color.unwrap_or(layout_state.text_color),

--- a/src/rendering/component/mod.rs
+++ b/src/rendering/component/mod.rs
@@ -17,10 +17,13 @@ pub mod timer;
 pub mod title;
 
 pub enum Cache<I> {
-    DetailedTimer(detailed_timer::Cache<I>),
-    Splits(splits::Cache<I>),
-    Title(title::Cache<I>),
     Empty,
+    DetailedTimer(detailed_timer::Cache<I>),
+    KeyValue(key_value::Cache<I>),
+    Splits(splits::Cache<I>),
+    Text(text::Cache<I>),
+    Timer(timer::Cache<I>),
+    Title(title::Cache<I>),
 }
 
 macro_rules! accessors {
@@ -43,7 +46,10 @@ impl<I> Cache<I> {
     pub const fn new(component: &ComponentState) -> Self {
         match component {
             ComponentState::DetailedTimer(_) => Self::DetailedTimer(detailed_timer::Cache::new()),
+            ComponentState::KeyValue(_) => Self::KeyValue(key_value::Cache::new()),
             ComponentState::Splits(_) => Self::Splits(splits::Cache::new()),
+            ComponentState::Text(_) => Self::Text(text::Cache::new()),
+            ComponentState::Timer(_) => Self::Timer(timer::Cache::new()),
             ComponentState::Title(_) => Self::Title(title::Cache::new()),
             _ => Self::Empty,
         }
@@ -55,7 +61,10 @@ impl<I> Cache<I> {
 
     accessors! {
         DetailedTimer detailed_timer,
+        KeyValue key_value,
         Splits splits,
+        Text text,
+        Timer timer,
         Title title
     }
 }
@@ -144,8 +153,7 @@ pub(super) fn render<A: ResourceAllocator>(
             graph::render(context, dim, component, state)
         }
         ComponentState::KeyValue(component) => {
-            cache.make_empty();
-            key_value::render(context, dim, component, state)
+            key_value::render(cache.key_value(), context, dim, component, state)
         }
         ComponentState::Separator(component) => {
             cache.make_empty();
@@ -155,12 +163,10 @@ pub(super) fn render<A: ResourceAllocator>(
             splits::render(cache.splits(), context, dim, component, state)
         }
         ComponentState::Text(component) => {
-            cache.make_empty();
-            text::render(context, dim, component, state)
+            text::render(cache.text(), context, dim, component, state)
         }
         ComponentState::Timer(component) => {
-            cache.make_empty();
-            timer::render(context, dim, component);
+            timer::render(cache.timer(), context, dim, component);
         }
         ComponentState::Title(component) => {
             title::render(cache.title(), context, dim, component, state)

--- a/src/rendering/component/text.rs
+++ b/src/rendering/component/text.rs
@@ -1,15 +1,35 @@
+use std::marker::PhantomData;
+
 use crate::{
     component::text::{State, TextState},
     layout::{LayoutDirection, LayoutState},
     rendering::{
         consts::{DEFAULT_TEXT_SIZE, PADDING, TEXT_ALIGN_TOP},
+        font::{AbbreviatedLabel, Label},
         resource::ResourceAllocator,
         solid, RenderContext,
     },
 };
 
-pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+pub struct Cache<I> {
+    label1: AbbreviatedLabel,
+    label2: Label,
+    _image: PhantomData<I>,
+}
+
+impl<I> Cache<I> {
+    pub const fn new() -> Self {
+        Self {
+            label1: AbbreviatedLabel::new(),
+            label2: Label::new(),
+            _image: PhantomData,
+        }
+    }
+}
+
+pub(in crate::rendering) fn render<B: ResourceAllocator>(
+    cache: &mut Cache<B::Image>,
+    context: &mut RenderContext<'_, B>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,
@@ -18,6 +38,7 @@ pub(in crate::rendering) fn render(
     match &component.text {
         TextState::Center(text) => context.render_text_centered(
             text,
+            &mut cache.label2,
             PADDING,
             width - PADDING,
             [0.5 * width, TEXT_ALIGN_TOP],
@@ -31,7 +52,9 @@ pub(in crate::rendering) fn render(
         TextState::Split(left, right) => context.render_key_value_component(
             left,
             &[],
+            &mut cache.label1,
             right,
+            &mut cache.label2,
             false,
             [width, height],
             component

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -1,12 +1,32 @@
+use std::marker::PhantomData;
+
 use crate::{
     component::timer::State,
     rendering::{
-        consts::PADDING, resource::ResourceAllocator, scene::Layer, FillShader, RenderContext,
+        consts::PADDING, font::Label, resource::ResourceAllocator, scene::Layer, FillShader,
+        RenderContext,
     },
 };
 
-pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+pub struct Cache<I> {
+    time: Label,
+    fraction: Label,
+    _image: PhantomData<I>,
+}
+
+impl<I> Cache<I> {
+    pub const fn new() -> Self {
+        Self {
+            time: Label::new(),
+            fraction: Label::new(),
+            _image: PhantomData,
+        }
+    }
+}
+
+pub(in crate::rendering) fn render<B: ResourceAllocator>(
+    cache: &mut Cache<B::Image>,
+    context: &mut RenderContext<'_, B>,
     [width, height]: [f32; 2],
     component: &State,
 ) -> f32 {
@@ -18,6 +38,7 @@ pub(in crate::rendering) fn render(
     let render_target = Layer::from_updates_frequently(component.updates_frequently);
     let x = context.render_timer(
         &component.fraction,
+        &mut cache.fraction,
         render_target,
         [width - PADDING, 0.85 * height],
         0.8 * height,
@@ -25,6 +46,7 @@ pub(in crate::rendering) fn render(
     );
     context.render_timer(
         &component.time,
+        &mut cache.time,
         render_target,
         [x, 0.85 * height],
         1.2 * height,

--- a/src/rendering/font/cache.rs
+++ b/src/rendering/font/cache.rs
@@ -1,5 +1,3 @@
-use rustybuzz::UnicodeBuffer;
-
 use super::{Font, GlyphCache, SharedOwnership, TEXT_FONT, TIMER_FONT};
 use crate::settings::{FontStretch, FontStyle, FontWeight};
 
@@ -38,7 +36,6 @@ impl<P: SharedOwnership> CachedFont<P> {
 }
 
 pub struct FontCache<P> {
-    pub buffer: Option<UnicodeBuffer>,
     pub timer: CachedFont<P>,
     pub times: CachedFont<P>,
     pub text: CachedFont<P>,
@@ -47,7 +44,6 @@ pub struct FontCache<P> {
 impl<P: SharedOwnership> FontCache<P> {
     pub fn new() -> Option<Self> {
         Some(Self {
-            buffer: None,
             timer: CachedFont::new(Font::from_slice(
                 TIMER_FONT,
                 0,


### PR DESCRIPTION
Instead of shaping all the text every frame, the recently introduced caching system allows us to cache the labels and only shape them again when they change. This gives a hefty performance boost of up to 25x for the scene update.

Resolves #432 