### PR TITLE
Implement unstable `WASI` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0.98", default-features = false, features = [
     "alloc",
     "derive",
 ] }
-serde_json = { version = "1.0.8", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.60", default-features = false, features = ["alloc"] }
 smallstr = { version = "0.3.0", default-features = false }
 snafu = { version = "0.7.0", default-features = false }
 unicase = "2.6.0"
@@ -155,6 +155,7 @@ wasm-web = [
 ]
 networking = ["std", "splits-io-api"]
 auto-splitting = ["std", "livesplit-auto-splitting", "tokio", "log"]
+unstable-auto-splitting = ["livesplit-auto-splitting?/unstable"]
 
 [lib]
 bench = false

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -17,3 +17,7 @@ wasmtime = { version = "0.39.1", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
+wasmtime-wasi = { version = "0.39.1", optional = true }
+
+[features]
+unstable = ["wasmtime-wasi"]

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -108,3 +108,6 @@ extern "C" {
     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
 }
 ```
+
+On top of the runtime's API, there's also unstable `WASI` support via the
+`unstable` feature.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -108,6 +108,9 @@
 //!     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
 //! }
 //! ```
+//!
+//! On top of the runtime's API, there's also unstable `WASI` support via the
+//! `unstable` feature.
 
 #![warn(
     clippy::complexity,

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "unstable")]
+
+use livesplit_auto_splitting::{Runtime, Timer, TimerState};
+use log::Log;
+use std::{
+    cell::RefCell,
+    ffi::OsStr,
+    fmt::Write,
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+thread_local! {
+    static BUF: RefCell<Option<String>> = RefCell::new(None);
+}
+struct Logger;
+static LOGGER: Logger = Logger;
+
+impl Log for Logger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        if record.target() != "Auto Splitter" {
+            return;
+        }
+        BUF.with(|b| {
+            if let Some(b) = &mut *b.borrow_mut() {
+                let _ = writeln!(b, "{}", record.args());
+            }
+        });
+    }
+    fn flush(&self) {}
+}
+
+struct DummyTimer;
+
+impl Timer for DummyTimer {
+    fn state(&self) -> TimerState {
+        TimerState::NotRunning
+    }
+    fn start(&mut self) {}
+    fn split(&mut self) {}
+    fn reset(&mut self) {}
+    fn set_game_time(&mut self, time: time::Duration) {}
+    fn pause_game_time(&mut self) {}
+    fn resume_game_time(&mut self) {}
+    fn set_variable(&mut self, key: &str, value: &str) {}
+}
+
+fn compile(crate_name: &str) -> anyhow::Result<Runtime<DummyTimer>> {
+    let mut path = PathBuf::from("tests");
+    path.push("test-cases");
+    path.push(crate_name);
+
+    let output = Command::new("cargo")
+        .current_dir(&path)
+        .arg("build")
+        .arg("--target")
+        .arg("wasm32-wasi")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .output()
+        .unwrap();
+
+    if !output.status.success() {
+        let output = String::from_utf8_lossy(&output.stderr);
+        panic!("{}", output);
+    }
+
+    path.push("target");
+    path.push("wasm32-wasi");
+    path.push("debug");
+    let wasm_path = fs::read_dir(path)
+        .unwrap()
+        .find_map(|e| {
+            let path = e.unwrap().path();
+            if path.extension() == Some(OsStr::new("wasm")) {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    Ok(Runtime::new(&wasm_path, DummyTimer)?)
+}
+
+fn run(crate_name: &str) -> anyhow::Result<()> {
+    let mut runtime = compile(crate_name)?;
+    runtime.step()?;
+    Ok(())
+}
+
+#[test]
+fn empty() {
+    run("empty").unwrap();
+}
+
+#[test]
+fn proc_exit() {
+    assert!(run("proc-exit").is_err());
+}
+
+#[test]
+fn create_file() {
+    run("create-file").unwrap();
+}
+
+#[test]
+fn stdout() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Trace);
+    BUF.with(|b| *b.borrow_mut() = Some(String::new()));
+    run("stdout").unwrap();
+    let output = BUF.with(|b| b.borrow_mut().take());
+    // FIXME: For now we don't actually hook up stdout or stderr.
+    assert_eq!(output.unwrap(), "");
+}
+
+#[test]
+fn segfault() {
+    assert!(run("segfault").is_err());
+}
+
+#[test]
+fn env() {
+    run("env").unwrap();
+    assert!(std::env::var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS").is_err());
+}
+
+#[test]
+fn threads() {
+    // There's no threads in WASI / WASM yet, so this is expected to trap.
+    assert!(run("threads").is_err());
+}
+
+#[test]
+fn sleep() {
+    // FIXME: Sleeping can basically deadlock the code. We should have a limit on
+    // how long it can sleep.
+    run("sleep").unwrap();
+}
+
+#[test]
+fn time() {
+    run("time").unwrap();
+}
+
+#[test]
+fn random() {
+    run("random").unwrap();
+}
+
+// #[test]
+// fn poll() {
+//     // FIXME: This is basically what happens at the lower levels of sleeping. You
+//     // can block on file descriptors and have a timeout with this. Both of which
+//     // could deadlock the script.
+//     run("poll").unwrap();
+// }
+
+#[test]
+fn infinite_loop() {
+    let mut runtime = compile("infinite-loop").unwrap();
+
+    let interrupt = runtime.interrupt_handle();
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(5));
+        interrupt.interrupt();
+    });
+
+    assert!(runtime.step().is_err());
+}
+
+// FIXME: Test Network
+
+// FIXME: Test heavy amounts of allocations

