### PR TITLE
Improve the Correctness & Performance of Time Formatting

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -127,4 +127,5 @@ mod runtime;
 mod timer;
 
 pub use runtime::{CreationError, InterruptHandle, RunError, Runtime};
+pub use time;
 pub use timer::{Timer, TimerState};

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -219,7 +219,7 @@ fn interpolate(
     (weight_right, time_right): (f64, TimeSpan),
 ) -> TimeSpan {
     let weight_diff_recip = (weight_right - weight_left).recip();
-    let perc_down = (weight_right - perc) * time_left.total_milliseconds() * weight_diff_recip;
-    let perc_up = (perc - weight_left) * time_right.total_milliseconds() * weight_diff_recip;
-    TimeSpan::from_milliseconds(perc_up + perc_down)
+    let perc_down = (weight_right - perc) * time_left.total_seconds() * weight_diff_recip;
+    let perc_up = (perc - weight_left) * time_right.total_seconds() * weight_diff_recip;
+    TimeSpan::from_seconds(perc_up + perc_down)
 }

--- a/src/platform/math.rs
+++ b/src/platform/math.rs
@@ -1,17 +1,5 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
-        pub mod f64 {
-            #[inline(always)]
-            pub fn abs(x: f64) -> f64 {
-                x.abs()
-            }
-
-            #[inline(always)]
-            pub fn floor(x: f64) -> f64 {
-                x.floor()
-            }
-        }
-
         pub mod f32 {
             #[inline(always)]
             pub fn abs(x: f32) -> f32 {
@@ -24,10 +12,6 @@ cfg_if::cfg_if! {
             }
         }
     } else {
-        pub mod f64 {
-            pub use libm::{fabs as abs, floor};
-        }
-
         pub mod f32 {
             pub use libm::{fabsf as abs, powf};
         }

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -15,41 +15,30 @@ pub enum Accuracy {
 }
 
 impl Accuracy {
-    /// Formats the seconds provided with the chosen accuracy. If there should
-    /// be a zero prefix, the seconds are prefixed with a 0, if they are less
-    /// than 10s.
-    pub const fn format_seconds(self, seconds: f64, zero_prefix: bool) -> FormattedSeconds {
+    /// Formats the nanoseconds provided with the chosen accuracy.
+    pub const fn format_nanoseconds(self, nanoseconds: u32) -> FormattedSeconds {
         FormattedSeconds {
             accuracy: self,
-            seconds,
-            zero_prefix,
+            nanoseconds,
         }
     }
 }
 
-use super::{extract_hundredths, extract_milliseconds, extract_tenths};
 use core::fmt::{Display, Formatter, Result};
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct FormattedSeconds {
     accuracy: Accuracy,
-    seconds: f64,
-    zero_prefix: bool,
+    nanoseconds: u32,
 }
 
 impl Display for FormattedSeconds {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let s = self.seconds as u8;
-        if self.zero_prefix {
-            write!(f, "{s:02}")?;
-        } else {
-            write!(f, "{s}")?;
-        }
         match self.accuracy {
             Accuracy::Seconds => Ok(()),
-            Accuracy::Tenths => write!(f, ".{}", extract_tenths(self.seconds)),
-            Accuracy::Hundredths => write!(f, ".{:02}", extract_hundredths(self.seconds)),
-            Accuracy::Milliseconds => write!(f, ".{:03}", extract_milliseconds(self.seconds)),
+            Accuracy::Tenths => write!(f, ".{}", self.nanoseconds / 100_000_000),
+            Accuracy::Hundredths => write!(f, ".{:02}", self.nanoseconds / 10_000_000),
+            Accuracy::Milliseconds => write!(f, ".{:03}", self.nanoseconds / 1_000_000),
         }
     }
 }

--- a/src/timing/formatter/delta.rs
+++ b/src/timing/formatter/delta.rs
@@ -1,4 +1,4 @@
-use super::{Accuracy, TimeFormatter, DASH, MINUS, PLUS};
+use super::{Accuracy, TimeFormatter, DASH, MINUS, PLUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE};
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
 
@@ -71,42 +71,39 @@ impl TimeFormatter<'_> for Delta {
 impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
-            let mut total_seconds = time.total_seconds();
-            if total_seconds < 0.0 {
-                total_seconds *= -1.0;
-                write!(f, "{MINUS}")?;
+            let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
+            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+                f.write_str(MINUS)?;
+                ((-total_seconds) as u64, (-nanoseconds) as u32)
             } else {
-                write!(f, "{PLUS}")?;
-            }
-            let seconds = total_seconds % 60.0;
-            let total_minutes = (total_seconds / 60.0) as u64;
-            let minutes = total_minutes % 60;
-            let hours = total_minutes / 60;
+                f.write_str(PLUS)?;
+                (total_seconds as u64, nanoseconds as u32)
+            };
+            // These are intentionally not data dependent, such that the CPU can
+            // calculate all of them in parallel. On top of that they are
+            // integer divisions of known constants, which get turned into
+            // multiplies and shifts, which is very fast.
+            let seconds = total_seconds % SECONDS_PER_MINUTE;
+            let minutes = (total_seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
+            let hours = total_seconds / SECONDS_PER_HOUR;
             if hours > 0 {
-                if self.drop_decimals {
-                    write!(f, "{hours}:{minutes:02}:{:02}", seconds as u8)
-                } else {
-                    write!(
-                        f,
-                        "{hours}:{minutes:02}:{}",
-                        self.accuracy.format_seconds(seconds, true)
-                    )
-                }
-            } else if total_minutes > 0 {
-                if self.drop_decimals {
-                    write!(f, "{minutes}:{:02}", seconds as u8)
-                } else {
-                    write!(
-                        f,
-                        "{minutes}:{}",
-                        self.accuracy.format_seconds(seconds, true)
-                    )
-                }
+                write!(f, "{hours}:{minutes:02}:{seconds:02}")?;
+            } else if minutes > 0 {
+                write!(f, "{minutes}:{seconds:02}")?;
             } else {
-                write!(f, "{}", self.accuracy.format_seconds(seconds, false))
+                return write!(
+                    f,
+                    "{seconds}{}",
+                    self.accuracy.format_nanoseconds(nanoseconds)
+                );
+            }
+            if !self.drop_decimals {
+                write!(f, "{}", self.accuracy.format_nanoseconds(nanoseconds))
+            } else {
+                Ok(())
             }
         } else {
-            write!(f, "{DASH}")
+            f.write_str(DASH)
         }
     }
 }

