### PR TITLE
Support Software Rendering on `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,17 @@ parking_lot = { version = "0.12.0", default-features = false, optional = true }
 # Currently doesn't require any additional dependencies.
 
 # Path-based Text Engine
-rustybuzz = { version = "0.5.0", optional = true }
-ttf-parser = { version = "0.15.0", optional = true }
+rustybuzz = { git = "https://github.com/RazrFalcon/rustybuzz", default-features = false, features = [
+    "libm",
+], optional = true }
+ttf-parser = { version = "0.15.0", default-features = false, optional = true }
 
 # Font Loading
 font-kit = { version = "0.11.0", optional = true }
 
 # Software Rendering
 tiny-skia = { version = "0.6.0", default-features = false, features = [
-    "std",
+    "libm",
     "simd",
 ], optional = true }
 
@@ -117,34 +119,37 @@ std = [
     "livesplit-hotkey/std",
     "memchr/std",
     "parking_lot",
+    "rustybuzz?/std",
     "serde/std",
     "serde_json/std",
     "simdutf8/std",
     "snafu/std",
     "time/formatting",
     "time/local-offset",
+    "tiny-skia?/std",
+    "ttf-parser?/std",
     "winapi",
 ]
 more-image-formats = [
-    "image/bmp",
-    "image/farbfeld",
-    "image/hdr",
-    "image/ico",
-    "image/jpeg",
-    "image/pnm",
-    "image/tga",
-    "image/tiff",
-    "image/webp",
+    "image?/bmp",
+    "image?/farbfeld",
+    "image?/hdr",
+    "image?/ico",
+    "image?/jpeg",
+    "image?/pnm",
+    "image?/tga",
+    "image?/tiff",
+    "image?/webp",
 ]
 image-shrinking = ["std", "more-image-formats"]
 rendering = ["more-image-formats"]
-path-based-text-engine = ["std", "rendering", "rustybuzz", "ttf-parser"]
+path-based-text-engine = ["rendering", "rustybuzz", "ttf-parser"]
 font-loading = ["std", "path-based-text-engine", "font-kit"]
 software-rendering = ["path-based-text-engine", "tiny-skia"]
 wasm-web = [
+    "std",
     "js-sys",
     "livesplit-hotkey/wasm-web",
-    "std",
     "wasm-bindgen",
     "web-sys",
 ]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -17,6 +17,11 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(not(target_has_atomic = "ptr"))]
+pub use alloc::rc::Rc as Arc;
+#[cfg(target_has_atomic = "ptr")]
+pub use alloc::sync::Arc;
+
 pub mod math;
 
 #[cfg(feature = "std")]

--- a/src/platform/no_std/mod.rs
+++ b/src/platform/no_std/mod.rs
@@ -1,2 +1,18 @@
 mod time;
 pub use self::time::*;
+
+pub struct RwLock<T>(core::cell::RefCell<T>);
+
+impl<T> RwLock<T> {
+    pub fn new(value: T) -> Self {
+        Self(core::cell::RefCell::new(value))
+    }
+
+    pub fn write(&self) -> core::cell::RefMut<'_, T> {
+        self.0.borrow_mut()
+    }
+
+    pub fn read(&self) -> core::cell::Ref<'_, T> {
+        self.0.borrow()
+    }
+}

--- a/src/platform/normal/mod.rs
+++ b/src/platform/normal/mod.rs
@@ -1,3 +1,4 @@
+pub use parking_lot::RwLock;
 use time::UtcOffset;
 pub use time::{Duration, OffsetDateTime as DateTime};
 

--- a/src/platform/wasm/unknown/mod.rs
+++ b/src/platform/wasm/unknown/mod.rs
@@ -1,3 +1,4 @@
 mod time;
 
 pub use self::time::*;
+pub use parking_lot::RwLock;

--- a/src/platform/wasm/web/mod.rs
+++ b/src/platform/wasm/web/mod.rs
@@ -1,2 +1,3 @@
 mod time;
 pub use self::time::*;
+pub use parking_lot::RwLock;

--- a/src/rendering/path_based_text_engine/color_font/cpal.rs
+++ b/src/rendering/path_based_text_engine/color_font/cpal.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 use crate::util::byte_parsing::{
     big_endian::{U16, U32 as O32},

--- a/src/rendering/path_based_text_engine/mod.rs
+++ b/src/rendering/path_based_text_engine/mod.rs
@@ -3,7 +3,7 @@
 //! underlying renderer doesn't by itself need to be able to render text, as all
 //! the text gets turned into paths.
 
-use std::sync::Arc;
+use crate::platform::{prelude::*, Arc, RwLock};
 
 #[cfg(feature = "font-loading")]
 use font_kit::{
@@ -13,7 +13,6 @@ use font_kit::{
     source::SystemSource,
 };
 use hashbrown::HashMap;
-use parking_lot::{const_rwlock, RwLock};
 use rustybuzz::{Face, Feature, Tag, UnicodeBuffer, Variation};
 use ttf_parser::{GlyphId, OutlineBuilder};
 
@@ -65,6 +64,9 @@ impl TextEngine {
                 return font;
             }
         }
+        #[cfg(not(feature = "font-loading"))]
+        let _ = font;
+
         let (font_data, style, weight, stretch) = match kind {
             FontKind::Timer => (
                 TIMER_FONT,
@@ -97,7 +99,7 @@ impl TextEngine {
         font: &mut Font<PB::Path>,
         max_width: Option<f32>,
     ) -> Label<PB::Path> {
-        let mut label = Arc::new(const_rwlock(LockedLabel {
+        let mut label = Arc::new(RwLock::new(LockedLabel {
             width: 0.0,
             width_without_max_width: 0.0,
             scale: 0.0,

--- a/src/rendering/resource/shared_ownership.rs
+++ b/src/rendering/resource/shared_ownership.rs
@@ -1,4 +1,4 @@
-use alloc::{rc::Rc, sync::Arc};
+use alloc::rc::Rc;
 
 /// Describes that ownership of a value can be cheaply shared. This is similar
 /// to the [`Clone`] trait, but is expected to only be implemented if sharing is
@@ -14,7 +14,8 @@ impl<T: ?Sized> SharedOwnership for Rc<T> {
     }
 }
 
-impl<T: ?Sized> SharedOwnership for Arc<T> {
+#[cfg(target_has_atomic = "ptr")]
+impl<T: ?Sized> SharedOwnership for alloc::sync::Arc<T> {
     fn share(&self) -> Self {
         self.clone()
     }

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -1,7 +1,9 @@
 //! Provides a software renderer that can be used without a GPU. The renderer is
 //! surprisingly fast and can be considered the default rendering backend.
 
-use std::{mem, ops::Deref, rc::Rc};
+use crate::platform::prelude::*;
+use alloc::rc::Rc;
+use core::{mem, ops::Deref};
 
 use super::{
     entity::Entity,
@@ -10,12 +12,14 @@ use super::{
     FillShader, FontKind, Scene, SceneManager, SharedOwnership, Transform,
 };
 use crate::{layout::LayoutState, settings};
+#[cfg(feature = "image")]
 use image::ImageBuffer;
 use tiny_skia::{
     BlendMode, Color, FillRule, FilterQuality, GradientStop, LinearGradient, Paint, Path,
     PathBuilder, Pattern, Pixmap, PixmapMut, Point, Rect, Shader, SpreadMode, Stroke,
 };
 
+#[cfg(feature = "image")]
 pub use image::{self, RgbaImage};
 
 struct SkiaBuilder(PathBuilder);
@@ -321,6 +325,7 @@ impl Renderer {
     }
 
     /// Accesses the image.
+    #[cfg(feature = "image")]
     pub fn image(&self) -> ImageBuffer<image::Rgba<u8>, &[u8]> {
         ImageBuffer::from_raw(
             self.frame_buffer.width(),
@@ -331,6 +336,7 @@ impl Renderer {
     }
 
     /// Turns the whole renderer into the underlying image.
+    #[cfg(feature = "image")]
     pub fn into_image(self) -> RgbaImage {
         RgbaImage::from_raw(
             self.frame_buffer.width(),

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -113,7 +113,7 @@ impl FromStr for TimeSpan {
 
 impl Default for TimeSpan {
     fn default() -> Self {
-        TimeSpan(Duration::nanoseconds(0))
+        TimeSpan(Duration::ZERO)
     }
 }
 


### PR DESCRIPTION
With the introduction of weak dependency features in cargo, we are able to make the software rendering available on `no_std`. Previously we weren't able to properly delegate the std feature to all the rendering crates without also having to compile those.

Fixes #223