### PR TITLE
Clean up for Rust 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ include = [
 ]
 edition = "2021"
 resolver = "2"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -56,7 +57,6 @@ unicase = "2.6.0"
 image = { version = "0.24.0", features = [
     "png",
 ], default-features = false, optional = true }
-parking_lot = { version = "0.12.0", default-features = false, optional = true }
 
 # Rendering
 # Currently doesn't require any additional dependencies.
@@ -118,7 +118,6 @@ std = [
     "libc",
     "livesplit-hotkey/std",
     "memchr/std",
-    "parking_lot",
     "rustybuzz?/std",
     "serde/std",
     "serde_json/std",
@@ -142,7 +141,7 @@ more-image-formats = [
     "image?/webp",
 ]
 image-shrinking = ["std", "more-image-formats"]
-rendering = ["more-image-formats"]
+rendering = ["more-image-formats", "image?/gif"]
 path-based-text-engine = ["rendering", "rustybuzz", "ttf-parser"]
 font-loading = ["std", "path-based-text-engine", "font-kit"]
 software-rendering = ["path-based-text-engine", "tiny-skia"]

--- a/capi/src/shared_timer.rs
+++ b/capi/src/shared_timer.rs
@@ -27,7 +27,7 @@ pub extern "C" fn SharedTimer_drop(this: OwnedSharedTimer) {
 /// you are done using the timer.
 #[no_mangle]
 pub extern "C" fn SharedTimer_read(this: &'static SharedTimer) -> OwnedTimerReadLock {
-    Box::new(this.read())
+    Box::new(this.read().unwrap())
 }
 
 /// Requests write access to the timer that is being shared. This blocks the
@@ -35,7 +35,7 @@ pub extern "C" fn SharedTimer_read(this: &'static SharedTimer) -> OwnedTimerRead
 /// lock when you are done using the timer.
 #[no_mangle]
 pub extern "C" fn SharedTimer_write(this: &'static SharedTimer) -> OwnedTimerWriteLock {
-    Box::new(this.write())
+    Box::new(this.write().unwrap())
 }
 
 /// Replaces the timer that is being shared by the timer provided. This blocks
@@ -44,5 +44,5 @@ pub extern "C" fn SharedTimer_write(this: &'static SharedTimer) -> OwnedTimerWri
 /// completion.
 #[no_mangle]
 pub extern "C" fn SharedTimer_replace_inner(this: &SharedTimer, timer: OwnedTimer) {
-    *this.write() = *timer;
+    *this.write().unwrap() = *timer;
 }

--- a/capi/src/timer_read_lock.rs
+++ b/capi/src/timer_read_lock.rs
@@ -1,7 +1,8 @@
 //! A Timer Read Lock allows temporary read access to a timer. Dispose this to
 //! release the read lock.
 
-use livesplit_core::parking_lot::RwLockReadGuard;
+use std::sync::RwLockReadGuard;
+
 use livesplit_core::Timer;
 
 /// type
@@ -18,5 +19,5 @@ pub extern "C" fn TimerReadLock_drop(this: OwnedTimerReadLock) {
 /// Accesses the timer.
 #[no_mangle]
 pub extern "C" fn TimerReadLock_timer(this: &TimerReadLock) -> &Timer {
-    &*this
+    this
 }

--- a/capi/src/timer_write_lock.rs
+++ b/capi/src/timer_write_lock.rs
@@ -1,7 +1,8 @@
 //! A Timer Write Lock allows temporary write access to a timer. Dispose this to
 //! release the write lock.
 
-use livesplit_core::parking_lot::RwLockWriteGuard;
+use std::sync::RwLockWriteGuard;
+
 use livesplit_core::Timer;
 
 /// type

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -15,16 +15,14 @@ winapi = { version = "0.3.2", features = [
     "processthreadsapi",
     "winuser"
 ], optional = true }
-parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-evdev = { version = "0.11.1", optional = true }
+evdev = { version = "=0.11.4", optional = true }
 mio = { version = "0.8.0", default-features = false, features = ["os-ext", "os-poll"], optional = true }
 promising-future = { version = "0.2.4", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bitflags = { version = "1.2.1", optional = true }
-parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.54", optional = true }
@@ -37,5 +35,5 @@ snafu = { version = "0.7.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["snafu/std", "serde/std", "parking_lot", "evdev", "mio", "promising-future", "winapi", "bitflags"]
+std = ["snafu/std", "serde/std", "evdev", "mio", "promising-future", "winapi", "bitflags"]
 wasm-web = ["wasm-bindgen", "web-sys"]

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -1,12 +1,11 @@
 use crate::KeyCode;
-use parking_lot::Mutex;
 use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
     mem, ptr,
     sync::{
         mpsc::{channel, Sender},
-        Arc,
+        Arc, Mutex,
     },
     thread,
 };
@@ -351,7 +350,7 @@ impl Hook {
 
         thread::spawn(move || {
             while let Ok(key) = events_rx.recv() {
-                if let Some(callback) = hotkey_map.lock().get_mut(&key) {
+                if let Some(callback) = hotkey_map.lock().unwrap().get_mut(&key) {
                     callback();
                 }
             }
@@ -367,7 +366,7 @@ impl Hook {
     where
         F: FnMut() + Send + 'static,
     {
-        if let Entry::Vacant(vacant) = self.hotkeys.lock().entry(hotkey) {
+        if let Entry::Vacant(vacant) = self.hotkeys.lock().unwrap().entry(hotkey) {
             vacant.insert(Box::new(callback));
             Ok(())
         } else {
@@ -377,7 +376,7 @@ impl Hook {
 
     /// Unregisters a previously registered hotkey.
     pub fn unregister(&self, hotkey: KeyCode) -> Result<()> {
-        if self.hotkeys.lock().remove(&hotkey).is_some() {
+        if self.hotkeys.lock().unwrap().remove(&hotkey).is_some() {
             Ok(())
         } else {
             Err(Error::NotRegistered)

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -247,7 +247,7 @@ struct Timer(SharedTimer);
 
 impl AutoSplitTimer for Timer {
     fn state(&self) -> TimerState {
-        match self.0.read().current_phase() {
+        match self.0.read().unwrap().current_phase() {
             TimerPhase::NotRunning => TimerState::NotRunning,
             TimerPhase::Running => TimerState::Running,
             TimerPhase::Paused => TimerState::Paused,
@@ -256,31 +256,31 @@ impl AutoSplitTimer for Timer {
     }
 
     fn start(&mut self) {
-        self.0.write().start()
+        self.0.write().unwrap().start()
     }
 
     fn split(&mut self) {
-        self.0.write().split()
+        self.0.write().unwrap().split()
     }
 
     fn reset(&mut self) {
-        self.0.write().reset(true)
+        self.0.write().unwrap().reset(true)
     }
 
     fn set_game_time(&mut self, time: time::Duration) {
-        self.0.write().set_game_time(time.into());
+        self.0.write().unwrap().set_game_time(time.into());
     }
 
     fn pause_game_time(&mut self) {
-        self.0.write().pause_game_time()
+        self.0.write().unwrap().pause_game_time()
     }
 
     fn resume_game_time(&mut self) {
-        self.0.write().resume_game_time()
+        self.0.write().unwrap().resume_game_time()
     }
 
     fn set_variable(&mut self, name: &str, value: &str) {
-        self.0.write().set_custom_variable(name, value)
+        self.0.write().unwrap().set_custom_variable(name, value)
     }
 }
 

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -41,7 +41,7 @@ pub struct ColumnSettings {
 
 /// Specifies the value a segment starts out with before it gets replaced
 /// with the current attempt's information when splitting.
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ColumnStartWith {
     /// The column starts out with an empty value.
     Empty,
@@ -59,7 +59,7 @@ pub enum ColumnStartWith {
 /// Once a certain condition is met, which is usually being on the split or
 /// already having completed the split, the time gets updated with the value
 /// specified here.
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ColumnUpdateWith {
     /// The value doesn't get updated and stays on the value it started out
     /// with.
@@ -89,7 +89,7 @@ pub enum ColumnUpdateWith {
 }
 
 /// Specifies when a column's value gets updated.
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ColumnUpdateTrigger {
     /// The value gets updated as soon as the segment is started. The value
     /// constantly updates until the segment ends.

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -284,7 +284,7 @@ impl Component {
                                 if !shortest_game_name.is_empty() && !category_abbrev.is_empty() {
                                     abbrev.push_str(" - ");
                                 }
-                                abbrev.push_str(&*category_abbrev);
+                                abbrev.push_str(category_abbrev);
                                 abbrevs.push(abbrev.as_str().into());
                                 abbrev.drain(game_len..);
                             }

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -60,17 +60,21 @@ impl Hotkey {
 
     fn callback(self, timer: SharedTimer) -> Box<dyn FnMut() + Send + 'static> {
         match self {
-            Hotkey::Split => Box::new(move || timer.write().split_or_start()),
-            Hotkey::Reset => Box::new(move || timer.write().reset(true)),
-            Hotkey::Undo => Box::new(move || timer.write().undo_split()),
-            Hotkey::Skip => Box::new(move || timer.write().skip_split()),
-            Hotkey::Pause => Box::new(move || timer.write().toggle_pause_or_start()),
-            Hotkey::UndoAllPauses => Box::new(move || timer.write().undo_all_pauses()),
+            Hotkey::Split => Box::new(move || timer.write().unwrap().split_or_start()),
+            Hotkey::Reset => Box::new(move || timer.write().unwrap().reset(true)),
+            Hotkey::Undo => Box::new(move || timer.write().unwrap().undo_split()),
+            Hotkey::Skip => Box::new(move || timer.write().unwrap().skip_split()),
+            Hotkey::Pause => Box::new(move || timer.write().unwrap().toggle_pause_or_start()),
+            Hotkey::UndoAllPauses => Box::new(move || timer.write().unwrap().undo_all_pauses()),
             Hotkey::PreviousComparison => {
-                Box::new(move || timer.write().switch_to_previous_comparison())
+                Box::new(move || timer.write().unwrap().switch_to_previous_comparison())
             }
-            Hotkey::NextComparison => Box::new(move || timer.write().switch_to_next_comparison()),
-            Hotkey::ToggleTimingMethod => Box::new(move || timer.write().toggle_timing_method()),
+            Hotkey::NextComparison => {
+                Box::new(move || timer.write().unwrap().switch_to_next_comparison())
+            }
+            Hotkey::ToggleTimingMethod => {
+                Box::new(move || timer.write().unwrap().toggle_timing_method())
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,4 @@ pub use livesplit_hotkey as hotkey;
 pub use crate::platform::{register_clock, Clock, Duration};
 
 #[cfg(feature = "std")]
-pub use parking_lot;
-
-#[cfg(feature = "std")]
 pub use crate::{hotkey_config::HotkeyConfig, hotkey_system::HotkeySystem, timing::SharedTimer};

--- a/src/platform/no_std/mod.rs
+++ b/src/platform/no_std/mod.rs
@@ -8,11 +8,11 @@ impl<T> RwLock<T> {
         Self(core::cell::RefCell::new(value))
     }
 
-    pub fn write(&self) -> core::cell::RefMut<'_, T> {
-        self.0.borrow_mut()
+    pub fn write(&self) -> Result<core::cell::RefMut<'_, T>, ()> {
+        Ok(self.0.borrow_mut())
     }
 
-    pub fn read(&self) -> core::cell::Ref<'_, T> {
-        self.0.borrow()
+    pub fn read(&self) -> Result<core::cell::Ref<'_, T>, ()> {
+        Ok(self.0.borrow())
     }
 }

--- a/src/platform/normal/mod.rs
+++ b/src/platform/normal/mod.rs
@@ -1,4 +1,4 @@
-pub use parking_lot::RwLock;
+pub use std::sync::RwLock;
 use time::UtcOffset;
 pub use time::{Duration, OffsetDateTime as DateTime};
 

--- a/src/platform/wasm/unknown/mod.rs
+++ b/src/platform/wasm/unknown/mod.rs
@@ -1,4 +1,4 @@
 mod time;
 
 pub use self::time::*;
-pub use parking_lot::RwLock;
+pub use std::sync::RwLock;

--- a/src/platform/wasm/web/mod.rs
+++ b/src/platform/wasm/web/mod.rs
@@ -1,3 +1,3 @@
 mod time;
 pub use self::time::*;
-pub use parking_lot::RwLock;
+pub use std::sync::RwLock;

--- a/src/rendering/path_based_text_engine/mod.rs
+++ b/src/rendering/path_based_text_engine/mod.rs
@@ -121,7 +121,7 @@ impl TextEngine {
         font: &mut Font<PB::Path>,
         max_width: Option<f32>,
     ) {
-        let mut label = label.write();
+        let mut label = label.write().unwrap();
         let label = &mut *label;
 
         let mut buffer = self.buffer.take().unwrap_or_else(UnicodeBuffer::new);
@@ -439,11 +439,11 @@ impl<P> LockedLabel<P> {
 
 impl<P> super::Label for Label<P> {
     fn width(&self, scale: f32) -> f32 {
-        self.read().width * scale
+        self.read().unwrap().width * scale
     }
 
     fn width_without_max_width(&self, scale: f32) -> f32 {
-        self.read().width_without_max_width * scale
+        self.read().unwrap().width_without_max_width * scale
     }
 }
 

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -421,7 +421,7 @@ fn render_layer(
                 }
             }
             Entity::Label(label, shader, transform) => {
-                let label = label.read();
+                let label = label.read().unwrap();
                 let label = &*label;
 
                 let paint = convert_shader(
@@ -632,7 +632,7 @@ fn calculate_bounds(layer: &[Entity<SkiaPath, SkiaImage, SkiaLabel>]) -> (f32, f
                 }
             }
             Entity::Label(label, _, transform) => {
-                for glyph in label.read().glyphs() {
+                for glyph in label.read().unwrap().glyphs() {
                     if let Some(path) = &glyph.path {
                         let transform = transform.pre_translate(glyph.x, glyph.y);
                         let bounds = path.bounds();

--- a/src/run/attempt.rs
+++ b/src/run/attempt.rs
@@ -3,7 +3,7 @@ use crate::{AtomicDateTime, Time, TimeSpan};
 /// An Attempt describes information about an attempt to run a specific category
 /// by a specific runner in the past. Every time a new attempt is started and
 /// then reset, an Attempt describing general information about it is created.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Attempt {
     index: i32,
     time: Time,

--- a/src/run/comparisons.rs
+++ b/src/run/comparisons.rs
@@ -20,7 +20,7 @@ use crate::{platform::prelude::*, Time};
 // could yield even better performance.
 
 /// A collection of a segment's comparison times.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Comparisons(Vec<(Box<str>, Time)>);
 
 impl Comparisons {

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -55,7 +55,7 @@ pub enum OpenError {
 }
 
 /// Error type for a failed Rename.
-#[derive(PartialEq, Debug, snafu::Snafu)]
+#[derive(PartialEq, Eq, Debug, snafu::Snafu)]
 #[snafu(context(suffix(false)))]
 pub enum RenameError {
     /// Old Comparison was not found during rename.

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -90,7 +90,7 @@ impl PartialEq for ComparisonGenerators {
 }
 
 /// Error type for an invalid comparison name
-#[derive(PartialEq, Debug, snafu::Snafu)]
+#[derive(PartialEq, Eq, Debug, snafu::Snafu)]
 pub enum ComparisonError {
     /// Comparison name starts with "\[Race\]".
     NameStartsWithRace,

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -49,7 +49,7 @@ impl CustomVariable {
 
 /// The Run Metadata stores additional information about a run, like the
 /// platform and region of the game. All of this information is optional.
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunMetadata {
     /// The speedrun.com Run ID of the run. You need to ensure that the record
     /// on speedrun.com matches up with the Personal Best of this run. This may

--- a/src/run/segment_history.rs
+++ b/src/run/segment_history.rs
@@ -1,13 +1,14 @@
-use crate::platform::prelude::*;
-use crate::Time;
-use core::cmp::min;
-use core::slice::{Iter, IterMut};
+use crate::{platform::prelude::*, Time};
+use core::{
+    cmp::min,
+    slice::{Iter, IterMut},
+};
 
 /// Stores the segment times achieved for a certain segment. Each segment is
 /// tagged with an index. Only segment times with an index larger than 0 are
 /// considered times actually achieved by the runner, while the others are
 /// artifacts of route changes and similar algorithmic changes.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct SegmentHistory(Vec<(i32, Time)>);
 
 impl SegmentHistory {

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -176,7 +176,7 @@ impl Image {
 /// With a Cached Image ID you can track image changes. It starts with an
 /// uncached state and then gets updated with the images provided to it. It can
 /// be reset at any point in order to force a change to be detected.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum CachedImageId {
     /// The initial uncached state.
     Uncached,

--- a/src/timing/atomic_date_time.rs
+++ b/src/timing/atomic_date_time.rs
@@ -6,7 +6,7 @@ use core::ops::Sub;
 
 /// An Atomic Date Time represents a UTC Date Time that tries to be as close to
 /// an atomic clock as possible.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AtomicDateTime {
     /// The UTC Date Time represented by this Atomic Date Time.
     pub time: DateTime,

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -84,7 +84,7 @@ impl Deref for Snapshot<'_> {
 /// A Shared Timer is a wrapper around the Timer that can be shared across
 /// multiple threads with multiple owners.
 #[cfg(feature = "std")]
-pub type SharedTimer = alloc::sync::Arc<parking_lot::RwLock<Timer>>;
+pub type SharedTimer = alloc::sync::Arc<std::sync::RwLock<Timer>>;
 
 /// The Error type for creating a new Timer from a Run.
 #[derive(Debug, snafu::Snafu)]
@@ -130,7 +130,7 @@ impl Timer {
     /// multiple threads with multiple owners.
     #[cfg(feature = "std")]
     pub fn into_shared(self) -> SharedTimer {
-        alloc::sync::Arc::new(parking_lot::RwLock::new(self))
+        alloc::sync::Arc::new(std::sync::RwLock::new(self))
     }
 
     /// Takes out the Run from the Timer and resets the current attempt if there

--- a/src/util/ordered_map.rs
+++ b/src/util/ordered_map.rs
@@ -11,7 +11,7 @@ use serde::{
 
 /// An ordered [`Map`] is a map where the iteration order of the key-value pairs is
 /// based on the order the pairs were inserted into the map.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Map<V>(Vec<(Box<str>, V)>);
 
 /// An iterator over the entries of the [`Map`].


### PR DESCRIPTION
This applies a bunch of small cleanups, such as:
1. Removing `parking_lot` as a dependency. They recently made a bunch of improvements to the locking primitives in std, such that `parking_lot` is no longer really needed.
2. `Eq` is now derived when it's possible to do so.
3. `evdev` accidentally releases breaking changes a lot. We'll pin the version for now.
4. `rendering` now activates the `gif` feature of the `image` crate, such that GIFs can be rendered.

Resolves #291