--- a/crates/livesplit-auto-splitting/tests/test-cases/create-file/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/create-file/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "create-file"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/create-file/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/create-file/src/main.rs
@@ -1,0 +1,10 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    assert!(std::fs::write(
+        "shouldnt_exist.txt",
+        "This file should never exist. File a bug if you see this.",
+    )
+    .is_err());
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/empty/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/empty/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "empty"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/empty/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/empty/src/main.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn update() {}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/env/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/env/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "env"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/env/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/env/src/main.rs
@@ -1,0 +1,19 @@
+use std::{env, path::Path};
+
+#[no_mangle]
+pub extern "C" fn update() {
+    assert!(env::args().next().is_none());
+    assert!(env::current_exe().is_err());
+    assert_eq!(env::current_dir().unwrap(), Path::new("/"));
+    assert!(env::vars().next().is_none());
+
+    env::set_var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS", "YES");
+
+    // but auto splitter should
+    assert_eq!(
+        env::var("AUTOSPLITTER_HOST_SHOULDNT_SEE_THIS").unwrap(),
+        "YES",
+    );
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "infinite-loop"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/infinite-loop/src/main.rs
@@ -1,0 +1,8 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    loop {
+        std::thread::yield_now();
+    }
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "proc-exit"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/proc-exit/src/main.rs
@@ -1,0 +1,6 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    std::process::exit(-1);
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/random/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/random/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "random"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]
+getrandom = "0.1.14"

--- a/crates/livesplit-auto-splitting/tests/test-cases/random/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/random/src/main.rs
@@ -1,0 +1,8 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    let mut buf = [0; 32];
+    getrandom::getrandom(&mut buf).unwrap();
+    assert_ne!(buf, [0; 32]);
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/segfault/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/segfault/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "segfault"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/segfault/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/segfault/src/main.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+pub unsafe extern "C" fn update() {
+    let some_large_ptr = (usize::MAX / 2) as *mut u64;
+    *some_large_ptr = !0;
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/sleep/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/sleep/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sleep"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/sleep/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/sleep/src/main.rs
@@ -1,0 +1,9 @@
+use std::{thread, time};
+
+#[no_mangle]
+pub extern "C" fn update() {
+    thread::yield_now();
+    thread::sleep(time::Duration::from_secs(10));
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/stdout/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/stdout/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "stdout"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/stdout/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/stdout/src/main.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    println!("Printing from the auto splitter");
+    eprintln!("Error printing from the auto splitter");
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/threads/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/threads/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "threads"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/threads/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/threads/src/main.rs
@@ -1,0 +1,6 @@
+#[no_mangle]
+pub extern "C" fn update() {
+    assert!(std::thread::spawn(|| {}).join().is_err());
+}
+
+fn main() {}

--- a/crates/livesplit-auto-splitting/tests/test-cases/time/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/time/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "time"
+version = "0.1.0"
+authors = ["Christopher Serr <christopher.serr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/time/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/time/src/main.rs
@@ -1,0 +1,15 @@
+use std::{
+    thread,
+    time::{Duration, Instant, SystemTime},
+};
+
+#[no_mangle]
+pub extern "C" fn update() {
+    assert!(SystemTime::now() > SystemTime::UNIX_EPOCH);
+
+    let earlier = Instant::now();
+    thread::sleep(Duration::from_secs(1));
+    assert_ne!(earlier.elapsed(), Duration::from_secs(0));
+}
+
+fn main() {}


### PR DESCRIPTION
The `WebAssembly System Interface` (WASI) specifies a set of APIs that allow running the WebAssembly file as if it was running in a full operating system. The `WASI` specification is not stable yet, so `WASI` support is considered unstable for now and needs to be activated by activating the `unstable` feature. For now `stdout`, `stdin` and `stderr` are not hooked up and the file system is empty. We can incrementally explore adding files to the file system as well as hooking up `stdout` / `stderr` (it's unclear whether they should just log or allow controlling the runtime by printing commands to it).