### PR TITLE
Make `updates_frequently` more consistent

### DIFF
--- a/src/analysis/pb_chance/mod.rs
+++ b/src/analysis/pb_chance/mod.rs
@@ -88,5 +88,5 @@ pub fn for_timer(timer: &Snapshot<'_>) -> (f64, bool) {
         calculate(segments, method, current_time)
     };
 
-    (chance, is_live)
+    (chance, is_live && timer.current_phase().is_running())
 }

--- a/src/analysis/possible_time_save.rs
+++ b/src/analysis/possible_time_save.rs
@@ -14,56 +14,56 @@ use crate::{analysis, timing::Snapshot, TimeSpan};
 /// current attempt is used if it gets longer than the segment time of the
 /// segment the possible time save is calculated for. So the possible time save
 /// shrinks towards zero as time goes on. The time returned by this function can
-/// never be below zero.
+/// never be below zero. Additionally a boolean is returned that indicates if
+/// the value is currently actively changing as time is being lost.
 pub fn calculate(
     timer: &Snapshot<'_>,
     segment_index: usize,
     comparison: &str,
     live: bool,
-) -> Option<TimeSpan> {
+) -> (Option<TimeSpan>, bool) {
     let segments = timer.run().segments();
     let method = timer.current_timing_method();
     let mut prev_time = TimeSpan::zero();
     let segment = timer.run().segment(segment_index);
-    let mut best_segments = segment.best_segment_time()[method];
 
-    for segment in segments[..segment_index].iter().rev() {
-        if let Some(best_segments) = &mut best_segments {
+    catch! {
+        let mut best_segments = segment.best_segment_time()[method]?;
+
+        for segment in segments[..segment_index].iter().rev() {
             if let Some(split_time) = segment.comparison(comparison)[method] {
                 prev_time = split_time;
                 break;
             } else if let Some(best_segment) = segment.best_segment_time()[method] {
-                *best_segments += best_segment;
+                best_segments += best_segment;
             }
-        } else {
-            break;
         }
-    }
 
-    catch! {
-        let mut time = segment.comparison(comparison)[method]? - best_segments? - prev_time;
+        let mut time = segment.comparison(comparison)[method]? - best_segments - prev_time;
+        let mut updates_frequently = false;
 
-        catch! {
-            if live && timer.current_split_index()? == segment_index {
-                let segment_delta = analysis::live_segment_delta(
-                    timer,
-                    segment_index,
-                    comparison,
-                    method,
-                )?;
+        if live && timer.current_split_index() == Some(segment_index) {
+            if let Some(segment_delta) = analysis::live_segment_delta(
+                timer,
+                segment_index,
+                comparison,
+                method,
+            ) {
                 let segment_delta = TimeSpan::zero() - segment_delta;
                 if segment_delta < time {
                     time = segment_delta;
+                    updates_frequently = timer.current_phase().is_running();
                 }
-            };
-        };
+            }
+        }
 
         if time < TimeSpan::zero() {
-            TimeSpan::zero()
+            (Some(TimeSpan::zero()), false)
         } else {
-            time
+            (Some(time), updates_frequently)
         }
     }
+    .unwrap_or_default()
 }
 
 /// Calculates how much time could be saved on the remainder of the run with the
@@ -73,14 +73,23 @@ pub fn calculate(
 /// actually be saved. This information is always live, so the total possible
 /// time save will shrink towards zero throughout the run and when time is lost
 /// on a segment. The time returned by this function can never be below zero.
-pub fn calculate_total(timer: &Snapshot<'_>, segment_index: usize, comparison: &str) -> TimeSpan {
+/// Additionally a boolean is returned that indicates if the value is currently
+/// actively changing as time is being lost.
+pub fn calculate_total(
+    timer: &Snapshot<'_>,
+    segment_index: usize,
+    comparison: &str,
+) -> (TimeSpan, bool) {
     let mut total = TimeSpan::zero();
+    let mut updates_frequently = false;
 
     for index in segment_index..timer.run().len() {
-        if let Some(time_save) = calculate(timer, index, comparison, true) {
+        let (time_save, changing) = calculate(timer, index, comparison, true);
+        updates_frequently |= changing;
+        if let Some(time_save) = time_save {
             total += time_save;
         }
     }
 
-    total
+    (total, updates_frequently)
 }

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -121,16 +121,14 @@ impl Component {
         let text = self.text(comparison);
         let comparison = comparison::or_current(comparison, timer);
 
-        let time = if self.settings.total_possible_time_save {
-            Some(possible_time_save::calculate_total(
-                timer,
-                segment_index.unwrap_or(0),
-                comparison,
-            ))
+        let (time, updates_frequently) = if self.settings.total_possible_time_save {
+            let (time, updates_frequently) =
+                possible_time_save::calculate_total(timer, segment_index.unwrap_or(0), comparison);
+            (Some(time), updates_frequently)
         } else if current_phase == TimerPhase::Running || current_phase == TimerPhase::Paused {
             possible_time_save::calculate(timer, segment_index.unwrap(), comparison, false)
         } else {
-            None
+            (None, false)
         };
 
         state.background = self.settings.background;
@@ -159,7 +157,7 @@ impl Component {
         state.key_abbreviations.push("Time Save".into());
 
         state.display_two_rows = self.settings.display_two_rows;
-        state.updates_frequently = false;
+        state.updates_frequently = updates_frequently;
     }
 
     /// Calculates the component's state based on the timer provided.

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -141,7 +141,8 @@ impl Component {
                         split_index,
                         comparison,
                         false,
-                    );
+                    )
+                    .0;
                 }
             } else if let Some(prev_split_index) = split_index.checked_sub(1) {
                 time_change =
@@ -152,7 +153,8 @@ impl Component {
                         prev_split_index,
                         comparison,
                         false,
-                    );
+                    )
+                    .0;
                 }
             };
 
@@ -235,7 +237,7 @@ impl Component {
         }
 
         state.display_two_rows = self.settings.display_two_rows;
-        state.updates_frequently = live_segment.is_some();
+        state.updates_frequently = live_segment.is_some() && phase.is_running();
     }
 
     /// Calculates the component's state based on the timer and the layout

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -189,7 +189,7 @@ pub fn update_state(
                     ColumnFormatter::SegmentTime,
                 ),
                 ColumnStartWith::PossibleTimeSave => (
-                    possible_time_save::calculate(timer, segment_index, comparison, false),
+                    possible_time_save::calculate(timer, segment_index, comparison, false).0,
                     SemanticColor::Default,
                     ColumnFormatter::SegmentTime,
                 ),


### PR DESCRIPTION
Fixes #439.

This changes the public API because I changed the return value of `analysis::possible_time_save::{calculate, calculate_total}`.
Additionally, if the timer is paused, no component should say it is updating frequently.