### PR TITLE
Remove checks for "normal" when parsing GDI font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 **.rs.bk
-capi/bind_gen/target
+.DS_Store
 capi/bindings
-capi/Cargo.lock
-capi/target
 Cargo.lock
 docs
 target

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -364,6 +364,8 @@ where
         // in its public API.
 
         for token in family.split_whitespace().rev() {
+            // FontWeight and FontStretch both have the variant "normal"
+            // which is the default and can thus be ignored.
             if token.eq_ignore_ascii_case("italic") {
                 style = FontStyle::Italic;
             } else if token.eq_ignore_ascii_case("thin") || token.eq_ignore_ascii_case("hairline") {
@@ -378,8 +380,6 @@ where
                 || token.eq_ignore_ascii_case("demilight")
             {
                 weight = FontWeight::SemiLight;
-            } else if token.eq_ignore_ascii_case("normal") {
-                weight = FontWeight::Normal;
             } else if token.eq_ignore_ascii_case("medium") {
                 weight = FontWeight::Medium;
             } else if token.eq_ignore_ascii_case("semibold")
@@ -406,8 +406,6 @@ where
                 stretch = FontStretch::Condensed;
             } else if token.eq_ignore_ascii_case("semicondensed") {
                 stretch = FontStretch::SemiCondensed;
-            } else if token.eq_ignore_ascii_case("normal") {
-                stretch = FontStretch::Normal;
             } else if token.eq_ignore_ascii_case("semiexpanded") {
                 stretch = FontStretch::SemiExpanded;
             } else if token.eq_ignore_ascii_case("expanded") {


### PR DESCRIPTION
This has the side effect that e.g. the font "Example Normal Thin" would now have a font weight of `Thin` instead of `Normal` (assuming that font name could exist). I also removed some lines from `.gitignore` that don't do anything since `target` and `Cargo.lock` are already ignored.

Fixes #486.