### PR TITLE
Rewrite swift API `bind_gen`

### DIFF
--- a/capi/bind_gen/src/swift/header.rs
+++ b/capi/bind_gen/src/swift/header.rs
@@ -26,15 +26,8 @@ fn get_type(ty: &Type) -> Cow<'_, str> {
         x => x,
     });
     match (ty.is_custom, ty.kind) {
-        (false, TypeKind::RefMut) => name.to_mut().push_str("*"),
-        (false, TypeKind::Ref) => {
-            if name == "char" {
-                name.to_mut().push_str(" const*")
-            } else {
-                name.to_mut().push_str("*")
-            }
-        }
-        (true, TypeKind::Ref) => name = Cow::Borrowed("void*"),
+        (false, TypeKind::Ref) if name == "char" => name.to_mut().push_str(" const*"),
+        (false, TypeKind::Ref | TypeKind::RefMut) => name.to_mut().push('*'),
         (true, _) => name = Cow::Borrowed("void*"),
         _ => (),
     }
@@ -63,7 +56,7 @@ extern "C" {
     )?;
 
     for class in classes.values() {
-        writeln!(writer, "")?;
+        writeln!(writer)?;
 
         for function in class
             .static_fns

--- a/capi/bind_gen/src/swift/module.map
+++ b/capi/bind_gen/src/swift/module.map
@@ -1,9 +1,0 @@
-module LiveSplitCoreNative [extern_c] {
-    header "livesplit_core.h"
-    link "resolv"
-    link "c"
-    link "m"
-    link "System"
-    link "objc"
-    export *
-}

--- a/capi/bind_gen/src/swift/module.modulemap
+++ b/capi/bind_gen/src/swift/module.modulemap
@@ -1,0 +1,8 @@
+module CLiveSplitCore [extern_c] {
+    header "livesplit_core.h"
+    link "livesplit_core"
+    link framework "Carbon"
+    link framework "CoreFoundation"
+    link framework "CoreGraphics"
+    export *
+}


### PR DESCRIPTION
Previously, the generated bindings didn't actually work, there was even one syntax error in the swift code (and a lot of wrong types).
I don't know what the `link` lines in the module map did, I hope that doesn't break anything.

# Changes

- Cleanup of `main.rs`
- Rust-style doc comments (`///`)
- Nullable strings as outputs (#65)
- Fix types (remove bool/int  conversions, fix timer lock functions)
- Folder structure works with swift package manager (you need to set the linker `-L` path in the config)
- Remove some of the `override init`s
- Function `default` needs backticks
- Generate class docs only once
- Replace `Optional.none` with `nil`, seems to behave the same with equality
- Rename `LiveSplitCoreNative` to `CLiceSplitCore`
- Rename `module.map` to `module.modulemap` because the former is deprecated
- Move `init?` `nil`-check