### PR TITLE
Don't use Floats to Parse Times

### DIFF
--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -106,12 +106,5 @@ impl Display for Inner {
 fn test() {
     let time = "4:20.69".parse::<TimeSpan>().unwrap();
     let formatted = SegmentTime::new().format(time).to_string();
-    // FIXME: The parser should use integer parsing as well, and then this
-    // doesn't need to specialize bad floating point behavior anymore.
-    assert!(
-        // Modern processors
-        formatted == "4:20.69" ||
-        // Old x86 processors are apparently less precise
-        formatted == "4:20.68"
-    );
+    assert_eq!(formatted, "4:20.69");
 }

--- a/src/util/ascii_char.rs
+++ b/src/util/ascii_char.rs
@@ -1,3 +1,5 @@
+use core::iter;
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct AsciiChar(u8);
@@ -14,6 +16,8 @@ impl AsciiChar {
     pub const SINGLE_QUOTE: Self = Self::new(b'\'');
     pub const DOUBLE_QUOTE: Self = Self::new(b'"');
     pub const EQUALITY_SIGN: Self = Self::new(b'=');
+    pub const COLON: Self = Self::new(b':');
+    pub const DOT: Self = Self::new(b'.');
 
     pub const fn new(c: u8) -> Self {
         if c > 127 {
@@ -40,5 +44,22 @@ impl AsciiChar {
         // are looking for ASCII bytes, splitting at the position is guaranteed
         // to be valid UTF-8.
         unsafe { Some((text.get_unchecked(..pos), text.get_unchecked(pos + 1..))) }
+    }
+
+    pub fn split_iter(self, text: &str) -> impl Iterator<Item = &str> {
+        let mut slot = Some(text);
+        iter::from_fn(move || {
+            let rem = slot?;
+            Some(match self.split_once(rem) {
+                Some((before, after)) => {
+                    slot = Some(after);
+                    before
+                }
+                None => {
+                    slot = None;
+                    rem
+                }
+            })
+        })
     }
 }

--- a/src/util/ascii_set.rs
+++ b/src/util/ascii_set.rs
@@ -1,4 +1,4 @@
-use super::{ascii_char::AsciiChar, trim_end};
+use super::ascii_char::AsciiChar;
 
 #[repr(transparent)]
 pub struct AsciiSet([bool; 256]);
@@ -78,7 +78,7 @@ impl AsciiSet {
             // position is found by the find_not method. Also since we only
             // skipped ASCII characters, splitting the string at the position
             // will not result in a string that is not valid UTF-8.
-            trim_end(unsafe { text.get_unchecked(pos..) })
+            self.trim_end(unsafe { text.get_unchecked(pos..) })
         } else {
             ""
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,7 @@
 //! Various utilities used in this crate.
 
+pub(crate) mod ascii_char;
+pub(crate) mod ascii_set;
 pub(crate) mod byte_parsing;
 mod clear_vec;
 pub(crate) mod not_nan;

--- a/src/util/xml/mod.rs
+++ b/src/util/xml/mod.rs
@@ -5,10 +5,6 @@ use core::{
     iter, str,
 };
 
-use self::ascii_char::AsciiChar;
-
-mod ascii_char;
-mod ascii_set;
 pub mod helper;
 mod reader;
 mod writer;
@@ -17,6 +13,8 @@ pub use self::{
     reader::{Event, Reader},
     writer::{AttributeWriter, DisplayValue, Value, Writer, NO_ATTRIBUTES},
 };
+
+use super::{ascii_char::AsciiChar, ascii_set::AsciiSet};
 
 #[derive(Copy, Clone)]
 pub struct Tag<'a>(&'a str);
@@ -64,7 +62,7 @@ impl<'a> Attributes<'a> {
         iter::from_fn(move || {
             rem = trim_start(rem);
             let (key, space_maybe, after) =
-                ascii_set::AsciiSet::EQUALITY_OR_WHITE_SPACE.split_three_way(rem)?;
+                AsciiSet::EQUALITY_OR_WHITE_SPACE.split_three_way(rem)?;
             rem = after;
             if space_maybe.get() != b'=' {
                 rem = trim_start(rem);
@@ -191,19 +189,15 @@ impl<'a> Text<'a> {
 }
 
 fn split_whitespace(rem: &str) -> Option<(&str, &str)> {
-    ascii_set::AsciiSet::WHITE_SPACE.split(rem)
+    AsciiSet::WHITE_SPACE.split(rem)
 }
 
 fn trim(rem: &str) -> &str {
-    ascii_set::AsciiSet::WHITE_SPACE.trim(rem)
+    AsciiSet::WHITE_SPACE.trim(rem)
 }
 
 fn trim_start(rem: &str) -> &str {
-    ascii_set::AsciiSet::WHITE_SPACE.trim_start(rem)
-}
-
-fn trim_end(rem: &str) -> &str {
-    ascii_set::AsciiSet::WHITE_SPACE.trim_end(rem)
+    AsciiSet::WHITE_SPACE.trim_start(rem)
 }
 
 fn parse_hexadecimal(bytes: &str) -> char {

--- a/src/util/xml/reader.rs
+++ b/src/util/xml/reader.rs
@@ -1,4 +1,6 @@
-use super::{ascii_char::AsciiChar, trim, Tag, TagName, Text};
+use crate::util::ascii_char::AsciiChar;
+
+use super::{trim, Tag, TagName, Text};
 
 enum TagState<'a> {
     Closed,

--- a/src/util/xml/writer.rs
+++ b/src/util/xml/writer.rs
@@ -1,6 +1,8 @@
 use core::fmt::{self, Write};
 
-use super::{ascii_char::AsciiChar, ascii_set, Text};
+use crate::util::{ascii_char::AsciiChar, ascii_set::AsciiSet};
+
+use super::Text;
 
 pub struct Writer<T> {
     sink: T,
@@ -173,9 +175,7 @@ pub trait Value {
 
 impl Value for &str {
     fn write_escaped<T: fmt::Write>(mut self, sink: &mut T) -> fmt::Result {
-        while let Some((before, char, rem)) =
-            ascii_set::AsciiSet::CHARACTERS_TO_ESCAPE.split_three_way(self)
-        {
+        while let Some((before, char, rem)) = AsciiSet::CHARACTERS_TO_ESCAPE.split_three_way(self) {
             self = rem;
             sink.write_str(before)?;
             sink.write_str(match char {


### PR DESCRIPTION
We want to be able to perfectly roundtrip a time, and since we already switched to using only integers when formatting a time, we are able to store them in a splits file in full precision, down to the nanosecond. This PR allows us to parse them again without any loss of precision. In the PRs for formatting a time we gained a bunch of speed by switching to the integers. I haven't done any benchmarks here, but improving the parsing speed isn't the point of this PR anyway.