### PR TITLE
Switch to evdev for Linux hotkeys

### DIFF
--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -18,9 +18,9 @@ winapi = { version = "0.3.2", features = [
 parking_lot = { version = "0.11.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-x11-dl = { version = "2.18.5", optional = true }
 mio = { version = "0.7.7", default-features = false, features = ["os-ext", "os-poll"], optional = true }
 promising-future = { version = "0.2.4", optional = true }
+evdev = "0.11.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bitflags = { version = "1.2.1", optional = true }
@@ -37,5 +37,5 @@ snafu = { version = "0.6.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["snafu/std", "serde/std", "parking_lot", "x11-dl", "mio", "promising-future", "winapi", "bitflags"]
+std = ["snafu/std", "serde/std", "parking_lot", "mio", "promising-future", "winapi", "bitflags"]
 wasm-web = ["wasm-bindgen", "web-sys", "parking_lot/wasm-bindgen"]

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -18,9 +18,9 @@ winapi = { version = "0.3.2", features = [
 parking_lot = { version = "0.11.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+evdev = { version = "0.11.1", optional = true }
 mio = { version = "0.7.7", default-features = false, features = ["os-ext", "os-poll"], optional = true }
 promising-future = { version = "0.2.4", optional = true }
-evdev = "0.11.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bitflags = { version = "1.2.1", optional = true }
@@ -37,5 +37,5 @@ snafu = { version = "0.6.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["snafu/std", "serde/std", "parking_lot", "mio", "promising-future", "winapi", "bitflags"]
+std = ["snafu/std", "serde/std", "parking_lot", "evdev", "mio", "promising-future", "winapi", "bitflags"]
 wasm-web = ["wasm-bindgen", "web-sys", "parking_lot/wasm-bindgen"]

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -49,14 +49,14 @@ mod tests {
         println!("Press Numpad1");
         thread::sleep(Duration::from_secs(5));
         hook.unregister(KeyCode::Numpad1).unwrap();
-        hook.register(KeyCode::Numpad4, || println!("B")).unwrap();
-        println!("Press Numpad4");
+        hook.register(KeyCode::KeyN, || println!("B")).unwrap();
+        println!("Press KeyN");
         thread::sleep(Duration::from_secs(5));
-        hook.unregister(KeyCode::Numpad4).unwrap();
-        hook.register(KeyCode::Numpad1, || println!("C")).unwrap();
-        println!("Press Numpad1");
+        hook.unregister(KeyCode::KeyN).unwrap();
+        hook.register(KeyCode::Space, || println!("C")).unwrap();
+        println!("Press Space");
         thread::sleep(Duration::from_secs(5));
-        hook.unregister(KeyCode::Numpad1).unwrap();
+        hook.unregister(KeyCode::Space).unwrap();
     }
 
     #[test]

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -53,10 +53,10 @@ mod tests {
         println!("Press KeyN");
         thread::sleep(Duration::from_secs(5));
         hook.unregister(KeyCode::KeyN).unwrap();
-        hook.register(KeyCode::Space, || println!("C")).unwrap();
-        println!("Press Space");
+        hook.register(KeyCode::Numpad1, || println!("C")).unwrap();
+        println!("Press Numpad1");
         thread::sleep(Duration::from_secs(5));
-        hook.unregister(KeyCode::Space).unwrap();
+        hook.unregister(KeyCode::Numpad1).unwrap();
     }
 
     #[test]

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -4,8 +4,7 @@ use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
 use promising_future::{future_promise, Promise};
 use std::{
     collections::hash_map::HashMap,
-    convert::{TryFrom, TryInto},
-    os::unix::prelude::{AsRawFd, RawFd},
+    os::unix::prelude::AsRawFd,
     sync::mpsc::{channel, Sender},
     thread::{self, JoinHandle},
 };
@@ -16,7 +15,6 @@ pub enum Error {
     ThreadStopped,
     AlreadyRegistered,
     NotRegistered,
-    UnknownKey,
     EvDev,
 }
 
@@ -32,8 +30,8 @@ enum Message {
     End,
 }
 
-// Low numbered tokens are allocated to devices
-const PING_TOKEN: Token = Token(256);
+// Low numbered tokens are allocated to devices.
+const PING_TOKEN: Token = Token(usize::MAX);
 
 pub struct Hook {
     sender: Sender<Message>,
@@ -51,6 +49,228 @@ impl Drop for Hook {
     }
 }
 
+fn code_for(key: KeyCode) -> Option<Key> {
+    // This mapping is based on all the different browsers. They however all use
+    // the X11 scan codes. Fortunately those have a trivial 1:1 mapping to evdev
+    // scan codes.
+    // https://github.com/freedesktop/xorg-xf86-input-evdev/blob/71036116be11b8c9d39ce153738875c44183cc60/src/evdev.c#L280
+    // You simply need to subtract 8 from the X11 scan code to get to the evdev
+    // scan code. So we take the mapping from the browsers, subtract 8 from each
+    // value and then use the named constant for that value.
+    use self::KeyCode::*;
+    Some(match key {
+        Escape => Key::KEY_ESC,
+        Digit1 => Key::KEY_1,
+        Digit2 => Key::KEY_2,
+        Digit3 => Key::KEY_3,
+        Digit4 => Key::KEY_4,
+        Digit5 => Key::KEY_5,
+        Digit6 => Key::KEY_6,
+        Digit7 => Key::KEY_7,
+        Digit8 => Key::KEY_8,
+        Digit9 => Key::KEY_9,
+        Digit0 => Key::KEY_0,
+        Minus => Key::KEY_MINUS,
+        Equal => Key::KEY_EQUAL,
+        Backspace => Key::KEY_BACKSPACE,
+        Tab => Key::KEY_TAB,
+        KeyQ => Key::KEY_Q,
+        KeyW => Key::KEY_W,
+        KeyE => Key::KEY_E,
+        KeyR => Key::KEY_R,
+        KeyT => Key::KEY_T,
+        KeyY => Key::KEY_Y,
+        KeyU => Key::KEY_U,
+        KeyI => Key::KEY_I,
+        KeyO => Key::KEY_O,
+        KeyP => Key::KEY_P,
+        BracketLeft => Key::KEY_LEFTBRACE,
+        BracketRight => Key::KEY_RIGHTBRACE,
+        Enter => Key::KEY_ENTER,
+        ControlLeft => Key::KEY_LEFTCTRL,
+        KeyA => Key::KEY_A,
+        KeyS => Key::KEY_S,
+        KeyD => Key::KEY_D,
+        KeyF => Key::KEY_F,
+        KeyG => Key::KEY_G,
+        KeyH => Key::KEY_H,
+        KeyJ => Key::KEY_J,
+        KeyK => Key::KEY_K,
+        KeyL => Key::KEY_L,
+        Semicolon => Key::KEY_SEMICOLON,
+        Quote => Key::KEY_APOSTROPHE,
+        Backquote => Key::KEY_GRAVE,
+        ShiftLeft => Key::KEY_LEFTSHIFT,
+        Backslash => Key::KEY_BACKSLASH,
+        KeyZ => Key::KEY_Z,
+        KeyX => Key::KEY_X,
+        KeyC => Key::KEY_C,
+        KeyV => Key::KEY_V,
+        KeyB => Key::KEY_B,
+        KeyN => Key::KEY_N,
+        KeyM => Key::KEY_M,
+        Comma => Key::KEY_COMMA,
+        Period => Key::KEY_DOT,
+        Slash => Key::KEY_SLASH,
+        ShiftRight => Key::KEY_RIGHTSHIFT,
+        NumpadMultiply => Key::KEY_KPASTERISK,
+        AltLeft => Key::KEY_LEFTALT,
+        Space => Key::KEY_SPACE,
+        CapsLock => Key::KEY_CAPSLOCK,
+        F1 => Key::KEY_F1,
+        F2 => Key::KEY_F2,
+        F3 => Key::KEY_F3,
+        F4 => Key::KEY_F4,
+        F5 => Key::KEY_F5,
+        F6 => Key::KEY_F6,
+        F7 => Key::KEY_F7,
+        F8 => Key::KEY_F8,
+        F9 => Key::KEY_F9,
+        F10 => Key::KEY_F10,
+        NumLock => Key::KEY_NUMLOCK,
+        ScrollLock => Key::KEY_SCROLLLOCK,
+        Numpad7 => Key::KEY_KP7,
+        Numpad8 => Key::KEY_KP8,
+        Numpad9 => Key::KEY_KP9,
+        NumpadSubtract => Key::KEY_KPMINUS,
+        Numpad4 => Key::KEY_KP4,
+        Numpad5 => Key::KEY_KP5,
+        Numpad6 => Key::KEY_KP6,
+        NumpadAdd => Key::KEY_KPPLUS,
+        Numpad1 => Key::KEY_KP1,
+        Numpad2 => Key::KEY_KP2,
+        Numpad3 => Key::KEY_KP3,
+        Numpad0 => Key::KEY_KP0,
+        NumpadDecimal => Key::KEY_KPDOT,
+        Lang5 => Key::KEY_ZENKAKUHANKAKU, // Not Firefox, Not Safari
+        IntlBackslash => Key::KEY_102ND,
+        F11 => Key::KEY_F11,
+        F12 => Key::KEY_F12,
+        IntlRo => Key::KEY_RO,
+        Lang3 => Key::KEY_KATAKANA, // Not Firefox, Not Safari
+        Lang4 => Key::KEY_HIRAGANA, // Not Firefox, Not Safari
+        Convert => Key::KEY_HENKAN,
+        KanaMode => Key::KEY_KATAKANAHIRAGANA,
+        NonConvert => Key::KEY_MUHENKAN,
+        NumpadEnter => Key::KEY_KPENTER,
+        ControlRight => Key::KEY_RIGHTCTRL,
+        NumpadDivide => Key::KEY_KPSLASH,
+        PrintScreen => Key::KEY_SYSRQ,
+        AltRight => Key::KEY_RIGHTALT,
+        Home => Key::KEY_HOME,
+        ArrowUp => Key::KEY_UP,
+        PageUp => Key::KEY_PAGEUP,
+        ArrowLeft => Key::KEY_LEFT,
+        ArrowRight => Key::KEY_RIGHT,
+        End => Key::KEY_END,
+        ArrowDown => Key::KEY_DOWN,
+        PageDown => Key::KEY_PAGEDOWN,
+        Insert => Key::KEY_INSERT,
+        Delete => Key::KEY_DELETE,
+        AudioVolumeMute => Key::KEY_MUTE,
+        AudioVolumeDown => Key::KEY_VOLUMEDOWN,
+        AudioVolumeUp => Key::KEY_VOLUMEUP,
+        Power => Key::KEY_POWER, // Not Firefox, Not Safari
+        NumpadEqual => Key::KEY_KPEQUAL,
+        Pause => Key::KEY_PAUSE,
+        ShowAllWindows => Key::KEY_SCALE, // Chrome only
+        NumpadComma => Key::KEY_KPCOMMA,
+        Lang1 => Key::KEY_HANGEUL,
+        Lang2 => Key::KEY_HANJA,
+        IntlYen => Key::KEY_YEN,
+        MetaLeft => Key::KEY_LEFTMETA,
+        MetaRight => Key::KEY_RIGHTMETA,
+        ContextMenu => Key::KEY_COMPOSE,
+        BrowserStop => Key::KEY_STOP,
+        Again => Key::KEY_AGAIN,
+        Props => Key::KEY_PROPS, // Not Chrome
+        Undo => Key::KEY_UNDO,
+        Select => Key::KEY_FRONT,
+        Copy => Key::KEY_COPY,
+        Open => Key::KEY_OPEN,
+        Paste => Key::KEY_PASTE,
+        Find => Key::KEY_FIND,
+        Cut => Key::KEY_CUT,
+        Help => Key::KEY_HELP,
+        LaunchApp2 => Key::KEY_CALC,
+        Sleep => Key::KEY_SLEEP, // Not Firefox, Not Safari
+        WakeUp => Key::KEY_WAKEUP,
+        LaunchApp1 => Key::KEY_FILE,
+        LaunchMail => Key::KEY_MAIL,
+        BrowserFavorites => Key::KEY_BOOKMARKS,
+        BrowserBack => Key::KEY_BACK,
+        BrowserForward => Key::KEY_FORWARD,
+        Eject => Key::KEY_EJECTCD,
+        MediaTrackNext => Key::KEY_NEXTSONG,
+        MediaPlayPause => Key::KEY_PLAYPAUSE,
+        MediaTrackPrevious => Key::KEY_PREVIOUSSONG,
+        MediaStop => Key::KEY_STOPCD,
+        MediaRecord => Key::KEY_RECORD, // Chrome only
+        MediaRewind => Key::KEY_REWIND, // Chrome only
+        MediaSelect => Key::KEY_CONFIG,
+        BrowserHome => Key::KEY_HOMEPAGE,
+        BrowserRefresh => Key::KEY_REFRESH,
+        NumpadParenLeft => Key::KEY_KPLEFTPAREN, // Not Firefox, Not Safari
+        NumpadParenRight => Key::KEY_KPRIGHTPAREN, // Not Firefox, Not Safari
+        F13 => Key::KEY_F13,
+        F14 => Key::KEY_F14,
+        F15 => Key::KEY_F15,
+        F16 => Key::KEY_F16,
+        F17 => Key::KEY_F17,
+        F18 => Key::KEY_F18,
+        F19 => Key::KEY_F19,
+        F20 => Key::KEY_F20,
+        F21 => Key::KEY_F21,
+        F22 => Key::KEY_F22,
+        F23 => Key::KEY_F23,
+        F24 => Key::KEY_F24,
+        MediaPause => Key::KEY_PAUSECD,           // Chrome only
+        MediaPlay => Key::KEY_PLAY,               // Chrome only
+        MediaFastForward => Key::KEY_FASTFORWARD, // Chrome only
+        BrowserSearch => Key::KEY_SEARCH,
+        BrightnessDown => Key::KEY_BRIGHTNESSDOWN, // Chrome only
+        BrightnessUp => Key::KEY_BRIGHTNESSUP,     // Chrome only
+        DisplayToggleIntExt => Key::KEY_SWITCHVIDEOMODE, // Chrome only
+        MailSend => Key::KEY_SEND,                 // Chrome only
+        MailReply => Key::KEY_REPLY,               // Chrome only
+        MailForward => Key::KEY_FORWARDMAIL,       // Chrome only
+        ZoomToggle => Key::KEY_ZOOM,               // Chrome only
+        LaunchControlPanel => Key::KEY_CONTROLPANEL, // Chrome only
+        SelectTask => Key::KEY_APPSELECT,          // Chrome only
+        LaunchScreenSaver => Key::KEY_SCREENSAVER, // Chrome only
+        LaunchAssistant => Key::KEY_ASSISTANT,     // Chrome only
+        KeyboardLayoutSelect => Key::KEY_KBD_LAYOUT_NEXT, // Chrome only
+        PrivacyScreenToggle => Key::KEY_PRIVACY_SCREEN_TOGGLE, // Chrome only
+
+        // In addition evdev supports gamepads. So we base this off the
+        // "Standard Gamepad" defined here:
+        // https://w3c.github.io/gamepad/#dfn-standard-gamepad
+        // And here the buttons this maps to:
+        // https://www.kernel.org/doc/html/v4.12/input/gamepad.html#geometry
+        // Though the naming isn't fully the same, so we somewhat based it off
+        // gilrs:
+        // https://gitlab.com/gilrs-project/gilrs/-/blob/60883ea0f1b95b66e4ae1e00e5b7366cc605068e/gilrs-core/src/platform/wasm/gamepad.rs#L349-367
+        Gamepad0 => Key::BTN_SOUTH,
+        Gamepad1 => Key::BTN_EAST,
+        Gamepad2 => Key::BTN_WEST,
+        Gamepad3 => Key::BTN_NORTH,
+        Gamepad4 => Key::BTN_TL,
+        Gamepad5 => Key::BTN_TR,
+        Gamepad6 => Key::BTN_TL2,
+        Gamepad7 => Key::BTN_TR2,
+        Gamepad8 => Key::BTN_SELECT,
+        Gamepad9 => Key::BTN_START,
+        Gamepad10 => Key::BTN_THUMBL,
+        Gamepad11 => Key::BTN_THUMBR,
+        Gamepad12 => Key::BTN_DPAD_UP,
+        Gamepad13 => Key::BTN_DPAD_DOWN,
+        Gamepad14 => Key::BTN_DPAD_LEFT,
+        Gamepad15 => Key::BTN_DPAD_RIGHT,
+        Gamepad16 => Key::BTN_MODE,
+        _ => return None,
+    })
+}
+
 impl Hook {
     pub fn new() -> Result<Self> {
         let (sender, receiver) = channel();
@@ -60,11 +280,10 @@ impl Hook {
         let mut devices: Vec<Device> = evdev::enumerate()
             .filter(|d| d.supported_events().contains(EventType::KEY))
             .collect();
-        let fds: Vec<RawFd> = devices.iter().map(|d| d.as_raw_fd()).collect();
 
-        for (i, fd) in fds.iter().enumerate() {
+        for (i, fd) in devices.iter().enumerate() {
             poll.registry()
-                .register(&mut SourceFd(fd), Token(i), Interest::READABLE)
+                .register(&mut SourceFd(&fd.as_raw_fd()), Token(i), Interest::READABLE)
                 .map_err(|_| Error::EPoll)?;
         }
 
@@ -84,8 +303,12 @@ impl Hook {
                         let idx = mio_event.token().0;
                         for ev in devices[idx].fetch_events().map_err(|_| Error::EvDev)? {
                             if let InputEventKind::Key(k) = ev.kind() {
-                                // println!("{:?} - {}", k, ev.value());
-                                if ev.value() != 0 {
+                                // The values are:
+                                // - 0: Released
+                                // - 1: Pressed
+                                // - 2: Repeating
+                                // We don't want it to repeat so we only care about 1.
+                                if ev.value() == 1 {
                                     if let Some(callback) = hotkeys.get_mut(&k) {
                                         callback();
                                     }
@@ -96,20 +319,21 @@ impl Hook {
                         for message in receiver.try_iter() {
                             match message {
                                 Message::Register(key, callback, promise) => {
-                                    promise.set(key.try_into().and_then(|k| {
-                                        if hotkeys.insert(k, callback).is_some() {
+                                    promise.set(
+                                        if code_for(key)
+                                            .and_then(|k| hotkeys.insert(k, callback))
+                                            .is_some()
+                                        {
                                             Err(Error::AlreadyRegistered)
                                         } else {
                                             Ok(())
-                                        }
-                                    }))
+                                        },
+                                    );
                                 }
                                 Message::Unregister(key, promise) => promise.set(
-                                    key.try_into()
-                                        .and_then(|k| {
-                                            hotkeys.remove(&k).ok_or(Error::NotRegistered)
-                                        })
-                                        .and(Ok(())),
+                                    code_for(key)
+                                        .and_then(|k| hotkeys.remove(&k).map(drop))
+                                        .ok_or(Error::NotRegistered),
                                 ),
                                 Message::End => {
                                     break 'event_loop;
@@ -159,211 +383,4 @@ impl Hook {
 
 pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
     None
-}
-
-impl TryFrom<KeyCode> for Key {
-    type Error = Error;
-    fn try_from(k: KeyCode) -> Result<Self> {
-        use self::KeyCode::*;
-        Ok(match k {
-            Again => Key::KEY_AGAIN,
-            AltLeft => Key::KEY_LEFTALT,
-            AltRight => Key::KEY_RIGHTALT,
-            ArrowDown => Key::KEY_DOWN,
-            ArrowLeft => Key::KEY_LEFT,
-            ArrowRight => Key::KEY_RIGHT,
-            ArrowUp => Key::KEY_UP,
-            AudioVolumeDown => Key::KEY_VOLUMEUP,
-            AudioVolumeMute => Key::KEY_MUTE,
-            AudioVolumeUp => Key::KEY_VOLUMEDOWN,
-            Backquote => Key::KEY_GRAVE,
-            Backslash => Key::KEY_BACKSLASH,
-            Backspace => Key::KEY_BACKSPACE,
-            BracketLeft => Key::KEY_LEFTBRACE,
-            BracketRight => Key::KEY_RIGHTBRACE,
-            BrightnessDown => Key::KEY_BRIGHTNESSDOWN,
-            BrightnessUp => Key::KEY_BRIGHTNESSUP,
-            BrowserBack => Key::KEY_BACK,
-            BrowserFavorites => Key::KEY_FAVORITES,
-            BrowserForward => Key::KEY_FORWARD,
-            BrowserHome => Key::KEY_HOMEPAGE,
-            BrowserRefresh => Key::KEY_REFRESH,
-            BrowserSearch => Key::KEY_SEARCH,
-            BrowserStop => Key::KEY_STOP,
-            CapsLock => Key::KEY_CAPSLOCK,
-            Comma => Key::KEY_COMMA,
-            ContextMenu => Key::KEY_CONTEXT_MENU,
-            ControlLeft => Key::KEY_LEFTCTRL,
-            ControlRight => Key::KEY_RIGHTCTRL,
-            Convert => Key::KEY_KATAKANA,
-            Copy => Key::KEY_COPY,
-            Cut => Key::KEY_CUT,
-            Delete => Key::KEY_DELETE,
-            Digit0 => Key::KEY_0,
-            Digit1 => Key::KEY_1,
-            Digit2 => Key::KEY_2,
-            Digit3 => Key::KEY_3,
-            Digit4 => Key::KEY_4,
-            Digit5 => Key::KEY_5,
-            Digit6 => Key::KEY_6,
-            Digit7 => Key::KEY_7,
-            Digit8 => Key::KEY_8,
-            Digit9 => Key::KEY_9,
-            DisplayToggleIntExt => Key::KEY_DISPLAYTOGGLE,
-            Eject => Key::KEY_EJECTCD,
-            End => Key::KEY_END,
-            Enter => Key::KEY_ENTER,
-            Equal => Key::KEY_EQUAL,
-            Escape => Key::KEY_ESC,
-            F1 => Key::KEY_F1,
-            F2 => Key::KEY_F2,
-            F3 => Key::KEY_F3,
-            F4 => Key::KEY_F4,
-            F5 => Key::KEY_F5,
-            F6 => Key::KEY_F6,
-            F7 => Key::KEY_F7,
-            F8 => Key::KEY_F8,
-            F9 => Key::KEY_F9,
-            F10 => Key::KEY_F10,
-            F11 => Key::KEY_F11,
-            F12 => Key::KEY_F12,
-            F13 => Key::KEY_F13,
-            F14 => Key::KEY_F14,
-            F15 => Key::KEY_F15,
-            F16 => Key::KEY_F16,
-            F17 => Key::KEY_F17,
-            F18 => Key::KEY_F18,
-            F19 => Key::KEY_F19,
-            F20 => Key::KEY_F20,
-            F21 => Key::KEY_F21,
-            F22 => Key::KEY_F22,
-            F23 => Key::KEY_F23,
-            F24 => Key::KEY_F24,
-            Find => Key::KEY_FIND,
-            Fn => Key::KEY_FN,
-            Gamepad0 => Key::BTN_SOUTH,
-            Gamepad1 => Key::BTN_EAST,
-            Gamepad2 => Key::BTN_C,
-            Gamepad3 => Key::BTN_NORTH,
-            Gamepad4 => Key::BTN_WEST,
-            Gamepad5 => Key::BTN_Z,
-            Gamepad6 => Key::BTN_TL,
-            Gamepad7 => Key::BTN_TR,
-            Gamepad8 => Key::BTN_TL2,
-            Gamepad9 => Key::BTN_TR2,
-            Gamepad10 => Key::BTN_SELECT,
-            Gamepad11 => Key::BTN_START,
-            Gamepad12 => Key::BTN_MODE,
-            Gamepad13 => Key::BTN_THUMBL,
-            Help => Key::KEY_HELP,
-            Home => Key::KEY_HOME,
-            Insert => Key::KEY_INSERT,
-            IntlYen => Key::KEY_YEN,
-            KanaMode => Key::KEY_KATAKANAHIRAGANA,
-            KeyA => Key::KEY_A,
-            KeyB => Key::KEY_B,
-            KeyC => Key::KEY_C,
-            KeyD => Key::KEY_D,
-            KeyE => Key::KEY_E,
-            KeyF => Key::KEY_F,
-            KeyG => Key::KEY_G,
-            KeyH => Key::KEY_H,
-            KeyI => Key::KEY_I,
-            KeyJ => Key::KEY_J,
-            KeyK => Key::KEY_K,
-            KeyL => Key::KEY_L,
-            KeyM => Key::KEY_M,
-            KeyN => Key::KEY_N,
-            KeyO => Key::KEY_O,
-            KeyP => Key::KEY_P,
-            KeyQ => Key::KEY_Q,
-            KeyR => Key::KEY_R,
-            KeyS => Key::KEY_S,
-            KeyT => Key::KEY_T,
-            KeyU => Key::KEY_U,
-            KeyV => Key::KEY_V,
-            KeyW => Key::KEY_W,
-            KeyX => Key::KEY_X,
-            KeyY => Key::KEY_Y,
-            KeyZ => Key::KEY_Z,
-            KeyboardLayoutSelect => Key::KEY_KBD_LAYOUT_NEXT,
-            Lang1 => Key::KEY_LANGUAGE,
-            LaunchAssistant => Key::KEY_ASSISTANT,
-            LaunchControlPanel => Key::KEY_CONTROLPANEL,
-            LaunchMail => Key::KEY_MAIL,
-            LaunchScreenSaver => Key::KEY_SCREENSAVER,
-            MailForward => Key::KEY_FORWARDMAIL,
-            MailReply => Key::KEY_REPLY,
-            MailSend => Key::KEY_SEND,
-            MediaFastForward => Key::KEY_FASTFORWARD,
-            MediaPause => Key::KEY_PAUSE,
-            MediaPlay => Key::KEY_PLAY,
-            MediaPlayPause => Key::KEY_PLAYPAUSE,
-            MediaRecord => Key::KEY_RECORD,
-            MediaRewind => Key::KEY_REWIND,
-            MediaSelect => Key::KEY_SELECT,
-            MediaStop => Key::KEY_STOPCD,
-            MediaTrackNext => Key::KEY_NEXTSONG,
-            MediaTrackPrevious => Key::KEY_PREVIOUSSONG,
-            MetaLeft => Key::KEY_LEFTMETA,
-            MetaRight => Key::KEY_RIGHTMETA,
-            Minus => Key::KEY_MINUS,
-            NumLock => Key::KEY_NUMLOCK,
-            Numpad0 => Key::KEY_NUMERIC_0,
-            Numpad1 => Key::KEY_NUMERIC_1,
-            Numpad2 => Key::KEY_NUMERIC_2,
-            Numpad3 => Key::KEY_NUMERIC_3,
-            Numpad4 => Key::KEY_NUMERIC_4,
-            Numpad5 => Key::KEY_NUMERIC_5,
-            Numpad6 => Key::KEY_NUMERIC_6,
-            Numpad7 => Key::KEY_NUMERIC_7,
-            Numpad8 => Key::KEY_NUMERIC_8,
-            Numpad9 => Key::KEY_NUMERIC_9,
-            NumpadAdd => Key::KEY_KPPLUS,
-            NumpadComma => Key::KEY_KPCOMMA,
-            NumpadDecimal => Key::KEY_KPDOT,
-            NumpadDivide => Key::KEY_KPSLASH,
-            NumpadEnter => Key::KEY_KPENTER,
-            NumpadEqual => Key::KEY_KPEQUAL,
-            NumpadHash => Key::KEY_NUMERIC_POUND,
-            NumpadParenLeft => Key::KEY_KPLEFTPAREN,
-            NumpadParenRight => Key::KEY_KPRIGHTPAREN,
-            NumpadStar => Key::KEY_NUMERIC_STAR,
-            NumpadSubtract => Key::KEY_KPMINUS,
-            Open => Key::KEY_OPEN,
-            PageDown => Key::KEY_PAGEDOWN,
-            PageUp => Key::KEY_PAGEUP,
-            Paste => Key::KEY_PASTE,
-            Pause => Key::KEY_PAUSE,
-            Period => Key::KEY_DOT,
-            Power => Key::KEY_POWER,
-            PrintScreen => Key::KEY_PRINT,
-            PrivacyScreenToggle => Key::KEY_PRIVACY_SCREEN_TOGGLE,
-            Props => Key::KEY_PROPS,
-            Quote => Key::KEY_APOSTROPHE,
-            ScrollLock => Key::KEY_SCROLLLOCK,
-            Select => Key::KEY_SELECT,
-            Semicolon => Key::KEY_SEMICOLON,
-            ShiftLeft => Key::KEY_LEFTSHIFT,
-            ShiftRight => Key::KEY_RIGHTSHIFT,
-            ShowAllWindows => Key::KEY_CYCLEWINDOWS,
-            Slash => Key::KEY_SLASH,
-            Sleep => Key::KEY_SLEEP,
-            Space => Key::KEY_SPACE,
-            Tab => Key::KEY_TAB,
-            Undo => Key::KEY_UNDO,
-            WakeUp => Key::KEY_WAKEUP,
-            ZoomToggle => Key::KEY_ZOOM,
-            // TODO: test on a gamepad with 20 buttons to see what the higher indices are
-            Gamepad14 | Gamepad15 | Gamepad16 | Gamepad17 | Gamepad18 | Gamepad19 => {
-                return Err(Error::UnknownKey)
-            }
-            // TODO: find a keyboard with these keys and see which they correspond to
-            SelectTask | IntlBackslash | IntlRo | Lang2 | Lang3 | Lang4 | Lang5
-            | NonConvert | FnLock | LaunchApp1 | LaunchApp2 | NumpadBackspace
-            | NumpadClear | NumpadClearEntry | NumpadMemoryAdd | NumpadMemoryClear
-            | NumpadMemoryRecall | NumpadMemoryStore | NumpadMemorySubtract
-            | NumpadMultiply => return Err(Error::UnknownKey),
-        })
-    }
 }

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -1,26 +1,23 @@
 use crate::KeyCode;
+use evdev::{self, Device, EventType, InputEventKind, Key};
 use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
 use promising_future::{future_promise, Promise};
 use std::{
-    collections::hash_map::{Entry, HashMap},
-    mem,
-    os::raw::{c_int, c_uint},
-    ptr,
+    collections::hash_map::HashMap,
+    convert::{TryFrom, TryInto},
+    os::unix::prelude::{AsRawFd, RawFd},
     sync::mpsc::{channel, Sender},
     thread::{self, JoinHandle},
-};
-use x11_dl::xlib::{
-    AnyKey, AnyModifier, Display, GrabModeAsync, KeyPress, XErrorEvent, XKeyEvent, Xlib,
 };
 
 #[derive(Debug, Copy, Clone, snafu::Snafu)]
 pub enum Error {
-    NoXLib,
-    OpenXServerConnection,
     EPoll,
     ThreadStopped,
     AlreadyRegistered,
     NotRegistered,
+    UnknownKey,
+    EvDev,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -35,8 +32,8 @@ enum Message {
     End,
 }
 
-const X_TOKEN: Token = Token(0);
-const PING_TOKEN: Token = Token(1);
+// Low numbered tokens are allocated to devices
+const PING_TOKEN: Token = Token(256);
 
 pub struct Hook {
     sender: Sender<Message>,
@@ -54,344 +51,82 @@ impl Drop for Hook {
     }
 }
 
-unsafe fn ungrab_all(xlib: &Xlib, display: *mut Display) {
-    let screencount = (xlib.XScreenCount)(display);
-    for screen in 0..screencount {
-        let rootwindow = (xlib.XRootWindow)(display, screen);
-        for _i in 0..rootwindow {
-            // FIXME: This loop looks very stupid, but it somehow it prevents
-            // button presses getting lost.
-            (xlib.XUngrabKey)(display, AnyKey, AnyModifier, rootwindow);
-        }
-    }
-}
-
-unsafe fn grab_all(xlib: &Xlib, display: *mut Display, keylist: &[c_uint]) {
-    ungrab_all(xlib, display);
-    let screencount = (xlib.XScreenCount)(display);
-    for screen in 0..screencount {
-        let rootwindow = (xlib.XRootWindow)(display, screen);
-        for &code in keylist {
-            (xlib.XGrabKey)(
-                display,
-                code as c_int,
-                AnyModifier,
-                rootwindow,
-                false as _,
-                GrabModeAsync,
-                GrabModeAsync,
-            );
-        }
-    }
-}
-
-unsafe extern "C" fn handle_error(_: *mut Display, _: *mut XErrorEvent) -> c_int {
-    0
-}
-
-fn code_for(key: KeyCode) -> Option<c_uint> {
-    use self::KeyCode::*;
-    Some(match key {
-        Escape => 0x0009,
-        Digit1 => 0x000A,
-        Digit2 => 0x000B,
-        Digit3 => 0x000C,
-        Digit4 => 0x000D,
-        Digit5 => 0x000E,
-        Digit6 => 0x000F,
-        Digit7 => 0x0010,
-        Digit8 => 0x0011,
-        Digit9 => 0x0012,
-        Digit0 => 0x0013,
-        Minus => 0x0014,
-        Equal => 0x0015,
-        Backspace => 0x0016,
-        Tab => 0x0017,
-        KeyQ => 0x0018,
-        KeyW => 0x0019,
-        KeyE => 0x001A,
-        KeyR => 0x001B,
-        KeyT => 0x001C,
-        KeyY => 0x001D,
-        KeyU => 0x001E,
-        KeyI => 0x001F,
-        KeyO => 0x0020,
-        KeyP => 0x0021,
-        BracketLeft => 0x0022,
-        BracketRight => 0x0023,
-        Enter => 0x0024,
-        ControlLeft => 0x0025,
-        KeyA => 0x0026,
-        KeyS => 0x0027,
-        KeyD => 0x0028,
-        KeyF => 0x0029,
-        KeyG => 0x002A,
-        KeyH => 0x002B,
-        KeyJ => 0x002C,
-        KeyK => 0x002D,
-        KeyL => 0x002E,
-        Semicolon => 0x002F,
-        Quote => 0x0030,
-        Backquote => 0x0031,
-        ShiftLeft => 0x0032,
-        Backslash => 0x0033,
-        KeyZ => 0x0034,
-        KeyX => 0x0035,
-        KeyC => 0x0036,
-        KeyV => 0x0037,
-        KeyB => 0x0038,
-        KeyN => 0x0039,
-        KeyM => 0x003A,
-        Comma => 0x003B,
-        Period => 0x003C,
-        Slash => 0x003D,
-        ShiftRight => 0x003E,
-        NumpadMultiply => 0x003F,
-        AltLeft => 0x0040,
-        Space => 0x0041,
-        CapsLock => 0x0042,
-        F1 => 0x0043,
-        F2 => 0x0044,
-        F3 => 0x0045,
-        F4 => 0x0046,
-        F5 => 0x0047,
-        F6 => 0x0048,
-        F7 => 0x0049,
-        F8 => 0x004A,
-        F9 => 0x004B,
-        F10 => 0x004C,
-        NumLock => 0x004D,
-        ScrollLock => 0x004E,
-        Numpad7 => 0x004F,
-        Numpad8 => 0x0050,
-        Numpad9 => 0x0051,
-        NumpadSubtract => 0x0052,
-        Numpad4 => 0x0053,
-        Numpad5 => 0x0054,
-        Numpad6 => 0x0055,
-        NumpadAdd => 0x0056,
-        Numpad1 => 0x0057,
-        Numpad2 => 0x0058,
-        Numpad3 => 0x0059,
-        Numpad0 => 0x005A,
-        NumpadDecimal => 0x005B,
-        Lang5 => 0x005D, // Not Firefox, Not Safari
-        IntlBackslash => 0x005E,
-        F11 => 0x005F,
-        F12 => 0x0060,
-        IntlRo => 0x0061,
-        Lang3 => 0x0062, // Not Firefox, Not Safari
-        Lang4 => 0x0063, // Not Firefox, Not Safari
-        Convert => 0x0064,
-        KanaMode => 0x0065,
-        NonConvert => 0x0066,
-        NumpadEnter => 0x0068,
-        ControlRight => 0x0069,
-        NumpadDivide => 0x006A,
-        PrintScreen => 0x006B,
-        AltRight => 0x006C,
-        Home => 0x006E,
-        ArrowUp => 0x006F,
-        PageUp => 0x0070,
-        ArrowLeft => 0x0071,
-        ArrowRight => 0x0072,
-        End => 0x0073,
-        ArrowDown => 0x0074,
-        PageDown => 0x0075,
-        Insert => 0x0076,
-        Delete => 0x0077,
-        AudioVolumeMute => 0x0079,
-        AudioVolumeDown => 0x007A,
-        AudioVolumeUp => 0x007B,
-        Power => 0x007C, // Not Firefox, Not Safari
-        NumpadEqual => 0x007D,
-        Pause => 0x007F,
-        ShowAllWindows => 0x0080, // Chrome only
-        NumpadComma => 0x0081,
-        Lang1 => 0x0082,
-        Lang2 => 0x0083,
-        IntlYen => 0x0084,
-        MetaLeft => 0x0085,
-        MetaRight => 0x0086,
-        ContextMenu => 0x0087,
-        BrowserStop => 0x0088,
-        Again => 0x0089,
-        Props => 0x008A, // Not Chrome
-        Undo => 0x008B,
-        Select => 0x008C,
-        Copy => 0x008D,
-        Open => 0x008E,
-        Paste => 0x008F,
-        Find => 0x0090,
-        Cut => 0x0091,
-        Help => 0x0092,
-        LaunchApp2 => 0x0094,
-        Sleep => 0x0096, // Not Firefox, Not Safari
-        WakeUp => 0x0097,
-        LaunchApp1 => 0x0098,
-        LaunchMail => 0x00A3,
-        BrowserFavorites => 0x00A4,
-        BrowserBack => 0x00A6,
-        BrowserForward => 0x00A7,
-        Eject => 0x00A9,
-        MediaTrackNext => 0x00AB,
-        MediaPlayPause => 0x00AC,
-        MediaTrackPrevious => 0x00AD,
-        MediaStop => 0x00AE,
-        MediaRecord => 0x00AF, // Chrome only
-        MediaRewind => 0x00B0, // Chrome only
-        MediaSelect => 0x00B3,
-        BrowserHome => 0x00B4,
-        BrowserRefresh => 0x00B5,
-        NumpadParenLeft => 0x00BB,  // Not Firefox, Not Safari
-        NumpadParenRight => 0x00BC, // Not Firefox, Not Safari
-        F13 => 0x00BF,
-        F14 => 0x00C0,
-        F15 => 0x00C1,
-        F16 => 0x00C2,
-        F17 => 0x00C3,
-        F18 => 0x00C4,
-        F19 => 0x00C5,
-        F20 => 0x00C6,
-        F21 => 0x00C7,
-        F22 => 0x00C8,
-        F23 => 0x00C9,
-        F24 => 0x00CA,
-        MediaPause => 0x00D1,       // Chrome only
-        MediaPlay => 0x00D7,        // Chrome only
-        MediaFastForward => 0x00D8, // Chrome only
-        BrowserSearch => 0x00E1,
-        BrightnessDown => 0x00E8,       // Chrome only
-        BrightnessUp => 0x00E9,         // Chrome only
-        DisplayToggleIntExt => 0x00EB,  // Chrome only
-        MailSend => 0x00EF,             // Chrome only
-        MailReply => 0x00F0,            // Chrome only
-        MailForward => 0x00F1,          // Chrome only
-        ZoomToggle => 0x017C,           // Chrome only
-        LaunchControlPanel => 0x024B,   // Chrome only
-        SelectTask => 0x024C,           // Chrome only
-        LaunchScreenSaver => 0x024D,    // Chrome only
-        LaunchAssistant => 0x024F,      // Chrome only
-        KeyboardLayoutSelect => 0x0250, // Chrome only
-        PrivacyScreenToggle => 0x0281,  // Chrome only
-        _ => return None,
-    })
-}
-
 impl Hook {
     pub fn new() -> Result<Self> {
-        unsafe {
-            let (sender, receiver) = channel();
+        let (sender, receiver) = channel();
+        let mut poll = Poll::new().map_err(|_| Error::EPoll)?;
+        let waker = Waker::new(poll.registry(), PING_TOKEN).map_err(|_| Error::EPoll)?;
 
-            let xlib = Xlib::open().map_err(|_| Error::NoXLib)?;
-            (xlib.XSetErrorHandler)(Some(handle_error));
+        let mut devices: Vec<Device> = evdev::enumerate()
+            .filter(|d| d.supported_events().contains(EventType::KEY))
+            .collect();
+        let fds: Vec<RawFd> = devices.iter().map(|d| d.as_raw_fd()).collect();
 
-            let display = (xlib.XOpenDisplay)(ptr::null());
-            if display.is_null() {
-                return Err(Error::OpenXServerConnection);
-            }
-
-            let fd = (xlib.XConnectionNumber)(display) as std::os::unix::io::RawFd;
-            let mut poll = Poll::new().map_err(|_| Error::EPoll)?;
-
-            let waker = Waker::new(poll.registry(), PING_TOKEN).map_err(|_| Error::EPoll)?;
-
+        for (i, fd) in fds.iter().enumerate() {
             poll.registry()
-                .register(
-                    &mut SourceFd(&fd),
-                    X_TOKEN,
-                    Interest::READABLE | Interest::WRITABLE,
-                )
+                .register(&mut SourceFd(fd), Token(i), Interest::READABLE)
                 .map_err(|_| Error::EPoll)?;
+        }
 
-            struct XData(Xlib, *mut Display);
-            unsafe impl Send for XData {}
-            let xdata = XData(xlib, display);
+        let join_handle = thread::spawn(move || -> Result<()> {
+            let mut result = Ok(());
+            let mut events = Events::with_capacity(1024);
+            let mut hotkeys: HashMap<Key, Box<dyn FnMut() + Send>> = HashMap::new();
 
-            let join_handle = thread::spawn(move || -> Result<()> {
-                let XData(xlib, display) = xdata;
+            'event_loop: loop {
+                if poll.poll(&mut events, None).is_err() {
+                    result = Err(Error::EPoll);
+                    break 'event_loop;
+                }
 
-                let mut result = Ok(());
-                let mut events = Events::with_capacity(1024);
-                let mut hotkeys = HashMap::new();
-
-                // For some reason we need to call this once for any KeyGrabs to
-                // actually do anything.
-                (xlib.XKeysymToKeycode)(display, 0);
-
-                'event_loop: loop {
-                    if poll.poll(&mut events, None).is_err() {
-                        result = Err(Error::EPoll);
-                        break 'event_loop;
-                    }
-
-                    for mio_event in &events {
-                        if mio_event.token() == PING_TOKEN {
-                            for message in receiver.try_iter() {
-                                match message {
-                                    Message::Register(key, callback, promise) => {
-                                        if let Some(code) = code_for(key) {
-                                            if let Entry::Vacant(vacant) = hotkeys.entry(code) {
-                                                vacant.insert(callback);
-                                                promise.set(Ok(()));
-                                            } else {
-                                                promise.set(Err(Error::AlreadyRegistered));
-                                            }
-                                            let keys = hotkeys.keys().copied().collect::<Vec<_>>();
-                                            grab_all(&xlib, display, &keys);
-                                        } else {
-                                            promise.set(Ok(()));
-                                        }
-                                    }
-                                    Message::Unregister(key, promise) => {
-                                        if let Some(code) = code_for(key) {
-                                            if hotkeys.remove(&code).is_some() {
-                                                promise.set(Ok(()));
-                                            } else {
-                                                promise.set(Err(Error::NotRegistered));
-                                            }
-                                            let keys = hotkeys.keys().copied().collect::<Vec<_>>();
-                                            grab_all(&xlib, display, &keys);
-                                        } else {
-                                            promise.set(Ok(()));
-                                        }
-                                    }
-                                    Message::End => {
-                                        break 'event_loop;
+                for mio_event in &events {
+                    if mio_event.token().0 < devices.len() {
+                        let idx = mio_event.token().0;
+                        for ev in devices[idx].fetch_events().map_err(|_| Error::EvDev)? {
+                            if let InputEventKind::Key(k) = ev.kind() {
+                                // println!("{:?} - {}", k, ev.value());
+                                if ev.value() != 0 {
+                                    if let Some(callback) = hotkeys.get_mut(&k) {
+                                        callback();
                                     }
                                 }
                             }
-                        } else if mio_event.token() == X_TOKEN {
-                            while (xlib.XPending)(display) != 0 {
-                                let mut event = mem::MaybeUninit::uninit();
-                                (xlib.XNextEvent)(display, event.as_mut_ptr());
-                                let event = event.assume_init();
-                                if event.get_type() == KeyPress {
-                                    let event: &XKeyEvent = event.as_ref();
-                                    if let Some(callback) = hotkeys.get_mut(&event.keycode) {
-                                        callback();
-                                    }
-                                    // FIXME: We should check else here: these amount to lost
-                                    // keypresses.
+                        }
+                    } else if mio_event.token() == PING_TOKEN {
+                        for message in receiver.try_iter() {
+                            match message {
+                                Message::Register(key, callback, promise) => {
+                                    promise.set(key.try_into().and_then(|k| {
+                                        if hotkeys.insert(k, callback).is_some() {
+                                            Err(Error::AlreadyRegistered)
+                                        } else {
+                                            Ok(())
+                                        }
+                                    }))
+                                }
+                                Message::Unregister(key, promise) => promise.set(
+                                    key.try_into()
+                                        .and_then(|k| {
+                                            hotkeys.remove(&k).ok_or(Error::NotRegistered)
+                                        })
+                                        .and(Ok(())),
+                                ),
+                                Message::End => {
+                                    break 'event_loop;
                                 }
                             }
                         }
                     }
                 }
+            }
+            result
+        });
 
-                ungrab_all(&xlib, display);
-
-                (xlib.XCloseDisplay)(display);
-
-                result
-            });
-
-            Ok(Hook {
-                sender,
-                waker,
-                join_handle: Some(join_handle),
-            })
-        }
+        Ok(Hook {
+            sender,
+            waker,
+            join_handle: Some(join_handle),
+        })
     }
 
     pub fn register<F>(&self, hotkey: KeyCode, callback: F) -> Result<()>
@@ -424,4 +159,211 @@ impl Hook {
 
 pub(crate) fn try_resolve(_key_code: KeyCode) -> Option<String> {
     None
+}
+
+impl TryFrom<KeyCode> for Key {
+    type Error = Error;
+    fn try_from(k: KeyCode) -> Result<Self> {
+        use self::KeyCode::*;
+        Ok(match k {
+            Again => Key::KEY_AGAIN,
+            AltLeft => Key::KEY_LEFTALT,
+            AltRight => Key::KEY_RIGHTALT,
+            ArrowDown => Key::KEY_DOWN,
+            ArrowLeft => Key::KEY_LEFT,
+            ArrowRight => Key::KEY_RIGHT,
+            ArrowUp => Key::KEY_UP,
+            AudioVolumeDown => Key::KEY_VOLUMEUP,
+            AudioVolumeMute => Key::KEY_MUTE,
+            AudioVolumeUp => Key::KEY_VOLUMEDOWN,
+            Backquote => Key::KEY_GRAVE,
+            Backslash => Key::KEY_BACKSLASH,
+            Backspace => Key::KEY_BACKSPACE,
+            BracketLeft => Key::KEY_LEFTBRACE,
+            BracketRight => Key::KEY_RIGHTBRACE,
+            BrightnessDown => Key::KEY_BRIGHTNESSDOWN,
+            BrightnessUp => Key::KEY_BRIGHTNESSUP,
+            BrowserBack => Key::KEY_BACK,
+            BrowserFavorites => Key::KEY_FAVORITES,
+            BrowserForward => Key::KEY_FORWARD,
+            BrowserHome => Key::KEY_HOMEPAGE,
+            BrowserRefresh => Key::KEY_REFRESH,
+            BrowserSearch => Key::KEY_SEARCH,
+            BrowserStop => Key::KEY_STOP,
+            CapsLock => Key::KEY_CAPSLOCK,
+            Comma => Key::KEY_COMMA,
+            ContextMenu => Key::KEY_CONTEXT_MENU,
+            ControlLeft => Key::KEY_LEFTCTRL,
+            ControlRight => Key::KEY_RIGHTCTRL,
+            Convert => Key::KEY_KATAKANA,
+            Copy => Key::KEY_COPY,
+            Cut => Key::KEY_CUT,
+            Delete => Key::KEY_DELETE,
+            Digit0 => Key::KEY_0,
+            Digit1 => Key::KEY_1,
+            Digit2 => Key::KEY_2,
+            Digit3 => Key::KEY_3,
+            Digit4 => Key::KEY_4,
+            Digit5 => Key::KEY_5,
+            Digit6 => Key::KEY_6,
+            Digit7 => Key::KEY_7,
+            Digit8 => Key::KEY_8,
+            Digit9 => Key::KEY_9,
+            DisplayToggleIntExt => Key::KEY_DISPLAYTOGGLE,
+            Eject => Key::KEY_EJECTCD,
+            End => Key::KEY_END,
+            Enter => Key::KEY_ENTER,
+            Equal => Key::KEY_EQUAL,
+            Escape => Key::KEY_ESC,
+            F1 => Key::KEY_F1,
+            F2 => Key::KEY_F2,
+            F3 => Key::KEY_F3,
+            F4 => Key::KEY_F4,
+            F5 => Key::KEY_F5,
+            F6 => Key::KEY_F6,
+            F7 => Key::KEY_F7,
+            F8 => Key::KEY_F8,
+            F9 => Key::KEY_F9,
+            F10 => Key::KEY_F10,
+            F11 => Key::KEY_F11,
+            F12 => Key::KEY_F12,
+            F13 => Key::KEY_F13,
+            F14 => Key::KEY_F14,
+            F15 => Key::KEY_F15,
+            F16 => Key::KEY_F16,
+            F17 => Key::KEY_F17,
+            F18 => Key::KEY_F18,
+            F19 => Key::KEY_F19,
+            F20 => Key::KEY_F20,
+            F21 => Key::KEY_F21,
+            F22 => Key::KEY_F22,
+            F23 => Key::KEY_F23,
+            F24 => Key::KEY_F24,
+            Find => Key::KEY_FIND,
+            Fn => Key::KEY_FN,
+            Gamepad0 => Key::BTN_SOUTH,
+            Gamepad1 => Key::BTN_EAST,
+            Gamepad2 => Key::BTN_C,
+            Gamepad3 => Key::BTN_NORTH,
+            Gamepad4 => Key::BTN_WEST,
+            Gamepad5 => Key::BTN_Z,
+            Gamepad6 => Key::BTN_TL,
+            Gamepad7 => Key::BTN_TR,
+            Gamepad8 => Key::BTN_TL2,
+            Gamepad9 => Key::BTN_TR2,
+            Gamepad10 => Key::BTN_SELECT,
+            Gamepad11 => Key::BTN_START,
+            Gamepad12 => Key::BTN_MODE,
+            Gamepad13 => Key::BTN_THUMBL,
+            Help => Key::KEY_HELP,
+            Home => Key::KEY_HOME,
+            Insert => Key::KEY_INSERT,
+            IntlYen => Key::KEY_YEN,
+            KanaMode => Key::KEY_KATAKANAHIRAGANA,
+            KeyA => Key::KEY_A,
+            KeyB => Key::KEY_B,
+            KeyC => Key::KEY_C,
+            KeyD => Key::KEY_D,
+            KeyE => Key::KEY_E,
+            KeyF => Key::KEY_F,
+            KeyG => Key::KEY_G,
+            KeyH => Key::KEY_H,
+            KeyI => Key::KEY_I,
+            KeyJ => Key::KEY_J,
+            KeyK => Key::KEY_K,
+            KeyL => Key::KEY_L,
+            KeyM => Key::KEY_M,
+            KeyN => Key::KEY_N,
+            KeyO => Key::KEY_O,
+            KeyP => Key::KEY_P,
+            KeyQ => Key::KEY_Q,
+            KeyR => Key::KEY_R,
+            KeyS => Key::KEY_S,
+            KeyT => Key::KEY_T,
+            KeyU => Key::KEY_U,
+            KeyV => Key::KEY_V,
+            KeyW => Key::KEY_W,
+            KeyX => Key::KEY_X,
+            KeyY => Key::KEY_Y,
+            KeyZ => Key::KEY_Z,
+            KeyboardLayoutSelect => Key::KEY_KBD_LAYOUT_NEXT,
+            Lang1 => Key::KEY_LANGUAGE,
+            LaunchAssistant => Key::KEY_ASSISTANT,
+            LaunchControlPanel => Key::KEY_CONTROLPANEL,
+            LaunchMail => Key::KEY_MAIL,
+            LaunchScreenSaver => Key::KEY_SCREENSAVER,
+            MailForward => Key::KEY_FORWARDMAIL,
+            MailReply => Key::KEY_REPLY,
+            MailSend => Key::KEY_SEND,
+            MediaFastForward => Key::KEY_FASTFORWARD,
+            MediaPause => Key::KEY_PAUSE,
+            MediaPlay => Key::KEY_PLAY,
+            MediaPlayPause => Key::KEY_PLAYPAUSE,
+            MediaRecord => Key::KEY_RECORD,
+            MediaRewind => Key::KEY_REWIND,
+            MediaSelect => Key::KEY_SELECT,
+            MediaStop => Key::KEY_STOPCD,
+            MediaTrackNext => Key::KEY_NEXTSONG,
+            MediaTrackPrevious => Key::KEY_PREVIOUSSONG,
+            MetaLeft => Key::KEY_LEFTMETA,
+            MetaRight => Key::KEY_RIGHTMETA,
+            Minus => Key::KEY_MINUS,
+            NumLock => Key::KEY_NUMLOCK,
+            Numpad0 => Key::KEY_NUMERIC_0,
+            Numpad1 => Key::KEY_NUMERIC_1,
+            Numpad2 => Key::KEY_NUMERIC_2,
+            Numpad3 => Key::KEY_NUMERIC_3,
+            Numpad4 => Key::KEY_NUMERIC_4,
+            Numpad5 => Key::KEY_NUMERIC_5,
+            Numpad6 => Key::KEY_NUMERIC_6,
+            Numpad7 => Key::KEY_NUMERIC_7,
+            Numpad8 => Key::KEY_NUMERIC_8,
+            Numpad9 => Key::KEY_NUMERIC_9,
+            NumpadAdd => Key::KEY_KPPLUS,
+            NumpadComma => Key::KEY_KPCOMMA,
+            NumpadDecimal => Key::KEY_KPDOT,
+            NumpadDivide => Key::KEY_KPSLASH,
+            NumpadEnter => Key::KEY_KPENTER,
+            NumpadEqual => Key::KEY_KPEQUAL,
+            NumpadHash => Key::KEY_NUMERIC_POUND,
+            NumpadParenLeft => Key::KEY_KPLEFTPAREN,
+            NumpadParenRight => Key::KEY_KPRIGHTPAREN,
+            NumpadStar => Key::KEY_NUMERIC_STAR,
+            NumpadSubtract => Key::KEY_KPMINUS,
+            Open => Key::KEY_OPEN,
+            PageDown => Key::KEY_PAGEDOWN,
+            PageUp => Key::KEY_PAGEUP,
+            Paste => Key::KEY_PASTE,
+            Pause => Key::KEY_PAUSE,
+            Period => Key::KEY_DOT,
+            Power => Key::KEY_POWER,
+            PrintScreen => Key::KEY_PRINT,
+            PrivacyScreenToggle => Key::KEY_PRIVACY_SCREEN_TOGGLE,
+            Props => Key::KEY_PROPS,
+            Quote => Key::KEY_APOSTROPHE,
+            ScrollLock => Key::KEY_SCROLLLOCK,
+            Select => Key::KEY_SELECT,
+            Semicolon => Key::KEY_SEMICOLON,
+            ShiftLeft => Key::KEY_LEFTSHIFT,
+            ShiftRight => Key::KEY_RIGHTSHIFT,
+            ShowAllWindows => Key::KEY_CYCLEWINDOWS,
+            Slash => Key::KEY_SLASH,
+            Sleep => Key::KEY_SLEEP,
+            Space => Key::KEY_SPACE,
+            Tab => Key::KEY_TAB,
+            Undo => Key::KEY_UNDO,
+            WakeUp => Key::KEY_WAKEUP,
+            ZoomToggle => Key::KEY_ZOOM,
+            // TODO: test on a gamepad with 20 buttons to see what the higher indices are
+            Gamepad14 | Gamepad15 | Gamepad16 | Gamepad17 | Gamepad18 | Gamepad19 => {
+                return Err(Error::UnknownKey)
+            }
+            // TODO: find a keyboard with these keys and see which they correspond to
+            SelectTask | IntlBackslash | IntlRo | Lang2 | Lang3 | Lang4 | Lang5
+            | NonConvert | FnLock | LaunchApp1 | LaunchApp2 | NumpadBackspace
+            | NumpadClear | NumpadClearEntry | NumpadMemoryAdd | NumpadMemoryClear
+            | NumpadMemoryRecall | NumpadMemoryStore | NumpadMemorySubtract
+            | NumpadMultiply => return Err(Error::UnknownKey),
+        })
+    }
 }


### PR DESCRIPTION
Apparently evdev is a lower level system provided by the kernel to read events for all the input devices attached to the PC. This makes the hotkeys work even without an X11 connection and thus works just fine in a terminal or wayland session. However this reads the keyboard that is directly attached to the PC that the process is running on rather than the keyboard associated with the X11 server, which might be a remote system. This isn't all too important for us, so that's fine. Also since we directly read all the key presses, this doesn't require "exclusively grabbing" any single of them. So this bring the Linux implementation closer to the rest of the platforms. Another advantage of this is that it brings support for gamepads without all too much additional effort.

Thanks to @P1n3appl3 for doing almost all of the work here.

Resolves #471 
Resolves #472 