### PR TITLE
Use published version of `rustybuzz` again

### DIFF
--- a/.github/workflows/build_static.sh
+++ b/.github/workflows/build_static.sh
@@ -11,7 +11,7 @@ main() {
     fi
 
     if [ "$NO_STD" = "true" ]; then
-        cargo build --target $TARGET --no-default-features $FEATURES
+        cargo build --target $TARGET --no-default-features --features software-rendering $FEATURES
         return
     fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ parking_lot = { version = "0.12.0", default-features = false, optional = true }
 # Currently doesn't require any additional dependencies.
 
 # Path-based Text Engine
-rustybuzz = { git = "https://github.com/RazrFalcon/rustybuzz", default-features = false, features = [
+rustybuzz = { version = "0.5.1", default-features = false, features = [
     "libm",
 ], optional = true }
 ttf-parser = { version = "0.15.0", default-features = false, optional = true }


### PR DESCRIPTION
We temporarily used the git version of `rustybuzz`. They now published a `0.5.1`.