--- a/src/timing/formatter/mod.rs
+++ b/src/timing/formatter/mod.rs
@@ -35,11 +35,8 @@ pub use self::{
     regular::Regular, segment_time::SegmentTime,
 };
 
-use crate::{
-    platform::math::f64::{abs, floor},
-    TimeSpan,
-};
-use core::{cmp::min, fmt::Display};
+use crate::TimeSpan;
+use core::fmt::Display;
 
 /// Time Formatters can be used to format optional Time Spans in various ways.
 pub trait TimeFormatter<'a> {
@@ -53,7 +50,6 @@ pub trait TimeFormatter<'a> {
         T: Into<Option<TimeSpan>>;
 }
 
-const EPSILON: f64 = 0.000_000_1;
 /// The dash symbol to use for generic dashes in text.
 pub const DASH: &str = "—";
 /// The minus symbol to use for negative numbers.
@@ -64,14 +60,6 @@ pub const ASCII_MINUS: &str = "-";
 /// The plus symbol to use for positive numbers.
 pub const PLUS: &str = "+";
 
-fn extract_tenths(seconds: f64) -> u8 {
-    min(9, floor((abs(seconds) % 1.0) * 10.0 + EPSILON) as u8)
-}
-
-fn extract_hundredths(seconds: f64) -> u8 {
-    min(99, floor((abs(seconds) % 1.0) * 100.0 + EPSILON) as u8)
-}
-
-fn extract_milliseconds(seconds: f64) -> u16 {
-    min(999, floor((abs(seconds) % 1.0) * 1000.0 + EPSILON) as u16)
-}
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -1,4 +1,4 @@
-use super::{Accuracy, TimeFormatter, DASH, MINUS};
+use super::{Accuracy, TimeFormatter, DASH, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE};
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
 
