### PR TITLE
Implement Columns that show Variables

### DIFF
--- a/src/component/splits/tests/column.rs
+++ b/src/component/splits/tests/column.rs
@@ -3,6 +3,7 @@ use super::{
     State,
 };
 use crate::{
+    component::splits::{ColumnKind, TimeColumn},
     settings::SemanticColor::{
         self, AheadGainingTime as AheadGaining, BehindLosingTime as BehindLosing,
         BestSegment as Best, Default as Text,
@@ -490,8 +491,11 @@ fn check_columns(
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         columns: vec![ColumnSettings {
-            start_with,
-            update_with,
+            kind: ColumnKind::Time(TimeColumn {
+                start_with,
+                update_with,
+                ..Default::default()
+            }),
             ..Default::default()
         }],
         fill_with_blank_space: false,
@@ -1079,9 +1083,12 @@ fn check_columns_update_trigger(
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         columns: vec![ColumnSettings {
-            start_with: ColumnStartWith::Empty,
-            update_with,
-            update_trigger,
+            kind: ColumnKind::Time(TimeColumn {
+                start_with: ColumnStartWith::Empty,
+                update_with,
+                update_trigger,
+                ..Default::default()
+            }),
             ..Default::default()
         }],
         fill_with_blank_space: false,
@@ -1157,8 +1164,11 @@ fn column_delta_best_segment_colors() {
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         columns: vec![ColumnSettings {
-            start_with: ColumnStartWith::Empty,
-            update_with: ColumnUpdateWith::Delta,
+            kind: ColumnKind::Time(TimeColumn {
+                start_with: ColumnStartWith::Empty,
+                update_with: ColumnUpdateWith::Delta,
+                ..Default::default()
+            }),
             ..Default::default()
         }],
         fill_with_blank_space: false,
@@ -1249,8 +1259,11 @@ fn delta_or_split_time() {
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         columns: vec![ColumnSettings {
-            start_with: ColumnStartWith::ComparisonTime,
-            update_with: ColumnUpdateWith::DeltaWithFallback,
+            kind: ColumnKind::Time(TimeColumn {
+                start_with: ColumnStartWith::ComparisonTime,
+                update_with: ColumnUpdateWith::DeltaWithFallback,
+                ..Default::default()
+            }),
             ..Default::default()
         }],
         fill_with_blank_space: false,

--- a/src/component/splits/tests/mod.rs
+++ b/src/component/splits/tests/mod.rs
@@ -2,7 +2,10 @@ use super::{
     ColumnSettings, ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith, Component, Settings,
     State,
 };
-use crate::{Run, Segment, TimeSpan, Timer, TimingMethod};
+use crate::{
+    component::splits::{ColumnKind, TimeColumn},
+    Run, Segment, TimeSpan, Timer, TimingMethod,
+};
 
 pub mod column;
 
@@ -85,9 +88,12 @@ fn negative_segment_times() {
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         columns: vec![ColumnSettings {
-            start_with: ColumnStartWith::Empty,
-            update_with: ColumnUpdateWith::SegmentTime,
-            update_trigger: ColumnUpdateTrigger::OnStartingSegment,
+            kind: ColumnKind::Time(TimeColumn {
+                start_with: ColumnStartWith::Empty,
+                update_with: ColumnUpdateWith::SegmentTime,
+                update_trigger: ColumnUpdateTrigger::OnStartingSegment,
+                ..Default::default()
+            }),
             ..Default::default()
         }],
         ..Default::default()

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -1,3 +1,5 @@
+use hashbrown::HashMap;
+
 use super::Comparisons;
 use crate::{
     comparison::personal_best, platform::prelude::*, settings::Image, util::PopulateString,
@@ -26,6 +28,7 @@ pub struct Segment {
     split_time: Time,
     segment_history: SegmentHistory,
     comparisons: Comparisons,
+    variables: HashMap<String, String>,
 }
 
 impl Segment {
@@ -175,5 +178,28 @@ impl Segment {
     #[inline]
     pub fn segment_history_mut(&mut self) -> &mut SegmentHistory {
         &mut self.segment_history
+    }
+
+    /// Accesses the segment's variables for the current attempt.
+    pub const fn variables(&self) -> &HashMap<String, String> {
+        &self.variables
+    }
+
+    /// Grants mutable access to the segment's variables for the current
+    /// attempt.
+    pub fn variables_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.variables
+    }
+
+    /// Clears the variables of the current attempt.
+    pub fn clear_variables(&mut self) {
+        self.variables.clear();
+    }
+
+    /// Clears all the information the segment stores when it has been splitted,
+    /// such as the split's time and variables.
+    pub fn clear_split_info(&mut self) {
+        self.clear_variables();
+        self.clear_split_time();
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -20,5 +20,5 @@ pub use self::{
     image::{CachedImageId, Image, ImageData},
     semantic_color::SemanticColor,
     settings_description::SettingsDescription,
-    value::{Error as ValueError, Result as ValueResult, Value},
+    value::{Error as ValueError, Result as ValueResult, Value, ColumnKind},
 };

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -13,6 +13,15 @@ use crate::{
 use core::result::Result as StdResult;
 use serde::{Deserialize, Serialize};
 
+/// Describes the kind of a column.
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ColumnKind {
+    /// The column shows a time.
+    Time,
+    /// The column shows a variable.
+    Variable,
+}
+
 /// Describes a setting's value. Such a value can be of a variety of different
 /// types.
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -45,6 +54,8 @@ pub enum Value {
     ListGradient(ListGradient),
     /// An alignment for the Title Component's title.
     Alignment(Alignment),
+    /// A column kind.
+    ColumnKind(ColumnKind),
     /// A value describing what a column of the Splits Component starts out
     /// with.
     ColumnStartWith(ColumnStartWith),
@@ -182,6 +193,12 @@ impl From<Option<Font>> for Value {
 impl From<DeltaGradient> for Value {
     fn from(x: DeltaGradient) -> Self {
         Value::DeltaGradient(x)
+    }
+}
+
+impl From<ColumnKind> for Value {
+    fn from(x: ColumnKind) -> Self {
+        Value::ColumnKind(x)
     }
 }
 
@@ -365,6 +382,14 @@ impl Value {
             _ => Err(Error::WrongType),
         }
     }
+
+    /// Tries to convert the value into a column kind.
+    pub fn into_column_kind(self) -> Result<ColumnKind> {
+        match self {
+            Value::ColumnKind(v) => Ok(v),
+            _ => Err(Error::WrongType),
+        }
+    }
 }
 
 impl From<Value> for bool {
@@ -484,5 +509,11 @@ impl From<Value> for Option<Font> {
 impl From<Value> for DeltaGradient {
     fn from(value: Value) -> Self {
         value.into_delta_gradient().unwrap()
+    }
+}
+
+impl From<Value> for ColumnKind {
+    fn from(value: Value) -> Self {
+        value.into_column_kind().unwrap()
     }
 }

--- a/src/util/clear_vec.rs
+++ b/src/util/clear_vec.rs
@@ -174,7 +174,7 @@ impl<T: Clear + Serialize> Serialize for ClearVec<T> {
     where
         S: serde::Serializer,
     {
-        (&**self).serialize(serializer)
+        <[T]>::serialize(self, serializer)
     }
 }
 


### PR DESCRIPTION
This implements columns for the splits component that can visualize the custom variables of the run at each split. This is mostly only useful in combination with an auto splitter that provides the variables.