### PR TITLE
Implement Resolving Key Codes on the Web

### DIFF
--- a/capi/src/hotkey_system.rs
+++ b/capi/src/hotkey_system.rs
@@ -4,9 +4,10 @@
 //! out on platforms that don't support hotkeys. You can turn off a Hotkey
 //! System temporarily. By default the Hotkey System is activated.
 
-use crate::hotkey_config::OwnedHotkeyConfig;
-use crate::shared_timer::OwnedSharedTimer;
-use livesplit_core::HotkeySystem;
+use std::{os::raw::c_char, str::FromStr};
+
+use crate::{hotkey_config::OwnedHotkeyConfig, output_str, shared_timer::OwnedSharedTimer, str};
+use livesplit_core::{hotkey::KeyCode, HotkeySystem};
 
 /// type
 pub type OwnedHotkeySystem = Box<HotkeySystem>;
@@ -67,4 +68,17 @@ pub extern "C" fn HotkeySystem_set_config(
     config: OwnedHotkeyConfig,
 ) -> bool {
     this.set_config(*config).is_ok()
+}
+
+/// Resolves the key according to the current keyboard layout.
+#[no_mangle]
+pub unsafe extern "C" fn HotkeySystem_resolve(
+    this: &HotkeySystem,
+    key_code: *const c_char,
+) -> *const c_char {
+    let name = str(key_code);
+    match KeyCode::from_str(name) {
+        Ok(key_code) => output_str(this.resolve(key_code)),
+        _ => output_str(name),
+    }
 }

--- a/capi/src/title_component_state.rs
+++ b/capi/src/title_component_state.rs
@@ -2,8 +2,7 @@
 
 use super::{output_str, Nullablec_char};
 use livesplit_core::component::title::State as TitleComponentState;
-use std::os::raw::c_char;
-use std::ptr;
+use std::{os::raw::c_char, ptr};
 
 /// type
 pub type OwnedTitleComponentState = Box<TitleComponentState>;
@@ -36,7 +35,7 @@ pub extern "C" fn TitleComponentState_icon_change_len(this: &TitleComponentState
 #[no_mangle]
 pub extern "C" fn TitleComponentState_line1(this: &TitleComponentState) -> *const c_char {
     // FIXME: Add API for querying the abbreviations.
-    output_str(&this.line1.last().unwrap())
+    output_str(this.line1.last().unwrap())
 }
 
 /// By default the category name is shown on the second line. Based on the
@@ -45,9 +44,7 @@ pub extern "C" fn TitleComponentState_line1(this: &TitleComponentState) -> *cons
 #[no_mangle]
 pub extern "C" fn TitleComponentState_line2(this: &TitleComponentState) -> *const Nullablec_char {
     // FIXME: Add API for querying the abbreviations.
-    this.line2
-        .last()
-        .map_or_else(ptr::null, |abbrev| output_str(&abbrev))
+    this.line2.last().map_or_else(ptr::null, output_str)
 }
 
 /// Specifies whether the title should centered or aligned to the left

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -29,6 +29,7 @@ x11-dl = { version = "2.20.0", optional = true }
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.54", optional = true }
 web-sys = { version = "0.3.28", default-features = false, features = ["Gamepad", "GamepadButton", "EventTarget", "KeyboardEvent", "Navigator", "Window"], optional = true }
+js-sys = { version = "0.3.28", default-features = false, optional = true }
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -39,4 +40,4 @@ bitflags = { version = "1.2.1" }
 [features]
 default = ["std"]
 std = ["snafu/std", "serde/std", "evdev", "mio", "nix", "promising-future", "winapi", "x11-dl"]
-wasm-web = ["wasm-bindgen", "web-sys"]
+wasm-web = ["wasm-bindgen", "web-sys", "js-sys"]

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
 use crate::{
-    hotkey::{Hotkey, KeyCode},
+    hotkey::Hotkey,
     platform::prelude::*,
     settings::{Field, SettingsDescription, Value},
 };

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -1,3 +1,6 @@
+use alloc::borrow::Cow;
+use livesplit_hotkey::KeyCode;
+
 use crate::{
     hotkey::{Hook, Hotkey},
     HotkeyConfig, SharedTimer,
@@ -264,5 +267,10 @@ impl HotkeySystem {
         self.set_toggle_timing_method(config.toggle_timing_method)?;
 
         Ok(())
+    }
+
+    /// Resolves the key according to the current keyboard layout.
+    pub fn resolve(&self, key_code: KeyCode) -> Cow<'static, str> {
+        key_code.resolve(&self.hook)
     }
 }

--- a/src/run/parser/speedrun_igt.rs
+++ b/src/run/parser/speedrun_igt.rs
@@ -2,7 +2,6 @@
 
 use alloc::borrow::Cow;
 use serde::Deserialize;
-use snafu::ResultExt;
 use time::Duration;
 
 use crate::{


### PR DESCRIPTION
It was a bit unclear how to deal with the fact that this is an asynchronous API on the web. But fortunately the promise resolves immediately on the next "tick". So as long as we are fine with not being able to resolve key codes on the first tick, we can just pretend it's a synchronous operation by firing off the promise early and then simply using its result in the resolve function. Firing off the promise early however is not that simple either, or at least was. Now that resolving key codes is tied to the `Hook`, the constructor can easily be this early point in time that fires off the promise and then starting with the next tick the resolve function should work perfectly fine.

Resolves #456 as all platforms can now resolve the key codes.