### PR TITLE
Remove some features from `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = ["capi", "capi/bind_gen", "crates/*"]
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
 cfg-if = "1.0.0"
-time = { version = "0.3.3", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3.3", default-features = false }
 hashbrown = "0.12.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.6.0", default-features = false }

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["Christopher Serr <christopher.serr@gmail.com>"]
 edition = "2018"
 
 [lib]
+name = "livesplit_core"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 livesplit-core = { path = "..", default-features = false, features = ["std"] }
-serde_json = "1.0.8"
-time = "0.3.4"
-simdutf8 = "0.1.4"
+serde_json = { version = "1.0.8", default-features = false }
+time = { version = "0.3.4", default-features = false }
+simdutf8 = { version = "0.1.4", default-features = false }
 
 [features]
 default = ["image-shrinking"]

--- a/capi/src/atomic_date_time.rs
+++ b/capi/src/atomic_date_time.rs
@@ -4,7 +4,7 @@
 use crate::output_vec;
 use livesplit_core::AtomicDateTime;
 use std::os::raw::c_char;
-use time::{format_description::well_known::Rfc3339, macros::format_description};
+use time::format_description::well_known::Rfc3339;
 
 /// type
 pub type OwnedAtomicDateTime = Box<AtomicDateTime>;
@@ -23,14 +23,6 @@ pub extern "C" fn AtomicDateTime_drop(this: OwnedAtomicDateTime) {
 #[no_mangle]
 pub extern "C" fn AtomicDateTime_is_synchronized(this: &AtomicDateTime) -> bool {
     this.synced_with_atomic_clock
-}
-
-/// Converts this atomic date time into a RFC 2822 formatted date time.
-#[no_mangle]
-pub extern "C" fn AtomicDateTime_to_rfc2822(this: &AtomicDateTime) -> *const c_char {
-    output_vec(|o| {
-        let _ = this.time.format_into(o, &format_description!("[weekday repr:short], [day padding:none] [month repr:short] [year] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"));
-    })
 }
 
 /// Converts this atomic date time into a RFC 3339 formatted date time.

--- a/src/util/xml/helper.rs
+++ b/src/util/xml/helper.rs
@@ -1,10 +1,6 @@
-use crate::{platform::prelude::*, timing};
+use crate::platform::prelude::*;
 use alloc::borrow::Cow;
-use core::{
-    fmt,
-    num::{ParseFloatError, ParseIntError},
-    str,
-};
+use core::{fmt, str};
 
 use super::{Attributes, Event, Reader, TagName, Text, Writer};
 
@@ -23,43 +19,6 @@ pub enum Error {
     AttributeNotFound,
     /// A required element has not been found.
     ElementNotFound,
-    /// The length of a buffer was too large.
-    LengthOutOfBounds,
-    /// Failed to parse an integer.
-    Int { source: ParseIntError },
-    /// Failed to parse a floating point number.
-    Float { source: ParseFloatError },
-    /// Failed to parse a time.
-    Time { source: timing::ParseError },
-    /// Failed to parse a date.
-    Date {
-        #[cfg_attr(not(feature = "std"), snafu(source(false)))]
-        source: time::error::Parse,
-    },
-}
-
-impl From<ParseIntError> for Error {
-    fn from(source: ParseIntError) -> Self {
-        Self::Int { source }
-    }
-}
-
-impl From<ParseFloatError> for Error {
-    fn from(source: ParseFloatError) -> Self {
-        Self::Float { source }
-    }
-}
-
-impl From<timing::ParseError> for Error {
-    fn from(source: timing::ParseError) -> Self {
-        Self::Time { source }
-    }
-}
-
-impl From<time::error::Parse> for Error {
-    fn from(source: time::error::Parse) -> Self {
-        Self::Date { source }
-    }
 }
 
 pub fn text_parsed<F, T, E>(reader: &mut Reader<'_>, f: F) -> Result<(), E>


### PR DESCRIPTION
It's pretty easy to do most of the formatting and parsing ourselves. This should improve the compile time and performance a little bit.