### PR TITLE
Borrow as much as possible in the parsers

### DIFF
--- a/capi/src/parse_run_result.rs
+++ b/capi/src/parse_run_result.rs
@@ -7,7 +7,7 @@ use livesplit_core::run::parser::{composite::ParsedRun, TimerKind};
 use std::{io::Write, os::raw::c_char};
 
 /// type
-pub type ParseRunResult = Option<ParsedRun>;
+pub type ParseRunResult = Option<ParsedRun<'static>>;
 /// type
 pub type OwnedParseRunResult = Box<ParseRunResult>;
 

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -83,7 +83,8 @@ pub unsafe extern "C" fn Run_parse_file_handle(
         Box::new(
             file.read_to_end(buf)
                 .ok()
-                .and_then(|_| parser::composite::parse(buf, path, load_files).ok()),
+                .and_then(|_| parser::composite::parse(buf, path, load_files).ok())
+                .map(|p| p.into_owned()),
         )
     })
 }

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -37,7 +37,7 @@ mod timer;
 mod title;
 mod total_playtime;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "std"))]
 mod font_resolving;
 
 // One single row component is:
@@ -394,7 +394,7 @@ where
         // receive the byte representation of individual tables we query for, so
         // we can get the family name from the `name` table.
 
-        #[cfg(windows)]
+        #[cfg(all(windows, feature = "std"))]
         let family = if let Some(info) =
             font_resolving::FontInfo::from_gdi(original_family_name, bold_flag, italic_flag)
         {
@@ -421,7 +421,7 @@ where
             family.to_owned()
         };
 
-        #[cfg(not(windows))]
+        #[cfg(not(all(windows, feature = "std")))]
         let family = family.to_owned();
 
         // The font might not exist on the user's system, so we still prefer to

--- a/src/networking/splits_io.rs
+++ b/src/networking/splits_io.rs
@@ -38,9 +38,10 @@ pub enum DownloadError {
 pub async fn download_run(
     client: &Client,
     id: &str,
-) -> Result<composite::ParsedRun, DownloadError> {
+) -> Result<composite::ParsedRun<'static>, DownloadError> {
     let bytes = api::run::download(client, id).await.context(Download)?;
-    composite::parse(&bytes, None, false).context(Parse)
+    let run = composite::parse(&bytes, None, false).context(Parse)?;
+    Ok(run.into_owned())
 }
 
 /// Asynchronously uploads a run to Splits.io. An object representing the ID of

--- a/src/run/parser/flitter/mod.rs
+++ b/src/run/parser/flitter/mod.rs
@@ -12,11 +12,12 @@ pub use self::s_expressions::Error;
 pub type Result<T> = StdResult<T, Error>;
 
 #[derive(Deserialize)]
