### PR TITLE
Changes Process.with_name to sort pids by id

### DIFF
--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -44,9 +44,17 @@ impl Process {
         process_list.refresh();
         let processes = process_list.processes_by_name(name);
 
-        // Use the process that was started the most recently, it's more
+        // Sorts the processes (asc) by numeric pid, to allow max_by_key to
+        // select the higher pid in case all records are equally maximum; otherwise
+        // use the process that was started the most recently, it's more
         // predictable for the user.
-        let pid = processes
+
+        let mut procs: Vec<&sysinfo::Process> = processes.map(|p| p).collect();
+
+        procs.sort_unstable_by_key(|p| p.pid().as_u32());
+
+        let pid = procs
+            .iter()
             .max_by_key(|p| p.start_time())
             .context(ProcessDoesntExist)?
             .pid()

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -49,13 +49,8 @@ impl Process {
         // use the process that was started the most recently, it's more
         // predictable for the user.
 
-        let mut procs: Vec<&sysinfo::Process> = processes.map(|p| p).collect();
-
-        procs.sort_unstable_by_key(|p| p.pid().as_u32());
-
-        let pid = procs
-            .iter()
-            .max_by_key(|p| p.start_time())
+        let pid = processes
+            .max_by_key(|p| (p.start_time(), p.pid().as_u32()))
             .context(ProcessDoesntExist)?
             .pid()
             .as_u32() as Pid;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -20,5 +20,5 @@ pub use self::{
     image::{CachedImageId, Image, ImageData},
     semantic_color::SemanticColor,
     settings_description::SettingsDescription,
-    value::{Error as ValueError, Result as ValueResult, Value, ColumnKind},
+    value::{ColumnKind, Error as ValueError, Result as ValueResult, Value},
 };


### PR DESCRIPTION
Prior to selecting max key by start time, this change sorts the keys to ascending to take the higher PID in case of all records having an equal `start_time()`

see: https://doc.rust-lang.org/nightly/src/core/iter/traits/iterator.rs.html#3011-3012

This is to fix a case where attempting to attach to steam proton processes on linux may return two PIDs with the same start_time, potentially selecting the wrong pid until a reload happens with the correct pid.

---

Apologies for the lack of tests - I couldn't figure out how to mock things in rust as I dont have access to sysinfo::Process fields

Note: includes a `cargo fmt`

Tested with a custom build of `obs-livesplit-one` and it seems to work perfectly - Have not tested windows; but the obs plugin will need an update.