### PR TITLE
Remove `euclid` and `ordered-float`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,9 +275,6 @@ jobs:
             target: wasm32-wasi
             os: ubuntu-latest
             cross: skip
-            # FIXME: We are currently hitting limits in wasmtime. We need to fix
-            # wasmtime before we can reenable these tests.
-            tests: skip
             dylib: skip
             install_target: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ hashbrown = "0.11.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.6.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.2.0" }
-ordered-float = { version = "2.0.1", default-features = false }
 serde = { version = "1.0.98", default-features = false, features = [
     "alloc",
     "derive",
@@ -65,7 +64,6 @@ utf-8 = { version = "0.7.4", optional = true }
 
 # Rendering
 ahash = { version = "0.7.0", default-features = false, optional = true }
-euclid = { version = "0.22.1", default-features = false, optional = true }
 rustybuzz = { version = "0.4.0", optional = true }
 ttf-parser = { version = "0.12.0", optional = true }
 
@@ -132,7 +130,6 @@ image-shrinking = ["std", "bytemuck", "more-image-formats"]
 rendering = [
     "ahash",
     "bytemuck/derive",
-    "euclid",
     "more-image-formats",
     "rustybuzz",
     "std",

--- a/src/comparison/median_segments.rs
+++ b/src/comparison/median_segments.rs
@@ -4,9 +4,7 @@
 //! suited to represent the current performance of a runner.
 
 use super::ComparisonGenerator;
-use crate::platform::prelude::*;
-use crate::{Attempt, Segment, TimeSpan, TimingMethod};
-use ordered_float::OrderedFloat;
+use crate::{platform::prelude::*, Attempt, Segment, TimeSpan, TimingMethod};
 
 /// The Comparison Generator for calculating the Median Segments of a Run. The
 /// Median Segments are calculated through a weighted median that gives more
@@ -23,7 +21,7 @@ pub const NAME: &str = "Median Segments";
 
 const WEIGHT: f64 = 0.75;
 
-fn generate(segments: &mut [Segment], medians: &mut Vec<(f64, f64)>, method: TimingMethod) {
+fn generate(segments: &mut [Segment], medians: &mut Vec<(f64, TimeSpan)>, method: TimingMethod) {
     let mut accumulated = Some(TimeSpan::zero());
 
     let mut previous_segment: Option<&Segment> = None;
@@ -42,7 +40,7 @@ fn generate(segments: &mut [Segment], medians: &mut Vec<(f64, f64)>, method: Tim
                     .unwrap_or(false);
 
                     if !skip {
-                        medians.push((current_weight, time.total_seconds()));
+                        medians.push((current_weight, time));
                         current_weight *= WEIGHT;
                     }
                 }
@@ -51,21 +49,15 @@ fn generate(segments: &mut [Segment], medians: &mut Vec<(f64, f64)>, method: Tim
             if medians.is_empty() {
                 accumulated = None;
             } else {
-                medians.sort_unstable_by_key(|&(_, time)| OrderedFloat(time));
+                medians.sort_unstable_by_key(|&(_, time)| time);
                 let mut total_weights = 0.0;
                 for (weight, _) in medians.iter_mut() {
                     *weight += total_weights;
                     total_weights = *weight;
                 }
-                let found_index = medians
-                    .binary_search_by_key(&OrderedFloat(total_weights / 2.0), |&(weight, _)| {
-                        OrderedFloat(weight)
-                    });
-                let segment_time = match found_index {
-                    Ok(index) => medians[index].1,
-                    Err(right_index) => medians[right_index].1,
-                };
-                *accumulated_val += TimeSpan::from_seconds(segment_time);
+                let median_weight = 0.5 * total_weights;
+                let found_index = medians.partition_point(|&(weight, _)| weight < median_weight);
+                *accumulated_val += medians[found_index].1;
             }
         }
         segment.comparison_mut(NAME)[method] = accumulated;

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -663,7 +663,7 @@ fn calculate_grid_lines(
     if current_phase != TimerPhase::NotRunning && total_delta < TimeSpan::zero() {
         grid_value_y = 1000.0;
         while (-total_delta.total_milliseconds() as f32) / grid_value_y
-            > (graph_height - graph_edge) * 2.0 / 20.0
+            > (graph_height - graph_edge) * (2.0 / 20.0)
         {
             grid_value_y *= 6.0;
         }

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -27,7 +27,7 @@ where
                 text_parsed(reader, tag.into_buf(), |v| total_height = translate_size(v))
             } else if tag.name() == b"SegmentTimerSizeRatio" {
                 text_parsed(reader, tag.into_buf(), |v: u32| {
-                    segment_timer_ratio = v as f32 / 100.0
+                    segment_timer_ratio = 0.01 * v as f32
                 })
             } else if tag.name() == b"TimerShowGradient" {
                 parse_bool(reader, tag.into_buf(), |b| settings.timer.show_gradient = b)

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -274,7 +274,7 @@ where
         // heuristic. We often have white on dark grey, instead of white on
         // black. Because of that, we use 1.75 as the exponent denominator for
         // the white on black case instead of the usual 2.2 for sRGB.
-        let lightness = (r + g + b) / 3.0;
+        let lightness = (r + g + b) * (1.0 / 3.0);
         color.alpha =
             (1.0 - lightness) * (1.0 - (1.0 - a).powf(1.0 / 2.2)) + lightness * a.powf(1.0 / 1.75);
 

--- a/src/rendering/component/blank_space.rs
+++ b/src/rendering/component/blank_space.rs
@@ -8,5 +8,5 @@ pub(in crate::rendering) fn render(
     dim: [f32; 2],
     component: &State,
 ) {
-    context.render_rectangle([0.0, 0.0], dim, &component.background);
+    context.render_background(dim, &component.background);
 }

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -45,7 +45,7 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     component: &State,
     layout_state: &LayoutState,
 ) {
-    context.render_rectangle([0.0, 0.0], [width, height], &component.background);
+    context.render_background([width, height], &component.background);
 
     let text_color = solid(&layout_state.text_color);
 

--- a/src/rendering/component/key_value.rs
+++ b/src/rendering/component/key_value.rs
@@ -33,7 +33,7 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     component: &State,
     layout_state: &LayoutState,
 ) {
-    context.render_rectangle([0.0, 0.0], dim, &component.background);
+    context.render_background(dim, &component.background);
     context.render_key_value_component(
         &component.key,
         &component.key_abbreviations,

--- a/src/rendering/component/separator.rs
+++ b/src/rendering/component/separator.rs
@@ -11,9 +11,5 @@ pub(in crate::rendering) fn render(
     _component: &State,
     layout_state: &LayoutState,
 ) {
-    context.render_rectangle(
-        [0.0, 0.0],
-        dim,
-        &Gradient::Plain(layout_state.separators_color),
-    );
+    context.render_background(dim, &Gradient::Plain(layout_state.separators_color));
 }

--- a/src/rendering/component/splits.rs
+++ b/src/rendering/component/splits.rs
@@ -156,14 +156,13 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
         }
 
         if split.is_current_split {
-            context.render_rectangle(
-                [0.0, 0.0],
+            context.render_background(
                 [split_width, split_height],
                 &component.current_split_gradient,
             );
         } else if let Some((even, odd)) = &split_background {
             let color = if split.index % 2 == 0 { even } else { odd };
-            context.render_rectangle([0.0, 0.0], split_background_bottom_right, color);
+            context.render_background(split_background_bottom_right, color);
         }
 
         {

--- a/src/rendering/component/text.rs
+++ b/src/rendering/component/text.rs
@@ -34,7 +34,7 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     component: &State,
     layout_state: &LayoutState,
 ) {
-    context.render_rectangle([0.0, 0.0], [width, height], &component.background);
+    context.render_background([width, height], &component.background);
     match &component.text {
         TextState::Center(text) => context.render_text_centered(
             text,

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -30,7 +30,7 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     [width, height]: [f32; 2],
     component: &State,
 ) -> f32 {
-    context.render_rectangle([0.0, 0.0], [width, height], &component.background);
+    context.render_background([width, height], &component.background);
     let shader = FillShader::VerticalGradient(
         component.top_color.to_array(),
         component.bottom_color.to_array(),

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -42,7 +42,7 @@ pub(in crate::rendering) fn render<B: ResourceAllocator>(
     component: &State,
     layout_state: &LayoutState,
 ) {
-    context.render_rectangle([0.0, 0.0], [width, height], &component.background);
+    context.render_background([width, height], &component.background);
     let text_color = component.text_color.unwrap_or(layout_state.text_color);
     let text_color = solid(&text_color);
 

--- a/src/rendering/font/mod.rs
+++ b/src/rendering/font/mod.rs
@@ -518,7 +518,7 @@ pub fn render<A: ResourceAllocator>(
         let layers = glyph_cache.lookup_or_insert(font.font, glyph.id, handles);
 
         let transform = transform
-            .pre_translate([glyph.x, glyph.y].into())
+            .pre_translate(glyph.x, glyph.y)
             .pre_scale(font.scale, font.scale);
 
         for (color, layer) in layers {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -47,7 +47,6 @@ use alloc::borrow::Cow;
 use alloc::string::String as PathBuf;
 use core::{cmp::max, fmt};
 use hashbrown::HashSet;
-use ordered_float::OrderedFloat;
 #[cfg(feature = "std")]
 use std::path::PathBuf;
 
@@ -617,8 +616,8 @@ impl Run {
     }
 
     fn remove_duplicates(&mut self) {
-        let mut rta_set = HashSet::<OrderedFloat<_>>::new();
-        let mut igt_set = HashSet::<OrderedFloat<_>>::new();
+        let mut rta_set = HashSet::new();
+        let mut igt_set = HashSet::new();
 
         for segment in self.segments_mut() {
             let history = segment.segment_history_mut();
@@ -628,10 +627,10 @@ impl Run {
 
             for &(_, time) in history.iter_actual_runs() {
                 if let Some(time) = time.real_time {
-                    rta_set.insert(time.total_milliseconds().into());
+                    rta_set.insert(time);
                 }
                 if let Some(time) = time.game_time {
-                    igt_set.insert(time.total_milliseconds().into());
+                    igt_set.insert(time);
                 }
             }
 
@@ -642,12 +641,12 @@ impl Run {
 
                 let (mut is_none, mut is_unique) = (true, false);
                 if let Some(time) = time.real_time {
-                    is_unique |= rta_set.insert(time.total_milliseconds().into());
+                    is_unique |= rta_set.insert(time);
                     is_none = false;
                 }
 
                 if let Some(time) = time.game_time {
-                    is_unique |= igt_set.insert(time.total_milliseconds().into());
+                    is_unique |= igt_set.insert(time);
                     is_none = false;
                 }
 


### PR DESCRIPTION
Both of these dependencies were barely needed. We only used the 2D transformation matrix from `euclid`. However we don't actually need rotations and also expose this type in the public API, so it's not ideal to directly export a third party type like that as any major version bump in `euclid` would also force us to do a major version bump as well. This introduces a much more lightweight and also faster alternative that we can expose in the API without any problems.

Additionally this removes `ordered-float`. In a lot of cases we can just use the `TimeSpan` type instead of converting them to floats. This actually has been the longest open issue in livesplit-core anyway, so fixing the algorithms to use `TimeSpan` also removes the need for sorting any floats... at least almost. In the few cases where we still want to sort floats we can guarantee that no `NaN` is involved anyway, so we can just do a simple comparison there without having to worry about that. This should also be slightly faster anyway.