-struct Splits {
-    title: String,
-    category: String,
+struct Splits<'a> {
+    title: &'a str,
+    category: &'a str,
     attempts: u32,
-    split_names: Vec<String>,
+    #[serde(borrow)]
+    split_names: Vec<&'a str>,
     golds: Option<Vec<Gold>>,
     personal_best: Option<Comparison>,
     world_record: Option<Comparison>,
@@ -39,7 +40,7 @@ struct Split {
 
 /// Attempts to parse a Flitter splits file.
 pub fn parse(source: &str) -> Result<Run> {
-    let splits: Splits = self::s_expressions::from_str(source)?;
+    let splits: Splits<'_> = self::s_expressions::from_str(source)?;
 
     let mut run = Run::new();
 

--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -135,6 +135,9 @@ pub fn parse(source: &[u8]) -> Result<Run> {
 
     // Seek to the first byte of the first segment
     cursor = cursor.get(0x8F..).context(ReadSegment)?;
+
+    run.segments_mut().reserve(segment_count as usize);
+
     for _ in 0..segment_count {
         #[cfg(feature = "std")]
         let mut icon = None;

--- a/src/run/parser/source_live_timer.rs
+++ b/src/run/parser/source_live_timer.rs
@@ -1,6 +1,7 @@
 //! Provides the parser for the SourceLiveTimer splits files.
 
 use crate::{platform::prelude::*, GameTime, Run, Segment, TimeSpan};
+use alloc::borrow::Cow;
 use core::result::Result as StdResult;
 use serde::Deserialize;
 use serde_json::Error as JsonError;
@@ -23,23 +24,27 @@ pub type Result<T> = StdResult<T, Error>;
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
-struct Splits {
-    Category: String,
-    RunName: Option<String>,
-    Splits: Option<Vec<Split>>,
+struct Splits<'a> {
+    #[serde(borrow)]
+    Category: Cow<'a, str>,
+    #[serde(borrow)]
+    RunName: Option<Cow<'a, str>>,
+    Splits: Option<Vec<Split<'a>>>,
 }
 
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
-struct Split {
-    Map: String,
-    Name: Option<String>,
+struct Split<'a> {
+    #[serde(borrow)]
+    Map: Cow<'a, str>,
+    #[serde(borrow)]
+    Name: Option<Cow<'a, str>>,
     Ticks: Option<u64>,
     BestSegment: Option<u64>,
 }
 
-fn time_span_from_ticks(category_name: &str, ticks: u64) -> TimeSpan {
-    let seconds = if category_name.starts_with("Portal 2") {
+fn time_span_from_ticks(is_portal2: bool, ticks: u64) -> TimeSpan {
+    let seconds = if is_portal2 {
         ticks as f64 / 30.0
     } else {
         // Game is either Portal or Half Life 2
@@ -51,7 +56,8 @@ fn time_span_from_ticks(category_name: &str, ticks: u64) -> TimeSpan {
 
 /// Attempts to parse a SourceLiveTimer splits file.
 pub fn parse(source: &str) -> Result<Run> {
-    let splits: Splits = serde_json::from_str(source).map_err(|source| Error::Json { source })?;
+    let splits: Splits<'_> =
+        serde_json::from_str(source).map_err(|source| Error::Json { source })?;
 
     let mut run = Run::new();
 
@@ -74,27 +80,23 @@ pub fn parse(source: &str) -> Result<Run> {
     }
 
     if let Some(segments) = splits.Splits {
-        for split in segments {
-            let name = if let Some(name) = split.Name {
-                name.to_owned()
-            } else {
-                split.Map.to_owned()
-            };
+        let is_portal2 = run.category_name().starts_with("Portal 2");
 
-            let mut segment = Segment::new(name);
+        run.segments_mut().extend(segments.into_iter().map(|split| {
+            let mut segment = Segment::new(split.Name.unwrap_or(split.Map));
 
             if let Some(ticks) = split.Ticks {
-                let pb_split_time = Some(time_span_from_ticks(run.category_name(), ticks));
+                let pb_split_time = Some(time_span_from_ticks(is_portal2, ticks));
                 segment.set_personal_best_split_time(GameTime(pb_split_time).into());
             }
 
             if let Some(best) = split.BestSegment {
-                let best_segment_time = Some(time_span_from_ticks(run.category_name(), best));
+                let best_segment_time = Some(time_span_from_ticks(is_portal2, best));
                 segment.set_best_segment_time(GameTime(best_segment_time).into());
             }
 
-            run.push_segment(segment);
-        }
+            segment
+        }));
     }
 
     Ok(run)

--- a/src/run/parser/splits_io.rs
+++ b/src/run/parser/splits_io.rs
@@ -1,6 +1,9 @@
 //! Provides the parser for generic Splits I/O splits files.
 
-use crate::{platform::prelude::*, Run, Segment as LiveSplitSegment, Time, TimeSpan};
+use crate::{
+    platform::prelude::*, util::PopulateString, Run, Segment as LiveSplitSegment, Time, TimeSpan,
+};
+use alloc::borrow::Cow;
 use core::result::Result as StdResult;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
@@ -61,88 +64,106 @@ struct Attempts {
     total: Option<u32>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-struct CategoryLinks {
+struct CategoryLinks<'a> {
     /// Speedrun.com ID specifies the category's Speedrun.com ID.
     #[serde(rename = "speedruncomID")]
-    speedruncom_id: Option<String>,
+    #[serde(borrow)]
+    speedruncom_id: Option<Cow<'a, str>>,
     /// Splits I/O ID specifies the category's Splits I/O ID.
     #[serde(rename = "splitsioID")]
-    splitsio_id: Option<String>,
+    #[serde(borrow)]
+    splitsio_id: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Category {
+struct Category<'a> {
     /// Links specifies the category's identity in other services.
-    links: Option<CategoryLinks>,
+    links: Option<CategoryLinks<'a>>,
     /// Longname is a human-readable category name, intended for display to users.
-    longname: String,
+    #[serde(borrow)]
+    longname: Cow<'a, str>,
     /// Shortname is a machine-readable category name, intended for use in APIs, databases, URLs,
     /// and filenames.
-    shortname: Option<String>,
+    #[serde(borrow)]
+    shortname: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-struct GameLinks {
+struct GameLinks<'a> {
     /// Speedrun.com ID specifies the game's Speedrun.com ID.
     #[serde(rename = "speedruncomID")]
-    speedruncom_id: Option<String>,
+    #[serde(borrow)]
+    speedruncom_id: Option<Cow<'a, str>>,
     /// Splits I/O ID specifies the game's Splits I/O ID.
     #[serde(rename = "splitsioID")]
-    splitsio_id: Option<String>,
+    #[serde(borrow)]
+    splitsio_id: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Game {
+struct Game<'a> {
     /// Links specifies the game's identity in other services.
-    links: Option<GameLinks>,
+    links: Option<GameLinks<'a>>,
     /// Longname is a human-readable game name, intended for display to users.
-    longname: String,
+    #[serde(borrow)]
+    longname: Cow<'a, str>,
     /// Shortname is a machine-readable game name, intended for use in APIs, databases, URLs, and
     /// filenames.
-    shortname: Option<String>,
+    #[serde(borrow)]
+    shortname: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-struct RunLinks {
+struct RunLinks<'a> {
     /// Speedrun.com ID is the run's ID on Speedrun.com. This can be used to communicate with the
     /// Speedrun.com API.
     #[serde(rename = "speedruncomID")]
-    speedruncom_id: Option<String>,
+    #[serde(borrow)]
+    speedruncom_id: Option<Cow<'a, str>>,
     /// Splits I/O ID is the run's ID on Splits I/O. This can be used to communicate with the
     /// Splits I/O API.
     #[serde(rename = "splitsioID")]
-    splitsio_id: Option<String>,
+    #[serde(borrow)]
+    splitsio_id: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Pause {
+struct Pause<'a> {
     /// Ended At is the date and time at which the pause was ended, specified in RFC 3339 format.
     #[serde(rename = "endedAt")]
-    ended_at: Option<String>,
+    #[serde(borrow)]
+    ended_at: Option<Cow<'a, str>>,
     /// Started At is the date and time at which the pause was started, specified in RFC 3339
     /// format.
     #[serde(rename = "startedAt")]
-    started_at: String,
+    #[serde(borrow)]
+    started_at: Cow<'a, str>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-struct RunnerLinks {
+struct RunnerLinks<'a> {
     /// Speedrun.com ID specifies the runner's Speedrun.com ID.
     #[serde(rename = "speedruncomID")]
-    speedruncom_id: Option<String>,
+    #[serde(borrow)]
+    speedruncom_id: Option<Cow<'a, str>>,
     /// Splits I/O ID specifies the runner's Splits I/O ID.
     #[serde(rename = "splitsioID")]
-    splitsio_id: Option<String>,
+    #[serde(borrow)]
+    splitsio_id: Option<Cow<'a, str>>,
     /// Twitch ID specifies the runner's Twitch ID.
     #[serde(rename = "twitchID")]
-    twitch_id: Option<String>,
+    #[serde(borrow)]
+    twitch_id: Option<Cow<'a, str>>,
     /// Twitter ID specifies the runner's Twitter ID.
     #[serde(rename = "twitterID")]
-    twitter_id: Option<String>,
+    #[serde(borrow)]
+    twitter_id: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Runner {
+struct Runner<'a> {
     /// Links specifies the runner's identity in other services.
-    links: Option<RunnerLinks>,
+    links: Option<RunnerLinks<'a>>,
     /// Longname is a human-readable runner name, intended for display to users.
-    longname: Option<String>,
+    #[serde(borrow)]
+    longname: Option<Cow<'a, str>>,
     /// Shortname is a machine-readable runner name, intended for use in APIs, databases, URLs, and
     /// filenames.
-    shortname: String,
+    #[serde(borrow)]
+    shortname: Cow<'a, str>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 struct SegmentHistoryElement {
@@ -164,7 +185,7 @@ struct SegmentHistoryElement {
     is_skipped: Option<bool>,
 }
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
-struct Segment {
+struct Segment<'a> {
     #[serde(rename = "bestDuration")]
     best_duration: Option<Duration>,
     #[serde(rename = "endedAt")]
@@ -180,59 +201,69 @@ struct Segment {
     #[serde(rename = "isSkipped")]
     is_skipped: Option<bool>,
     /// Name is the runner-provided name of this segment
-    name: Option<String>,
+    #[serde(borrow)]
+    name: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Timer {
+struct Timer<'a> {
     /// Longname is a human-readable timer name, intended for display to users.
-    longname: String,
+    #[serde(borrow)]
+    longname: Cow<'a, str>,
     /// Shortname is a machine-readable timer name, intended for use in APIs, databases, URLs, and
     /// filenames.
-    shortname: String,
+    #[serde(borrow)]
+    shortname: Cow<'a, str>,
     /// Version is the version of the timer used to record this run. Semantic Versioning is
     /// strongly recommended but not enforced.
-    version: String,
+    #[serde(borrow)]
+    version: Cow<'a, str>,
     /// Website is the URL for the timer's website.
-    website: Option<String>,
+    #[serde(borrow)]
+    website: Option<Cow<'a, str>>,
 }
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-struct Splits {
+struct Splits<'a> {
     /// Schema Version specifies which version of the Splits I/O JSON Schema is being used. This
     /// schema specifies only v1.0.0.
     #[serde(rename = "_schemaVersion")]
-    _schemaversion: String,
+    #[serde(borrow)]
+    _schemaversion: Cow<'a, str>,
     /// Attempts contains historical information about previous runs by this runner in this
     /// category.
     attempts: Option<Attempts>,
     /// Category specifies information about the category being run.
-    category: Option<Category>,
+    category: Option<Category<'a>>,
     /// Ended At is the date and time at which the run was ended, specified in RFC 3339 format.
     #[serde(rename = "endedAt")]
-    ended_at: Option<String>,
+    #[serde(borrow)]
+    ended_at: Option<Cow<'a, str>>,
     /// Game specifies information about the game being run.
-    game: Option<Game>,
+    game: Option<Game<'a>>,
     /// Image URL is the location of an image associated with this run. Often this is a screenshot
     /// of the timer at run completion, but can be anything the runner wants displayed alongside
     /// the run.
     #[serde(rename = "imageURL")]
-    image_url: Option<String>,
+    #[serde(borrow)]
+    image_url: Option<Cow<'a, str>>,
     /// Links specifies the run's identity in other services.
-    links: Option<RunLinks>,
+    links: Option<RunLinks<'a>>,
     /// Pauses holds runner-caused pauses that took place during the run.
-    pauses: Option<Vec<Pause>>,
+    pauses: Option<Vec<Pause<'a>>>,
     /// Runners is an array of people who participated in this run. Some games and categories call
     /// for cooperative play, but otherwise this will usually be just one person.
-    runners: Option<Vec<Runner>>,
+    runners: Option<Vec<Runner<'a>>>,
     /// Segments is an array of all segments for this run.
-    segments: Option<Vec<Segment>>,
+    segments: Option<Vec<Segment<'a>>>,
     /// Started At is the date and time at which the run was started, specified in RFC 3339 format.
     #[serde(rename = "startedAt")]
-    started_at: Option<String>,
+    #[serde(borrow)]
+    started_at: Option<Cow<'a, str>>,
     /// Timer holds information about the timer used to record the run.
-    timer: Timer,
+    timer: Timer<'a>,
     /// Video URL is the location of a VOD of the run.
     #[serde(rename = "videoURL")]
-    video_url: Option<String>,
+    #[serde(borrow)]
+    video_url: Option<Cow<'a, str>>,
 }
 
 impl From<Option<Duration>> for Time {
@@ -274,8 +305,9 @@ impl From<RunTime> for Time {
 }
 
 /// Attempts to parse a generic Splits I/O splits file.
-pub fn parse(source: &str) -> Result<(Run, String)> {
-    let splits: Splits = serde_json::from_str(source).map_err(|source| Error::Json { source })?;
+pub fn parse(source: &str) -> Result<(Run, Cow<'_, str>)> {
+    let splits: Splits<'_> =
+        serde_json::from_str(source).map_err(|source| Error::Json { source })?;
 
     let mut run = Run::new();
 
@@ -339,28 +371,30 @@ pub fn parse(source: &str) -> Result<(Run, String)> {
         }
     }
 
-    for split in splits.segments.into_iter().flatten() {
-        let mut segment = LiveSplitSegment::new(split.name.unwrap_or_default());
-        segment.set_personal_best_split_time(split.ended_at.into());
-        segment.set_best_segment_time(split.best_duration.into());
-        if let Some(mut history) = split.histories {
-            let segment_history = segment.segment_history_mut();
-            history.sort_unstable_by_key(|x| x.attempt_number);
-            for element in history {
-                segment_history.insert(element.attempt_number as i32, element.ended_at.into());
+    if let Some(segments) = splits.segments {
+        run.segments_mut().extend(segments.into_iter().map(|split| {
+            let mut segment = LiveSplitSegment::new(split.name.unwrap_or_default());
+            segment.set_personal_best_split_time(split.ended_at.into());
+            segment.set_best_segment_time(split.best_duration.into());
+            if let Some(mut history) = split.histories {
+                let segment_history = segment.segment_history_mut();
+                history.sort_unstable_by_key(|x| x.attempt_number);
+                for element in history {
+                    segment_history.insert(element.attempt_number as i32, element.ended_at.into());
+                }
             }
-        }
-        run.push_segment(segment);
+            segment
+        }));
     }
 
     if let Some(links) = splits.links {
         if let Some(link) = links.speedruncom_id {
-            run.metadata_mut().run_id = link;
+            link.populate(&mut run.metadata_mut().run_id);
         }
     }
 
     let timer = if splits.timer.longname.is_empty() {
-        String::from("Generic Timer")
+        "Generic Timer".into()
     } else {
         splits.timer.longname
     };

--- a/src/run/parser/splitterz.rs
+++ b/src/run/parser/splitterz.rs
@@ -74,48 +74,47 @@ pub fn parse(source: &str, #[allow(unused)] load_icons: bool) -> Result<Run> {
     );
 
     for line in &mut lines {
-        if !line.is_empty() {
-            let mut splits = line.split(',');
+        if line.is_empty() {
+            break;
+        }
 
-            let mut segment =
-                Segment::new(unescape(splits.next().ok_or(Error::ExpectedSegmentName)?));
+        let mut splits = line.split(',');
 
-            let time: TimeSpan = splits
-                .next()
-                .ok_or(Error::ExpectedSplitTime)?
-                .parse()
-                .context(ParseSplitTime)?;
-            if time != TimeSpan::zero() {
-                segment.set_personal_best_split_time(RealTime(Some(time)).into());
-            }
+        let mut segment = Segment::new(unescape(splits.next().ok_or(Error::ExpectedSegmentName)?));
 
-            let time: TimeSpan = splits
-                .next()
-                .ok_or(Error::ExpectedBestSegment)?
-                .parse()
-                .context(ParseBestSegment)?;
-            if time != TimeSpan::zero() {
-                segment.set_best_segment_time(RealTime(Some(time)).into());
-            }
+        let time: TimeSpan = splits
+            .next()
+            .ok_or(Error::ExpectedSplitTime)?
+            .parse()
+            .context(ParseSplitTime)?;
+        if time != TimeSpan::zero() {
+            segment.set_personal_best_split_time(RealTime(Some(time)).into());
+        }
 
-            #[cfg(feature = "std")]
-            if load_icons {
-                if let Some(icon_path) = splits.next() {
-                    if !icon_path.is_empty() {
-                        if let Ok(image) = crate::settings::Image::from_file(
-                            unescape(icon_path).as_ref(),
-                            &mut icon_buf,
-                        ) {
-                            segment.set_icon(image);
-                        }
+        let time: TimeSpan = splits
+            .next()
+            .ok_or(Error::ExpectedBestSegment)?
+            .parse()
+            .context(ParseBestSegment)?;
+        if time != TimeSpan::zero() {
+            segment.set_best_segment_time(RealTime(Some(time)).into());
+        }
+
+        #[cfg(feature = "std")]
+        if load_icons {
+            if let Some(icon_path) = splits.next() {
+                if !icon_path.is_empty() {
+                    if let Ok(image) = crate::settings::Image::from_file(
+                        unescape(icon_path).as_ref(),
+                        &mut icon_buf,
+                    ) {
+                        segment.set_icon(image);
                     }
                 }
             }
-
-            run.push_segment(segment);
-        } else {
-            break;
         }
+
+        run.push_segment(segment);
     }
 
     for line in lines {

--- a/src/run/parser/timer_kind.rs
+++ b/src/run/parser/timer_kind.rs
@@ -1,9 +1,10 @@
-use crate::platform::prelude::*;
+use alloc::borrow::Cow;
+
 use core::fmt;
 
 /// Describes the different Timers available that store splits files.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub enum TimerKind {
+pub enum TimerKind<'a> {
     /// LiveSplit
     LiveSplit,
     /// WSplit
@@ -34,10 +35,33 @@ pub enum TimerKind {
     Splitterino,
     /// A Generic Timer. The name of the timer is associated with the variant.
     /// "Generic Timer" is used if there is no known name.
-    Generic(String),
+    Generic(Cow<'a, str>),
 }
 
-impl fmt::Display for TimerKind {
+impl TimerKind<'_> {
+    /// Returns an owned version of the timer kind.
+    pub fn into_owned(self) -> TimerKind<'static> {
+        match self {
+            TimerKind::LiveSplit => TimerKind::LiveSplit,
+            TimerKind::WSplit => TimerKind::WSplit,
+            TimerKind::SplitterZ => TimerKind::SplitterZ,
+            TimerKind::ShitSplit => TimerKind::ShitSplit,
+            TimerKind::Splitty => TimerKind::Splitty,
+            TimerKind::TimeSplitTracker => TimerKind::TimeSplitTracker,
+            TimerKind::Portal2LiveTimer => TimerKind::Portal2LiveTimer,
+            TimerKind::FaceSplit => TimerKind::FaceSplit,
+            TimerKind::Flitter => TimerKind::Flitter,
+            TimerKind::Llanfair => TimerKind::Llanfair,
+            TimerKind::LlanfairGered => TimerKind::LlanfairGered,
+            TimerKind::Urn => TimerKind::Urn,
+            TimerKind::SourceLiveTimer => TimerKind::SourceLiveTimer,
+            TimerKind::Splitterino => TimerKind::Splitterino,
+            TimerKind::Generic(v) => TimerKind::Generic(v.into_owned().into()),
+        }
+    }
+}
+
+impl fmt::Display for TimerKind<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TimerKind::LiveSplit => write!(f, "LiveSplit"),


### PR DESCRIPTION
Turns out that `serde_json` actually allows you to borrow from the input string that you are parsing. I was under the impression that this was not possible, as there might be escaped strings. However by using `Cow<'a, str>` you can borrow when it's possible and if it's an escaped string it unescapes it into the owned variant of the `Cow`. This also extends it to our own s-expression parser and does a few minor improvements here and there such as using `extend` to parse the segments in order to preallocate enough memory for all the segments.

Resolves #545 