### PR TITLE
Update function names from dependency `heck`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -656,6 +656,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  bind_gen:
+    name: Generate bindings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+
+      - name: Generate bindings
+        run: |
+          cd capi/bind_gen
+          cargo run
+          cd ../..
+
   clippy:
     name: Check clippy lints
     runs-on: ubuntu-latest

--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -1,5 +1,5 @@
 use crate::{Class, Function, Type, TypeKind};
-use heck::{CamelCase, MixedCase};
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
@@ -134,7 +134,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         public{} {} {}("#,
             if is_static { " static" } else { "" },
             return_type,
-            function.method.to_camel_case()
+            function.method.to_upper_camel_case()
         )?;
     }
 
@@ -147,7 +147,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{} {}", get_hl_type(typ), name.to_mixed_case())?;
+        write!(
+            writer,
+            "{} {}",
+            get_hl_type(typ),
+            name.to_lower_camel_case()
+        )?;
     }
 
     if is_constructor {
@@ -175,7 +180,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
                 throw new ObjectDisposedException("{name}");
             }}
             "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -208,13 +213,13 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             if name == "this" {
                 "this.ptr".to_string()
             } else if ty_name == "UIntPtr" {
-                format!("(UIntPtr){}", name.to_mixed_case())
+                format!("(UIntPtr){}", name.to_lower_camel_case())
             } else if ty_name == "IntPtr" {
-                format!("(IntPtr){}", name.to_mixed_case())
+                format!("(IntPtr){}", name.to_lower_camel_case())
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -237,7 +242,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
                 writer,
                 r#"
             {}.ptr = IntPtr.Zero;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -1,6 +1,6 @@
 use super::write_class_comments;
 use crate::{Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     fs::File,
@@ -59,7 +59,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
     let return_type = get_hl_type(&function.output);
     let return_type_ll = get_ll_type(&function.output);
     let is_constructor = function.method == "new" && !function.output.is_nullable;
-    let mut method = function.method.to_mixed_case();
+    let mut method = function.method.to_lower_camel_case();
     if method == "clone" {
         method = "copy".into();
     } else if method == "close" {
@@ -123,7 +123,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{} {}", get_hl_type(typ), name.to_mixed_case())?;
+        write!(
+            writer,
+            "{} {}",
+            get_hl_type(typ),
+            name.to_lower_camel_case()
+        )?;
     }
 
     if is_constructor {
@@ -149,7 +154,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             throw new RuntimeException();
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -186,13 +191,13 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             if name == "this" {
                 "this.ptr".to_string()
             } else if hl_ty_name == "boolean" {
-                format!("(byte)({} ? 1 : 0)", name.to_mixed_case())
+                format!("(byte)({} ? 1 : 0)", name.to_lower_camel_case())
             } else if ty_name == "NativeLong" {
-                format!("new NativeLong({})", name.to_mixed_case())
+                format!("new NativeLong({})", name.to_lower_camel_case())
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -221,7 +226,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
                 writer,
                 r#"
         {}.ptr = Pointer.NULL;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -472,7 +477,7 @@ public interface LiveSplitCoreNative extends Library {
                     if name == "this" {
                         String::from("self")
                     } else {
-                        name.to_mixed_case()
+                        name.to_lower_camel_case()
                     }
                 )?;
             }

--- a/capi/bind_gen/src/java/jni.rs
+++ b/capi/bind_gen/src/java/jni.rs
@@ -1,6 +1,6 @@
 use super::write_class_comments;
 use crate::{Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     fs::File,
@@ -56,7 +56,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
     let has_return_type = function.has_return_type();
     let return_type = get_hl_type(&function.output);
     let is_constructor = function.method == "new" && !function.output.is_nullable;
-    let mut method = function.method.to_mixed_case();
+    let mut method = function.method.to_lower_camel_case();
     if method == "clone" {
         method = "copy".into();
     } else if method == "close" {
@@ -120,7 +120,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{} {}", get_hl_type(typ), name.to_mixed_case())?;
+        write!(
+            writer,
+            "{} {}",
+            get_hl_type(typ),
+            name.to_lower_camel_case()
+        )?;
     }
 
     if is_constructor {
@@ -146,7 +151,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             throw new RuntimeException();
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -169,7 +174,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         writer,
         r#"LiveSplitCoreNative.{}_{}("#,
         function.class,
-        function.method.to_mixed_case()
+        function.method.to_lower_camel_case()
     )?;
 
     for (i, (name, typ)) in function.inputs.iter().enumerate() {
@@ -182,9 +187,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             if name == "this" {
                 "this.ptr".to_string()
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -203,7 +208,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
                 writer,
                 r#"
         {}.ptr = 0;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -427,7 +432,7 @@ public class LiveSplitCoreNative {
     public static native {} {}_{}("#,
                 get_ll_type(&function.output),
                 function.class,
-                function.method.to_mixed_case()
+                function.method.to_lower_camel_case()
             )?;
 
             for (i, (name, typ)) in function.inputs.iter().enumerate() {
@@ -441,7 +446,7 @@ public class LiveSplitCoreNative {
                     if name == "this" {
                         String::from("self")
                     } else {
-                        name.to_mixed_case()
+                        name.to_lower_camel_case()
                     }
                 )?;
             }

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -1,5 +1,5 @@
 use crate::{Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     borrow::Cow,
     collections::BTreeMap,
@@ -76,7 +76,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
 extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jni_env, jobject"#,
         return_type,
         class_name,
-        function.method.to_mixed_case()
+        function.method.to_lower_camel_case()
     )?;
 
     for (name, typ) in &function.inputs {

--- a/capi/bind_gen/src/kotlin/jni.rs
+++ b/capi/bind_gen/src/kotlin/jni.rs
@@ -1,5 +1,5 @@
 use crate::{Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     fs::File,
@@ -81,7 +81,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
     let has_return_type = function.has_return_type();
     let return_type = get_hl_type(&function.output);
     let is_constructor = function.method == "new" && !function.output.is_nullable;
-    let mut method = function.method.to_mixed_case();
+    let mut method = function.method.to_lower_camel_case();
     if method == "clone" {
         method = "copy".into();
     } else if method == "close" {
@@ -142,7 +142,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{}: {}", name.to_mixed_case(), get_hl_type(typ))?;
+        write!(
+            writer,
+            "{}: {}",
+            name.to_lower_camel_case(),
+            get_hl_type(typ)
+        )?;
     }
 
     if is_constructor {
@@ -177,7 +182,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             throw RuntimeException()
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -200,7 +205,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         writer,
         r#"LiveSplitCoreNative.{}_{}("#,
         function.class,
-        function.method.to_mixed_case()
+        function.method.to_lower_camel_case()
     )?;
 
     for (i, (name, typ)) in function.inputs.iter().enumerate() {
@@ -213,9 +218,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             if name == "this" {
                 "this.ptr".to_string()
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -232,7 +237,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
                 writer,
                 r#"
         {}.ptr = 0L"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -472,7 +477,7 @@ object LiveSplitCoreNative {
                 r#"
     external fun {}_{}("#,
                 function.class,
-                function.method.to_mixed_case()
+                function.method.to_lower_camel_case()
             )?;
 
             for (i, (name, typ)) in function.inputs.iter().enumerate() {
@@ -485,7 +490,7 @@ object LiveSplitCoreNative {
                     if name == "this" {
                         String::from("self")
                     } else {
-                        name.to_mixed_case()
+                        name.to_lower_camel_case()
                     },
                     get_ll_type(typ)
                 )?;

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -1,5 +1,5 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
@@ -106,7 +106,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     let has_return_type = function.has_return_type();
     let return_type_with_null = get_hl_type_with_null(&function.output);
     let return_type_without_null = get_hl_type_without_null(&function.output);
-    let method = function.method.to_mixed_case();
+    let method = function.method.to_lower_camel_case();
     let is_json = has_return_type && function.output.name == "Json";
 
     if !function.comments.is_empty() || !type_script {
@@ -144,7 +144,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 r#"
      * @param {{{}}} {}"#,
                 get_hl_type_with_null(ty),
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
 
@@ -181,7 +181,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{}", name.to_mixed_case())?;
+        write!(writer, "{}", name.to_lower_camel_case())?;
         if type_script {
             write!(writer, ": {}", get_hl_type_with_null(ty))?;
         }
@@ -210,7 +210,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             throw "{name} is disposed";
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -239,11 +239,11 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             if name == "this" {
                 "this.ptr".to_string()
             } else if typ.name == "Json" {
-                format!("JSON.stringify({})", name.to_mixed_case())
+                format!("JSON.stringify({})", name.to_lower_camel_case())
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -262,7 +262,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"
         {}.ptr = ref.NULL;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }

--- a/capi/bind_gen/src/swift/code.rs
+++ b/capi/bind_gen/src/swift/code.rs
@@ -1,5 +1,5 @@
 use crate::{Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
@@ -121,7 +121,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             r#"
     public{} func {}("#,
             if is_static { " static" } else { "" },
-            function.method.to_mixed_case()
+            function.method.to_lower_camel_case()
         )?;
     }
 
@@ -134,7 +134,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "_ {}: {}", name.to_mixed_case(), get_hl_type(typ))?;
+        write!(
+            writer,
+            "_ {}: {}",
+            name.to_lower_camel_case(),
+            get_hl_type(typ)
+        )?;
     }
 
     if is_constructor {
@@ -173,7 +178,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
                 name = if name == "this" {
                     "self".to_string()
                 } else {
-                    name.to_mixed_case()
+                    name.to_lower_camel_case()
                 }
             )?;
         }
@@ -200,11 +205,11 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             if name == "this" {
                 "self.ptr".to_string()
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else if ty_name == "Bool" {
-                format!("{} ? 1 : 0", name.to_mixed_case())
+                format!("{} ? 1 : 0", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
     }
@@ -228,7 +233,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
                 if name == "this" {
                     "self".to_string()
                 } else {
-                    name.to_mixed_case()
+                    name.to_lower_camel_case()
                 }
             )?;
         }

--- a/capi/bind_gen/src/wasm.rs
+++ b/capi/bind_gen/src/wasm.rs
@@ -1,5 +1,5 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
@@ -79,7 +79,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     let has_return_type = function.has_return_type();
     let return_type_with_null = get_hl_type_with_null(&function.output);
     let return_type_without_null = get_hl_type_without_null(&function.output);
-    let method = function.method.to_mixed_case();
+    let method = function.method.to_lower_camel_case();
     let is_json = has_return_type && function.output.name == "Json";
 
     if !function.comments.is_empty() || !type_script {
@@ -117,7 +117,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 r#"
      * @param {{{}}} {}"#,
                 get_hl_type_with_null(ty),
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
 
@@ -154,7 +154,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{}", name.to_mixed_case())?;
+        write!(writer, "{}", name.to_lower_camel_case())?;
         if type_script {
             write!(writer, ": {}", get_hl_type_with_null(ty))?;
         }
@@ -183,7 +183,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             throw "{name} is disposed";
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -195,14 +195,14 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"const {0}_allocated = allocString({0});
         "#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         } else if typ.name == "Json" {
             write!(
                 writer,
                 r#"const {0}_allocated = allocString(JSON.stringify({0}));
         "#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -232,11 +232,11 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             if name == "this" {
                 "this.ptr".to_string()
             } else if type_name == "string" || typ.name == "Json" {
-                format!("{}_allocated.ptr", name.to_mixed_case())
+                format!("{}_allocated.ptr", name.to_lower_camel_case())
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
         if type_name == "boolean" {
@@ -267,7 +267,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"
         dealloc({}_allocated);"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -278,7 +278,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"
         {}.ptr = 0;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -1,5 +1,5 @@
 use crate::{typescript, Class, Function, Type, TypeKind};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
@@ -79,7 +79,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     let has_return_type = function.has_return_type();
     let return_type_with_null = get_hl_type_with_null(&function.output);
     let return_type_without_null = get_hl_type_without_null(&function.output);
-    let method = function.method.to_mixed_case();
+    let method = function.method.to_lower_camel_case();
     let is_json = has_return_type && function.output.name == "Json";
 
     if function
@@ -128,7 +128,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 r#"
      * @param {{{}}} {}"#,
                 get_hl_type_with_null(ty),
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
 
@@ -165,7 +165,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
         if i != 0 {
             write!(writer, ", ")?;
         }
-        write!(writer, "{}", name.to_mixed_case())?;
+        write!(writer, "{}", name.to_lower_camel_case())?;
         if type_script {
             write!(writer, ": {}", get_hl_type_with_null(ty))?;
         }
@@ -194,7 +194,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             throw "{name} is disposed";
         }}
         "#,
-                name = name.to_mixed_case()
+                name = name.to_lower_camel_case()
             )?;
         }
     }
@@ -206,14 +206,14 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"const {0}_allocated = allocString({0});
         "#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         } else if typ.name == "Json" {
             write!(
                 writer,
                 r#"const {0}_allocated = allocString(JSON.stringify({0}));
         "#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -243,11 +243,11 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             if name == "this" {
                 "this.ptr".to_string()
             } else if type_name == "string" || typ.name == "Json" {
-                format!("{}_allocated.ptr", name.to_mixed_case())
+                format!("{}_allocated.ptr", name.to_lower_camel_case())
             } else if typ.is_custom {
-                format!("{}.ptr", name.to_mixed_case())
+                format!("{}.ptr", name.to_lower_camel_case())
             } else {
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             }
         )?;
         if type_name == "boolean" {
@@ -278,7 +278,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"
         dealloc({}_allocated);"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }
@@ -289,7 +289,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
                 writer,
                 r#"
         {}.ptr = 0;"#,
-                name.to_mixed_case()
+                name.to_lower_camel_case()
             )?;
         }
     }


### PR DESCRIPTION
#488 broke `capi/bind_gen` because `heck` renamed its traits/functions.