### PR TITLE
Switch from `structopt` to `clap`

### DIFF
--- a/capi/bind_gen/Cargo.toml
+++ b/capi/bind_gen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 heck = "0.4.0"
-structopt = "0.3.7"
+clap = { version = "3.2.21", features = ["derive"] }
 syn = { version = "1.0.2", default-features = false, features = ["parsing", "full", "printing"] }

--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -13,6 +13,7 @@ mod typescript;
 mod wasm;
 mod wasm_bindgen;
 
+use clap::Parser;
 use std::{
     collections::BTreeMap,
     fs::{self, create_dir_all, remove_dir_all, File},
@@ -20,16 +21,15 @@ use std::{
     path::PathBuf,
     rc::Rc,
 };
-use structopt::StructOpt;
 use syn::{
     parse_file, FnArg, Item, ItemFn, Lit, Meta, Pat, ReturnType, Signature, Type as SynType,
     Visibility,
 };
 
-#[derive(StructOpt)]
-#[structopt(about = "Generates bindings for livesplit-core")]
+#[derive(clap::Parser)]
+#[clap(about = "Generates bindings for livesplit-core")]
 pub struct Opt {
-    #[structopt(
+    #[clap(
         long = "ruby-lib-path",
         help = "The path of the library for the Ruby bindings",
         default_value = "../liblivesplit_core.so"
@@ -167,7 +167,7 @@ fn get_comment(attrs: &[syn::Attribute]) -> Vec<String> {
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let mut contents = fs::read_to_string("../src/lib.rs").unwrap();
     let file = parse_file(&contents).unwrap();


### PR DESCRIPTION
The new `clap` version supersedes `structopt`. Additionally this gets rid of `ansi_term` as an indirect dependency, which is unmaintained.