### PR TITLE
Don't repeat hotkeys on WebAssembly

### DIFF
--- a/benches/software_rendering.rs
+++ b/benches/software_rendering.rs
@@ -26,8 +26,13 @@ cfg_if::cfg_if! {
             make_progress_run_with_splits_opt(&mut timer, &[Some(5.0), None, Some(10.0)]);
 
             let snapshot = timer.snapshot();
-            let state = layout.state(&snapshot);
+            let mut state = layout.state(&snapshot);
             let mut renderer = Renderer::new();
+
+            // Do a single frame beforehand as otherwise the layout state will
+            // keep saying that the icons changed.
+            renderer.render(&state, [300, 500]);
+            layout.update_state(&mut state, &snapshot);
 
             c.bench_function("Software Rendering (Default)", move |b| {
                 b.iter(|| renderer.render(&state, [300, 500]))
@@ -43,8 +48,13 @@ cfg_if::cfg_if! {
             make_progress_run_with_splits_opt(&mut timer, &[Some(10.0), None, Some(20.0), Some(55.0)]);
 
             let snapshot = timer.snapshot();
-            let state = layout.state(&snapshot);
+            let mut state = layout.state(&snapshot);
             let mut renderer = Renderer::new();
+
+            // Do a single frame beforehand as otherwise the layout state will
+            // keep saying that the icons changed.
+            renderer.render(&state, [300, 800]);
+            layout.update_state(&mut state, &snapshot);
 
             c.bench_function("Software Rendering (Subsplits Layout)", move |b| {
                 b.iter(|| renderer.render(&state, [300, 800]))

--- a/crates/livesplit-hotkey/src/wasm_web/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm_web/mod.rs
@@ -73,9 +73,11 @@ impl Hook {
 
         let hotkey_map = hotkeys.clone();
         let keyboard_callback = Closure::wrap(Box::new(move |event: KeyboardEvent| {
-            if let Ok(code) = event.code().parse() {
-                if let Some(callback) = hotkey_map.lock().unwrap().get_mut(&code) {
-                    callback();
+            if !event.repeat() {
+                if let Ok(code) = event.code().parse() {
+                    if let Some(callback) = hotkey_map.lock().unwrap().get_mut(&code) {
+                        callback();
+                    }
                 }
             }
         }) as Box<dyn FnMut(KeyboardEvent)>);

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -63,6 +63,8 @@ thread_local! {
 }
 
 fn parse_scan_code(value: DWORD) -> Option<KeyCode> {
+    // Windows uses PS/2 scan code set 1.
+    // https://www.avrfreaks.net/sites/default/files/PS2%20Keyboard.pdf Page 19
     use self::KeyCode::*;
     Some(match value {
         0x0001 => Escape,


### PR DESCRIPTION
Just like on the other platforms we don't want the hotkeys to repeat if the key is held down. On WebAssembly we just need to check the `repeat` field of the `KeyboardEvent` object.

I also snuck in some other minor improvements.

Resolves the Web part of #473 