### PR TITLE
Let the `Resource Allocator` decode the images

### DIFF
--- a/benches/scene_management.rs
+++ b/benches/scene_management.rs
@@ -38,7 +38,9 @@ cfg_if::cfg_if! {
             fn path_builder(&mut self) -> Self::PathBuilder {
                 Dummy
             }
-            fn create_image(&mut self, _: u32, _: u32, _: &[u8]) -> Self::Image {}
+            fn create_image(&mut self, _: &[u8]) -> Option<(Self::Image, f32)> {
+                Some(((), 1.0))
+            }
             fn create_font(&mut self, _: Option<&Font>, _: FontKind) -> Self::Font {}
             fn create_label(
                 &mut self,

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -444,26 +444,11 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
     }
 
     fn create_icon(&mut self, image_data: &[u8]) -> Option<Icon<A::Image>> {
-        #[cfg(feature = "image")]
-        {
-            if image_data.is_empty() {
-                return None;
-            }
-
-            let image = image::load_from_memory(image_data).ok()?.to_rgba8();
-
-            Some(Icon {
-                aspect_ratio: image.width() as f32 / image.height() as f32,
-                image: self
-                    .handles
-                    .create_image(image.width(), image.height(), &image),
-            })
-        }
-        #[cfg(not(feature = "image"))]
-        {
-            let _ = image_data;
-            None
-        }
+        let (image, aspect_ratio) = self.handles.create_image(image_data)?;
+        Some(Icon {
+            aspect_ratio,
+            image,
+        })
     }
 
     fn scale(&mut self, factor: f32) {

--- a/src/rendering/resource/allocation.rs
+++ b/src/rendering/resource/allocation.rs
@@ -59,10 +59,11 @@ pub trait ResourceAllocator {
         builder.finish()
     }
 
-    /// Creates an image out of the image data provided. The image's resolution
-    /// is provided as well. The data is an array of RGBA8 encoded pixels (red,
-    /// green, blue, alpha with each channel being an u8).
-    fn create_image(&mut self, width: u32, height: u32, data: &[u8]) -> Self::Image;
+    /// Creates an image out of the image data provided. The data represents the
+    /// image in its original file format. It needs to be parsed in order to be
+    /// visualized. The parsed image as well as the aspect ratio (width /
+    /// height) are returned in case the image was parsed successfully.
+    fn create_image(&mut self, data: &[u8]) -> Option<(Self::Image, f32)>;
 
     /// Creates a font from the font description provided. It is expected that
     /// the the font description is used in a font matching algorithm to find
@@ -191,8 +192,8 @@ impl<A: ResourceAllocator> ResourceAllocator for &mut A {
         MutPathBuilder((*self).path_builder())
     }
 
-    fn create_image(&mut self, width: u32, height: u32, data: &[u8]) -> Self::Image {
-        (*self).create_image(width, height, data)
+    fn create_image(&mut self, data: &[u8]) -> Option<(Self::Image, f32)> {
+        (*self).create_image(data)
     }
 
     fn create_font(&mut self, font: Option<&Font>, kind: FontKind) -> Self::Font {

--- a/src/rendering/resource/handles.rs
+++ b/src/rendering/resource/handles.rs
@@ -78,9 +78,9 @@ impl<A: ResourceAllocator> ResourceAllocator for Handles<A> {
         self.next(circle)
     }
 
-    fn create_image(&mut self, width: u32, height: u32, data: &[u8]) -> Self::Image {
-        let image = self.allocator.create_image(width, height, data);
-        self.next(image)
+    fn create_image(&mut self, data: &[u8]) -> Option<(Self::Image, f32)> {
+        let (image, aspect_ratio) = self.allocator.create_image(data)?;
+        Some((self.next(image), aspect_ratio))
     }
 
     fn create_font(&mut self, font: Option<&Font>, kind: super::FontKind) -> Self::Font {


### PR DESCRIPTION
We pass the encoded image data into the resource allocator now instead of trying to decode the image in the scene manager. This way the renderer has the ability to support all sorts of image formats that we might not support. For example, this would also allow the renderer to decode GIFs itself and thus properly animate them.

cc  #506 