### PR TITLE
Update some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,19 +63,19 @@ image = { version = "0.24.0", features = [
 # Currently doesn't require any additional dependencies.
 
 # Path-based Text Engine
-rustybuzz = { version = "0.5.1", default-features = false, features = [
+rustybuzz = { version = "0.5.2", default-features = false, features = [
     "libm",
 ], optional = true }
-ttf-parser = { version = "0.15.0", default-features = false, optional = true }
 
 # Font Loading
 font-kit = { version = "0.11.0", optional = true }
 
 # Software Rendering
-tiny-skia = { version = "0.8.1", default-features = false, features = [
+tiny-skia = { version = "0.8.2", default-features = false, features = [
     "no-std-float",
     "simd",
 ], optional = true }
+tiny-skia-path = { version = "0.8.2", default-features = false, optional = true }
 
 # Networking
 splits-io-api = { version = "0.2.0", optional = true }
@@ -129,7 +129,6 @@ std = [
     "time/formatting",
     "time/local-offset",
     "tiny-skia?/std",
-    "ttf-parser?/std",
     "winapi",
 ]
 more-image-formats = [
@@ -145,9 +144,9 @@ more-image-formats = [
 ]
 image-shrinking = ["std", "more-image-formats"]
 rendering = ["more-image-formats", "image?/gif"]
-path-based-text-engine = ["rendering", "rustybuzz", "ttf-parser"]
+path-based-text-engine = ["rendering", "rustybuzz"]
 font-loading = ["std", "path-based-text-engine", "font-kit"]
-software-rendering = ["path-based-text-engine", "tiny-skia"]
+software-rendering = ["path-based-text-engine", "tiny-skia", "tiny-skia-path"]
 wasm-web = [
     "std",
     "js-sys",

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -13,11 +13,11 @@ slotmap = { version = "1.0.2", default-features = false }
 snafu = "0.7.0"
 sysinfo = { version = "0.26.0", default-features = false, features = ["multithread"] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "1.0.0", default-features = false, features = [
+wasmtime = { version = "2.0.0", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = { version = "1.0.0", optional = true }
+wasmtime-wasi = { version = "2.0.0", optional = true }
 
 [features]
 unstable = ["wasmtime-wasi"]

--- a/src/rendering/path_based_text_engine/color_font/mod.rs
+++ b/src/rendering/path_based_text_engine/color_font/mod.rs
@@ -1,9 +1,12 @@
-use ttf_parser::{Face, GlyphId, Tag};
+use rustybuzz::ttf_parser::{Face, GlyphId, Tag};
 
 use crate::settings::Color;
 
 mod colr;
 mod cpal;
+
+const COLR: Tag = Tag::from_bytes(b"COLR");
+const CPAL: Tag = Tag::from_bytes(b"CPAL");
 
 pub struct ColorTables<'f> {
     colr: &'f [u8],
@@ -12,9 +15,10 @@ pub struct ColorTables<'f> {
 
 impl<'f> ColorTables<'f> {
     pub fn new(face: &Face<'f>) -> Option<Self> {
+        let raw_face = face.raw_face();
         Some(Self {
-            colr: face.table_data(Tag::from_bytes(b"COLR"))?,
-            cpal: face.table_data(Tag::from_bytes(b"CPAL"))?,
+            colr: raw_face.table(COLR)?,
+            cpal: raw_face.table(CPAL)?,
         })
     }
 

--- a/src/rendering/path_based_text_engine/mod.rs
+++ b/src/rendering/path_based_text_engine/mod.rs
@@ -13,8 +13,10 @@ use font_kit::{
     source::SystemSource,
 };
 use hashbrown::HashMap;
-use rustybuzz::{Face, Feature, Tag, UnicodeBuffer, Variation};
-use ttf_parser::{GlyphId, OutlineBuilder};
+use rustybuzz::{
+    ttf_parser::{GlyphId, OutlineBuilder},
+    Face, Feature, Tag, UnicodeBuffer, Variation,
+};
 
 use super::{
     font::{TEXT_FONT, TIMER_FONT},


### PR DESCRIPTION
This updates `tiny-skia` to pass ownership of our image buffers, `rustybuzz` to use its reexported `ttf-parser`, and `wasmtime` to `v2.0.0`.