### PR TITLE
Fix Formatting Negative Times

### DIFF
--- a/src/timing/formatter/complete.rs
+++ b/src/timing/formatter/complete.rs
@@ -48,7 +48,7 @@ impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.0 {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
-            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {
                 // Since, this Formatter is used for writing out split files, we
                 // have to use an ASCII Minus here.
                 f.write_str(ASCII_MINUS)?;

--- a/src/timing/formatter/days.rs
+++ b/src/timing/formatter/days.rs
@@ -45,8 +45,8 @@ impl TimeFormatter<'_> for Days {
 impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
-            let total_seconds = time.to_duration().whole_seconds();
-            let total_seconds = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
+            let total_seconds = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
                 (-total_seconds) as u64
             } else {

--- a/src/timing/formatter/delta.rs
+++ b/src/timing/formatter/delta.rs
@@ -74,7 +74,7 @@ impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
-            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
                 ((-total_seconds) as u64, (-nanoseconds) as u32)
             } else {

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -68,7 +68,7 @@ impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
-            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
                 ((-total_seconds) as u64, (-nanoseconds) as u32)
             } else {

--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -66,7 +66,7 @@ impl Display for Inner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
-            let (total_seconds, nanoseconds) = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
                 ((-total_seconds) as u64, (-nanoseconds) as u32)
             } else {

--- a/src/timing/formatter/timer.rs
+++ b/src/timing/formatter/timer.rs
@@ -69,8 +69,8 @@ impl TimeFormatter<'_> for Time {
 impl Display for TimeInner {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(time) = self.time {
-            let total_seconds = time.to_duration().whole_seconds();
-            let total_seconds = if total_seconds < 0 {
+            let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
+            let total_seconds = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
                 (-total_seconds) as u64
             } else {


### PR DESCRIPTION
It turns out that the new formatting code accidentally relied on the fact that the sign for both the seconds and the subsecond nanoseconds are always the same... and they almost always are. The problem is that unlike floating point numbers, integers can't represent a separate positive and negative 0. So if you have 0 seconds, the sign of the nanoseconds actually matters. So you always have to take its sign into account as well.