@@ -65,30 +65,35 @@ impl TimeFormatter<'_> for Regular {
 impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
-            let mut total_seconds = time.total_seconds();
-            if total_seconds < 0.0 {
-                total_seconds *= -1.0;
-                write!(f, "{MINUS}")?;
-            }
-            let seconds = total_seconds % 60.0;
-            let total_minutes = (total_seconds / 60.0) as u64;
-            let minutes = total_minutes % 60;
-            let hours = total_minutes / 60;
+            let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
+            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+                f.write_str(MINUS)?;
+                ((-total_seconds) as u64, (-nanoseconds) as u32)
+            } else {
+                (total_seconds as u64, nanoseconds as u32)
+            };
+            // These are intentionally not data dependent, such that the CPU can
+            // calculate all of them in parallel. On top of that they are
+            // integer divisions of known constants, which get turned into
+            // multiplies and shifts, which is very fast.
+            let seconds = total_seconds % SECONDS_PER_MINUTE;
+            let minutes = (total_seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
+            let hours = total_seconds / SECONDS_PER_HOUR;
             if hours > 0 {
                 write!(
                     f,
-                    "{hours}:{minutes:02}:{}",
-                    self.accuracy.format_seconds(seconds, true)
+                    "{hours}:{minutes:02}:{seconds:02}{}",
+                    self.accuracy.format_nanoseconds(nanoseconds)
                 )
             } else {
                 write!(
                     f,
-                    "{minutes}:{}",
-                    self.accuracy.format_seconds(seconds, true)
+                    "{minutes}:{seconds:02}{}",
+                    self.accuracy.format_nanoseconds(nanoseconds)
                 )
             }
         } else {
-            write!(f, "{DASH}")
+            f.write_str(DASH)
         }
     }
 }

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -16,14 +16,14 @@ impl TimeSpan {
         Default::default()
     }
 
-    /// Creates a new Time Span from a given amount of milliseconds.
-    pub fn from_milliseconds(milliseconds: f64) -> Self {
-        TimeSpan(Duration::seconds_f64(0.001 * milliseconds))
-    }
-
     /// Creates a new Time Span from a given amount of seconds.
     pub fn from_seconds(seconds: f64) -> Self {
         TimeSpan(Duration::seconds_f64(seconds))
+    }
+
+    /// Creates a new Time Span from a given amount of milliseconds.
+    pub fn from_milliseconds(milliseconds: f64) -> Self {
+        TimeSpan(Duration::seconds_f64(0.001 * milliseconds))
     }
 
     /// Creates a new Time Span from a given amount of days.
@@ -34,6 +34,13 @@ impl TimeSpan {
     /// Converts the Time Span to a Duration from the `time` crate.
     pub const fn to_duration(&self) -> Duration {
         self.0
+    }
+
+    /// Returns the underlying raw seconds and the nanoseconds past the last
+    /// full second that make up the Time Span. This is the most lossless
+    /// representation of a Time Span.
+    pub const fn to_seconds_and_subsec_nanoseconds(&self) -> (i64, i32) {
+        (self.0.whole_seconds(), self.0.subsec_nanoseconds())
     }
 
     /// Returns the total amount of seconds (including decimals) this Time Span


### PR DESCRIPTION
This improves the correctness and the performance of the time formatting by making use of the fact that the underlying times are represented as a pair of integers (seconds and the subsecond nanoseconds). This way instead of formatting the fractional part as a floating point number we already have the fractional part in form of the nanoseconds. On top of that we can improve the performance a little bit by removing the data dependency we introduced by calculating the hours from the total minutes (and so on) when we can just calculate the hours directly from the total seconds. This allows for a little bit of instruction level parallelism where the days, hours, minutes and seconds can all be calculated in parallel.