### PR TITLE
Update `parking_lot` and `image`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
 
           # Windows
           - Windows aarch64
-          - Windows i586
+          # FIXME: The `windows` crate doesn't compile on this target.
+          # - Windows i586
           - Windows i686
           - Windows x86_64
           - Windows i686 gnu
@@ -286,12 +287,12 @@ jobs:
             tests: skip
             install_target: true
 
-          - label: Windows i586
-            target: i586-pc-windows-msvc
-            os: windows-latest
-            cross: skip
-            auto_splitting: skip
-            install_target: true
+          # - label: Windows i586
+          #   target: i586-pc-windows-msvc
+          #   os: windows-latest
+          #   cross: skip
+          #   auto_splitting: skip
+          #   install_target: true
 
           - label: Windows i686
             target: i686-pc-windows-msvc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ unicase = "2.6.0"
 # std
 bytemuck = { version = "1.2.0", optional = true }
 byteorder = { version = "1.3.2", optional = true }
-image = { version = "0.23.12", features = [
+image = { version = "0.24.0", features = [
     "png",
 ], default-features = false, optional = true }
 indexmap = { version = "1.2.0", default-features = false, features = [
     "serde-1",
 ], optional = true }
-parking_lot = { version = "0.11.0", default-features = false, optional = true }
+parking_lot = { version = "0.12.0", default-features = false, optional = true }
 quick-xml = { version = "0.22.0", default-features = false, optional = true }
 serde_json = { version = "1.0.8", optional = true }
 utf-8 = { version = "0.7.4", optional = true }
@@ -83,7 +83,7 @@ splits-io-api = { version = "0.2.0", optional = true }
 
 # Auto Splitting
 livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
-crossbeam-channel = { version = "0.5.1", default-features = false, optional = true }
+crossbeam-channel = { version = "0.5.1", default-features = false, features = ["std"], optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
@@ -134,6 +134,7 @@ std = [
 ]
 more-image-formats = [
     "image/bmp",
+    "image/farbfeld",
     "image/hdr",
     "image/ico",
     "image/jpeg",
@@ -150,7 +151,6 @@ software-rendering = ["path-based-text-engine", "tiny-skia"]
 wasm-web = [
     "js-sys",
     "livesplit-hotkey/wasm-web",
-    "parking_lot/wasm-bindgen",
     "std",
     "wasm-bindgen",
     "web-sys",

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -15,7 +15,7 @@ winapi = { version = "0.3.2", features = [
     "processthreadsapi",
     "winuser"
 ], optional = true }
-parking_lot = { version = "0.11.0", optional = true }
+parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = { version = "0.11.1", optional = true }
@@ -24,7 +24,7 @@ promising-future = { version = "0.2.4", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bitflags = { version = "1.2.1", optional = true }
-parking_lot = { version = "0.11.0", optional = true }
+parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.54", optional = true }
@@ -38,4 +38,4 @@ snafu = { version = "0.7.0", default-features = false }
 [features]
 default = ["std"]
 std = ["snafu/std", "serde/std", "parking_lot", "evdev", "mio", "promising-future", "winapi", "bitflags"]
-wasm-web = ["wasm-bindgen", "web-sys", "parking_lot/wasm-bindgen"]
+wasm-web = ["wasm-bindgen", "web-sys"]

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -6,7 +6,7 @@ use core::{
     result::Result as StdResult,
     str::{from_utf8, Utf8Error},
 };
-use image::{codecs::png, ColorType, ImageBuffer, Rgba};
+use image::{codecs::png, ColorType, ImageBuffer, ImageEncoder, Rgba};
 use snafu::{OptionExt, ResultExt};
 use std::io::{self, Read, Seek, SeekFrom};
 
@@ -245,7 +245,7 @@ pub fn parse<R: Read + Seek>(mut source: R) -> Result<Run> {
             {
                 buf2.clear();
                 if png::PngEncoder::new(&mut buf2)
-                    .encode(image.as_ref(), width, height, ColorType::Rgba8)
+                    .write_image(image.as_ref(), width, height, ColorType::Rgba8)
                     .is_ok()
                 {
                     icon = Some(Image::new(&buf2));

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use base64::{self, STANDARD};
 use byteorder::{ReadBytesExt, BE};
-use image::{codecs::png, ColorType, ImageBuffer, Rgba};
+use image::{codecs::png, ColorType, ImageBuffer, ImageEncoder, Rgba};
 use quick_xml::Reader;
 use snafu::OptionExt;
 use std::io::{BufRead, Cursor, Seek, SeekFrom};
@@ -143,7 +143,7 @@ where
 
         tag_buf.clear();
         png::PngEncoder::new(&mut *tag_buf)
-            .encode(image.as_ref(), width, height, ColorType::Rgba8)
+            .write_image(image.as_ref(), width, height, ColorType::Rgba8)
             .map_err(|_| Error::Image)?;
 
         f(tag_buf);

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -1,8 +1,8 @@
 use alloc::borrow::Cow;
 use image::{
-    codecs::{bmp, hdr, ico, jpeg, png, pnm, tiff, webp},
-    guess_format, load_from_memory_with_format, DynamicImage, GenericImageView, ImageDecoder,
-    ImageError, ImageFormat,
+    codecs::{bmp, farbfeld, hdr, ico, jpeg, png, pnm, tga, tiff, webp},
+    guess_format, load_from_memory_with_format, ImageDecoder, ImageEncoder, ImageError,
+    ImageFormat,
 };
 use std::io::Cursor;
 
@@ -14,18 +14,21 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Result<Cow<'_, [u8]>, ImageError> 
         ImageFormat::Png => png::PngDecoder::new(cursor)?.dimensions(),
         ImageFormat::Jpeg => jpeg::JpegDecoder::new(cursor)?.dimensions(),
         ImageFormat::WebP => webp::WebPDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Pnm => pnm::PnmDecoder::new(cursor)?.dimensions(),
         ImageFormat::Tiff => tiff::TiffDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Tga => tga::TgaDecoder::new(cursor)?.dimensions(),
         ImageFormat::Bmp => bmp::BmpDecoder::new(cursor)?.dimensions(),
         ImageFormat::Ico => ico::IcoDecoder::new(cursor)?.dimensions(),
         ImageFormat::Hdr => hdr::HdrAdapter::new(cursor)?.dimensions(),
-        ImageFormat::Pnm => pnm::PnmDecoder::new(cursor)?.dimensions(),
+        ImageFormat::Farbfeld => farbfeld::FarbfeldDecoder::new(cursor)?.dimensions(),
         // FIXME: For GIF we would need to properly shrink the whole animation.
         // The image crate can't properly handle this at this point in time.
         // Some properties are not translated over properly it seems. We could
         // shrink GIFs that are a single frame, but we also can't tell how many
         // frames there are.
-        // TGA doesn't have a Header.
         // DDS isn't a format we really care for.
+        // AVIF uses C bindings, so it's not portable.
+        // The OpenEXR code in the image crate doesn't compile on Big Endian targets.
         // And the image format is non-exhaustive.
         _ => return Ok(data.into()),
     };
@@ -36,21 +39,9 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Result<Cow<'_, [u8]>, ImageError> 
         if is_too_large {
             image = image.thumbnail(max_dim, max_dim);
         }
-        let image_data = match &image {
-            DynamicImage::ImageLuma8(x) => x.as_ref(),
-            DynamicImage::ImageLumaA8(x) => x.as_ref(),
-            DynamicImage::ImageRgb8(x) => x.as_ref(),
-            DynamicImage::ImageRgba8(x) => x.as_ref(),
-            DynamicImage::ImageBgr8(x) => x.as_ref(),
-            DynamicImage::ImageBgra8(x) => x.as_ref(),
-            DynamicImage::ImageLuma16(x) => bytemuck::cast_slice(x.as_ref()),
-            DynamicImage::ImageLumaA16(x) => bytemuck::cast_slice(x.as_ref()),
-            DynamicImage::ImageRgb16(x) => bytemuck::cast_slice(x.as_ref()),
-            DynamicImage::ImageRgba16(x) => bytemuck::cast_slice(x.as_ref()),
-        };
         let mut data = Vec::new();
-        png::PngEncoder::new(&mut data).encode(
-            image_data,
+        png::PngEncoder::new(&mut data).write_image(
+            image.as_bytes(),
             image.width(),
             image.height(),
             image.color(),

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -239,10 +239,16 @@ fn check(state: &LayoutState, expected_hash_data: &str, name: &str) {
 }
 
 #[track_caller]
-fn check_dims(state: &LayoutState, dims: [u32; 2], expected_hash_data: &str, name: &str) {
+fn check_dims(
+    state: &LayoutState,
+    dims @ [width, height]: [u32; 2],
+    expected_hash_data: &str,
+    name: &str,
+) {
     let mut renderer = Renderer::new();
     renderer.render(state, dims);
-    let image = renderer.into_image();
+    let image =
+        img_hash::image::RgbaImage::from_raw(width, height, renderer.into_image_data()).unwrap();
 
     let hasher = HasherConfig::with_bytes_type::<[u8; 8]>().to_hasher();
 
@@ -270,7 +276,7 @@ fn check_dims(state: &LayoutState, dims: [u32; 2], expected_hash_data: &str, nam
             let mut expected_image = expected_image.to_rgba8();
             for (x, y, Rgba([r, g, b, a])) in expected_image.enumerate_pixels_mut() {
                 if x < image.width() && y < image.height() {
-                    let Rgba([r2, g2, b2, a2]) = image.get_pixel(x, y);
+                    let img_hash::image::Rgba([r2, g2, b2, a2]) = image.get_pixel(x, y);
                     *r = (*r as i16).wrapping_sub(*r2 as i16).abs() as u8;
                     *g = (*g as i16).wrapping_sub(*g2 as i16).abs() as u8;
                     *b = (*b as i16).wrapping_sub(*b2 as i16).abs() as u8;


### PR DESCRIPTION
Updating `image` was not super trivial as it introduced a few new formats and changed a few things. Also `img_hash` is once again not compatible with it. We can work around this though by making use of the reexported `image` crate in `img_hash`.