### PR TITLE
Cache digit width for tabular numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ capi/bindings
 Cargo.lock
 docs
 target
+.vs*


### PR DESCRIPTION
Fixes #470.
The max digit width is now calculated when the font is loaded, even if that font is never used for tabular numbers.