### PR TITLE
Fix Background Handling in Detailed Timer

### DIFF
--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -274,10 +274,13 @@ impl Component {
         self.timer
             .update_state(&mut state.timer, timer, layout_settings);
 
-        state.background = state.timer.background;
-
         self.segment_timer
             .update_state(&mut state.segment_timer, timer, layout_settings);
+
+        state.background = self
+            .settings
+            .background
+            .gradient(state.timer.semantic_color.visualize(layout_settings));
 
         update_comparison(&mut state.comparison1, comparison1);
         update_comparison(&mut state.comparison2, comparison2);
@@ -374,11 +377,7 @@ impl Component {
     /// the setting provided is out of bounds.
     pub fn set_value(&mut self, index: usize, value: Value) {
         match index {
-            0 => {
-                let value = value.into();
-                self.settings.background = value;
-                self.settings.timer.background = value;
-            }
+            0 => self.settings.background = value.into(),
             1 => {
                 let value = value.into();
                 self.settings.timer.timing_method = value;

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -264,10 +264,11 @@ impl Component {
             (Some(time), semantic_color)
         };
 
+        let not_overwritten_visual_color = semantic_color.visualize(layout_settings);
         let visual_color = if let Some(color) = self.settings.color_override {
             color
         } else {
-            semantic_color.visualize(layout_settings)
+            not_overwritten_visual_color
         };
 
         (state.top_color, state.bottom_color) = if self.settings.show_gradient {
@@ -279,7 +280,7 @@ impl Component {
         state.background = self
             .settings
             .background
-            .gradient(semantic_color.visualize(layout_settings));
+            .gradient(not_overwritten_visual_color);
 
         state.time.clear();
         let _ = write!(

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -92,7 +92,6 @@ pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()
         settings.timer.color_override = None;
     }
     settings.background = background_builder.build();
-    settings.timer.background = settings.background;
 
     settings.segment_timer.height = (total_height as f32 * segment_timer_ratio) as u32;
     settings.timer.height = total_height - settings.segment_timer.height;


### PR DESCRIPTION
The deailed timer internally contains two timer components. The way the background was synchronized between them was incorrect.