### PR TITLE
Adds types links to docs

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,5 +1,5 @@
 //! The analysis module provides a variety of functions for calculating
-//! information about runs.
+//! information about a [`Run`](crate::run::Run).
 
 pub mod current_pace;
 pub mod delta;

--- a/src/analysis/pb_chance/mod.rs
+++ b/src/analysis/pb_chance/mod.rs
@@ -1,13 +1,15 @@
 //! Provides functionality to calculate the chance to beat the Personal Best for
-//! either a Run or a Timer. For a Run it calculates the general chance to beat
-//! the Personal Best. For a Timer the chance is calculated in terms of the
+//! either a [`Run`](crate::Run) or a [`Timer`](crate::timing::Timer). For a
+//! [`Run`](crate::Run) it calculates the general chance to beat the Personal Best.
+//! For a [`Timer`](crate::timing::Timer) the chance is calculated in terms of the
 //! current attempt. If there is no attempt in progress it yields the same
-//! result as the PB chance for the Run. The value is being reported as a
+//! result as the PB chance for the run. The value is being reported as a
 //! floating point number in the range from 0 (0%) to 1 (100%).
 //!
 //! The PB chance is currently calculated with the skill curve. The PB chance is
 //! the percentile at which the PB is located on the skill curve. This is also
-//! where the Balanced PB would source its split times.
+//! where the [`BalancedPB`](crate::comparison::balanced_pb::BalancedPB) would
+//! source its split times.
 
 use super::SkillCurve;
 use crate::{comparison, timing::Snapshot, Run, Segment, TimeSpan, TimingMethod};
@@ -28,20 +30,20 @@ fn calculate(segments: &[Segment], method: TimingMethod, offset: TimeSpan) -> f6
     comparison::goal::determine_percentile(offset, segments, method, None, &mut SkillCurve::new())
 }
 
-/// Calculates the PB chance for a run. No information about an active attempt
-/// is used. Instead the general chance to beat the Personal Best is calculated.
-/// The value is being reported as a floating point number in the range from 0
-/// (0%) to 1 (100%).
+/// Calculates the PB chance for a [`Run`](crate::Run). No information about
+/// an active attempt is used. Instead the general chance to beat the Personal
+/// Best is calculated. The value is being reported as a floating point number
+/// in the range from 0 (0%) to 1 (100%).
 pub fn for_run(run: &Run, method: TimingMethod) -> f64 {
     calculate(run.segments(), method, TimeSpan::zero())
 }
 
-/// Calculates the PB chance for a timer. The chance is calculated in terms of
-/// the current attempt. If there is no attempt in progress it yields the same
-/// result as the PB chance for the run. The value is being reported as a
-/// floating point number in the range from 0 (0%) to 1 (100%). Additionally a
-/// boolean is returned that indicates if the value is currently actively
-/// changing as time is being lost.
+/// Calculates the PB chance for a [`Timer`](crate::timing::Timer). The chance
+/// is calculated in terms of the current attempt. If there is no attempt in
+/// progress it yields the same result as the PB chance for the run.
+/// The value is being reported as a floating point number in the range
+/// from 0 (0%) to 1 (100%). Additionally a boolean is returned that
+/// indicates if the value is currently actively changing as time is being lost.
 pub fn for_timer(timer: &Snapshot<'_>) -> (f64, bool) {
     let method = timer.current_timing_method();
     let all_segments = timer.run().segments();

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -4,10 +4,12 @@ use core::cmp::Ordering;
 const WEIGHT: f64 = 0.75;
 const TRIES: usize = 50;
 
-/// The skill curve analyzes the segment history across all segments. For each
-/// segment, all the segment times are sorted by length and weighted by their
-/// recency. Plotting this on a graph with the y-axis representing the segment
-/// time and the x-axis representing the percentile, with the shortest time at 0
+/// The skill curve analyzes the [`SegmentHistory`](crate::run::SegmentHistory)
+/// segment history across all segments. For each [`Segment`](crate::run::Segment),
+/// the segment times are sorted by length and weighted by their recency.
+///
+/// Plotting this on a graph with the y-axis representing the segment time and
+/// the x-axis representing the percentile, with the shortest time at 0
 /// and the longest time at 1, yields the so called "skill curve". If you sum
 /// all the different curves together for all the segments, you get the overall
 /// curve for the whole run.
@@ -16,9 +18,10 @@ const TRIES: usize = 50;
 ///
 /// If you sample the curve at 0, you get the simple sum of best segments, and if
 /// you sample the curve at 1, you get the simple sum of worst segments. At 0.5,
-/// you get the median segments. If you sample the individual segments at the same percentile where you
-/// find the Personal Best on the overall run's curve, you get the Balanced PB.
-/// The position of the Balanced PB on the x-axis is the PB chance.
+/// you get the median segments. If you sample the individual segments at the
+/// same percentile where you find the Personal Best on the overall run's curve,
+/// you get the Balanced PB. The position of the Balanced PB on the x-axis is the
+/// PB chance.
 #[derive(Default, Clone)]
 pub struct SkillCurve {
     all_weighted_segment_times: Vec<Vec<(f64, TimeSpan)>>,

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -5,12 +5,13 @@ use crate::{
     Timer, TimerPhase, TimingMethod,
 };
 
-/// Gets the last non-live delta in the run starting from `segment_index`.
+/// Gets the last non-live delta in the [`Run`](crate::Run) starting
+/// from `segment_index`.
 ///
-/// - `run`: The current run.
+/// - `run`: The current [`Run`](crate::Run).
 /// - `segment_index`: The split number to start checking deltas from.
 /// - `comparison`: The comparison that you are comparing with.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the last non-live delta or None if there have been no deltas yet.
 pub fn last_delta(
@@ -156,10 +157,10 @@ fn segment_time(
 
 /// Gets the length of the last segment that leads up to a certain split.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `segment_index`: The index of the split that represents the end of the
 ///   segment.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the length of the segment leading up to `segment_index`, returning
 /// None if the split is not completed yet.
@@ -180,10 +181,10 @@ pub fn previous_segment_time(
 /// Gets the length of the last segment that leads up to a certain split, using
 /// the live segment time if the split is not completed yet.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `segment_index`: The index of the split that represents the end of the
 ///   segment.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the length of the segment leading up to `segment_index`, returning
 /// the live segment time if the split is not completed yet.
@@ -203,10 +204,10 @@ pub fn live_segment_time(
 
 /// Gets the amount of time lost or gained on a certain split.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `segment_index`: The index of the split for which the delta is calculated.
 /// - `comparison`: The comparison that you are comparing with.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the segment delta for a certain split, returning None if the split
 /// is not completed yet.
@@ -228,10 +229,10 @@ pub fn previous_segment_delta(
 /// Gets the amount of time lost or gained on a certain split, using the live
 /// segment delta if the split is not completed yet.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `segment_index`: The index of the split for which the delta is calculated.
 /// - `comparison`: The comparison that you are comparing with.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the segment delta for a certain split, returning the live segment
 /// delta if the split is not completed yet.
@@ -252,12 +253,12 @@ pub fn live_segment_delta(
 
 /// Checks whether the live segment should now be shown.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `split_delta`: Specifies whether to return a split delta
 ///    rather than a segment delta and to start showing the live
 ///    segment once you are behind.
 /// - `comparison`: The comparison that you are comparing with.
-/// - `method`: The timing method that you are using.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) that you are using.
 ///
 /// Returns the current live delta.
 pub fn check_live_delta(
@@ -294,16 +295,17 @@ pub fn check_live_delta(
     None
 }
 
-/// Chooses a split color from the Layout Settings based on the current run.
+/// Chooses a split color from the [`LayoutSettings`](crate::layout::LayoutSettings)
+/// based on the current run.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `time_difference`: The delta that you want to find a color for.
 /// - `segment_index`: The split number that is associated with this delta.
 /// - `show_segment_deltas`: Can show ahead gaining and behind losing colors if
 ///    true.
 /// - `show_best_segments`: Can show the best segment color if true.
 /// - `comparison`: The comparison that you are comparing this delta to.
-/// - `method`: The timing method of this delta.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) of this delta.
 ///
 /// Returns the chosen color.
 pub fn split_color(
@@ -340,9 +342,9 @@ pub fn split_color(
 /// Calculates whether or not the Split Times for the indicated split qualify as
 /// a Best Segment.
 ///
-/// - `timer`: The current timer.
+/// - `timer`: The current [`Timer`](crate::timing::Timer).
 /// - `segment_index`: The split to check.
-/// - `method`: The timing method to use.
+/// - `method`: The [`TimingMethod`](crate::timing::TimingMethod) to use.
 ///
 /// Returns whether or not the indicated split is a Best Segment.
 pub fn check_best_segment(timer: &Timer, segment_index: usize, method: TimingMethod) -> bool {

--- a/src/analysis/sum_of_segments/best.rs
+++ b/src/analysis/sum_of_segments/best.rs
@@ -1,6 +1,6 @@
 //! Provides functionality for calculating the Sum of Best Segments for whole
-//! runs or specific parts. The Sum of Best Segments is the fastest time
-//! possible to complete a run of a category, based on information collected
+//! [`Run`](crate::Run) or specific parts. The Sum of Best Segments is the fastest
+//! time possible to complete a run of a category, based on information collected
 //! from all the previous attempts. This often matches up with the sum of the
 //! best segment times of all the segments, but that may not always be the case,
 //! as skipped segments may introduce combined segments that may be faster than
@@ -81,24 +81,27 @@ fn populate_predictions(
 }
 
 /// Calculates the Sum of Best Segments for the timing method provided. This is
-/// the fastest time possible to complete a run of a category, based on
-/// information collected from all the previous attempts. This often matches up
-/// with the sum of the best segment times of all the segments, but that may not
-/// always be the case, as skipped segments may introduce combined segments that
-/// may be faster than the actual sum of their best segment times. The name is
-/// therefore a bit misleading, but sticks around for historical reasons. You
-/// can choose to do a simple calculation instead, which excludes the Segment
-/// History from the calculation process. If there's an active attempt, you can
-/// choose to take it into account as well. This lower level function requires
-/// you to provide a buffer to fill up with the shortest paths to reach each of
-/// the segments. This means that the first segment will always be reached at a
-/// time of 0:00. However, if you are interested in the total Sum of Best
-/// Segments, then you can't look at the predictions value with the index of the
-/// last segment, as that only tells you what the best time to reach that
-/// segment is, not the best time to complete it. This means that the
-/// predictions buffer needs to have one more element than the list of segments
-/// provided, so that you can properly query the total Sum of Best Segments.
-/// This value is also the value that is being returned.
+/// the fastest time possible to complete a [`Run`](crate::Run) of a category,
+/// based on information collected from all the previous attempts.
+///
+/// This often matches up with the sum of the best segment times of all the
+/// segments, but that may not always be the case, as skipped segments may
+/// introduce combined segments that may be faster than the actual sum of their
+/// best segment times.
+///
+/// The name is therefore a bit misleading, but sticks around for historical
+/// reasons. You can choose to do a simple calculation instead, which excludes
+/// the Segment History from the calculation process. If there's an active
+/// attempt, you can choose to take it into account as well. This lower level
+/// function requires you to provide a buffer to fill up with the shortest
+/// paths to reach each of the segments. This means that the first segment
+/// will always be reached at a time of 0:00. However, if you are interested
+/// in the total Sum of Best Segments, then you can't look at the predictions
+/// value with the index of the last segment, as that only tells you what the
+/// best time to reach that segment is, not the best time to complete it. This
+/// means that the predictions buffer needs to have one more element than the
+/// list of segments provided, so that you can properly query the total Sum of
+/// Best Segments. This value is also the value that is being returned.
 #[allow(clippy::needless_range_loop)]
 pub fn calculate(
     segments: &[Segment],

--- a/src/analysis/sum_of_segments/worst.rs
+++ b/src/analysis/sum_of_segments/worst.rs
@@ -1,7 +1,7 @@
 //! Provides functionality for calculating the Sum of Worst Segments for whole
-//! runs or specific parts. The Sum of Worst Segments is the slowest time
-//! possible to complete a run of a category, based on information collected
-//! from all the previous attempts. This obviously isn't really the worst
+//! [`Run`](crate::Run) or specific parts. The Sum of Worst Segments is the
+//! slowest time possible to complete a run of a category, based on information
+//! collected from all the previous attempts. This obviously isn't really the worst
 //! possible time, but may be useful information regardless.
 
 use super::{track_branch, track_current_run, track_personal_best_run, Prediction};

--- a/src/analysis/total_playtime.rs
+++ b/src/analysis/total_playtime.rs
@@ -1,9 +1,9 @@
-//! Provides functionality to calculate the total playtime for either a Run or a
-//! Timer. For a Run, all the durations stored in the Attempt History are summed
-//! together. For a Timer, the current attempt's duration is also factored in.
+//! Provides functionality to calculate the total playtime for either a
+//! [`Run`] or a [`Timer`]. For a [`Run`], all the durations stored in the attempt
+//! history are summed together. For a [`Timer`], the current attempt's duration
+//! is also factored in.
 
 use crate::{Run, TimeSpan, Timer, TimingMethod};
-
 /// Allows calculating the total playtime.
 pub trait TotalPlaytime {
     /// Calculates the total playtime.
@@ -56,8 +56,8 @@ impl<'a, T: 'a + TotalPlaytime> TotalPlaytime for &'a T {
     }
 }
 
-/// Calculates the total playtime. The source can be a `Run`, `Timer` or any
-/// other type that implements the `TotalPlaytime` trait.
+/// Calculates the total playtime. The source can be a [`Run`], [`Timer`] or any
+/// other type that implements the [`TotalPlaytime`] trait.
 pub fn calculate<T: TotalPlaytime>(source: T) -> TimeSpan {
     source.total_playtime()
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -1,5 +1,5 @@
 //! The auto splitting module provides a runtime for running auto splitters that
-//! can control the timer. These auto splitters are provided as WebAssembly
+//! can control the [`Timer`](crate::timing::Timer). These auto splitters are provided as WebAssembly
 //! modules.
 //!
 //! # Requirements for the Auto Splitters
@@ -241,8 +241,8 @@ enum Request {
     UnloadScript(oneshot::Sender<()>),
 }
 
-// This newtype is required because SharedTimer is an Arc<RwLock<T>>, so we
-// can't implement the trait directly on it.
+// This newtype is required because [`SharedTimer`](crate::timing::SharedTimer)
+// is an Arc<RwLock<T>>, so we can't implement the trait directly on it.
 struct Timer(SharedTimer);
 
 impl AutoSplitTimer for Timer {

--- a/src/comparison/average_segments.rs
+++ b/src/comparison/average_segments.rs
@@ -1,16 +1,17 @@
 //! Defines the Comparison Generator for calculating the Average Segments of a
-//! Run. The Average Segments are calculated through a weighted arithmetic mean
-//! that gives more recent segments a larger weight so that the Average
-//! Segments are more suited to represent the current performance of a
-//! runner.
+//! [`Run`](crate::Run). The Average Segments are calculated through a
+//! weighted arithmetic mean that gives more recent segments a larger
+//! weight so that the Average Segments are more suited to represent
+//! the current performance of a runner.
 
 use super::ComparisonGenerator;
 use crate::{Attempt, Segment, TimeSpan, TimingMethod};
 
-/// The Comparison Generator for calculating the Average Segments of a Run. The
-/// Average Segments are calculated through a weighted arithmetic mean that
-/// gives more recent segments a larger weight so that the Average Segments are
-/// more suited to represent the current performance of a runner.
+/// The Comparison Generator for calculating the Average Segments of a
+/// [`Run`](crate::Run). The Average Segments are calculated through a weighted
+/// arithmetic mean that gives more recent segments a larger weight so that
+/// the Average Segments are more suited to represent the current performance
+/// of a runner.
 #[derive(Copy, Clone, Debug)]
 pub struct AverageSegments;
 

--- a/src/comparison/best_segments.rs
+++ b/src/comparison/best_segments.rs
@@ -1,4 +1,5 @@
-//! Defines the Comparison Generator for calculating the Best Segments of a Run.
+//! Defines the Comparison Generator for calculating the Best Segments of a
+//! [`Run`](crate::Run).
 
 use super::ComparisonGenerator;
 use crate::{
@@ -6,7 +7,8 @@ use crate::{
     TimingMethod,
 };
 
-/// The Comparison Generator for calculating the Best Segments of a Run.
+/// Defines the Comparison Generator for calculating the Best Segments of a
+/// [`Run`](crate::Run).
 #[derive(Copy, Clone, Debug)]
 pub struct BestSegments;
 

--- a/src/comparison/latest_run.rs
+++ b/src/comparison/latest_run.rs
@@ -1,5 +1,6 @@
-//! Defines the Comparison Generator for calculating the Latest Run. Using the
-//! Segment History, this comparison reconstructs the splits of the furthest,
+//! Defines the Comparison Generator for calculating the Latest
+//! [`Run`](crate::Run). Using the [`SegmentHistory`](crate::run::SegmentHistory),
+//! this comparison reconstructs the splits of the furthest,
 //! most recent attempt. If at least one attempt has been finished, this
 //! comparison will show the most recent finished attempt. If no attempts have
 //! been finished yet, this comparison will show the attempt that got the
@@ -8,8 +9,9 @@
 use super::ComparisonGenerator;
 use crate::{Attempt, Segment, TimeSpan, TimingMethod};
 
-/// The Comparison Generator for calculating the Latest Run. Using the
-/// Segment History, this comparison reconstructs the splits of the furthest,
+/// Defines the Comparison Generator for calculating the Latest
+/// [`Run`](crate::Run). Using the [`SegmentHistory`](crate::run::SegmentHistory),
+/// this comparison reconstructs the splits of the furthest,
 /// most recent attempt. If at least one attempt has been finished, this
 /// comparison will show the most recent finished attempt. If no attempts have
 /// been finished yet, this comparison will show the attempt that got the

--- a/src/comparison/median_segments.rs
+++ b/src/comparison/median_segments.rs
@@ -1,15 +1,15 @@
 //! Defines the Comparison Generator for calculating the Median Segments of a
-//! Run. The Median Segments are calculated through a weighted median that gives
-//! more recent segments a larger weight so that the Median Segments are more
-//! suited to represent the current performance of a runner.
+//! [`Run`](crate::Run). The Median Segments are calculated through a weighted
+//! median that gives more recent segments a larger weight so that the
+//! Median Segments are more suited to represent the current performance of a runner.
 
 use super::ComparisonGenerator;
 use crate::{platform::prelude::*, Attempt, Segment, TimeSpan, TimingMethod};
 
-/// The Comparison Generator for calculating the Median Segments of a Run. The
-/// Median Segments are calculated through a weighted median that gives more
-/// recent segments a larger weight so that the Median Segments are more suited
-/// to represent the current performance of a runner.
+/// Defines the Comparison Generator for calculating the Median Segments of a
+/// [`Run`](crate::Run). The Median Segments are calculated through a weighted
+/// median that gives more recent segments a larger weight so that the
+/// Median Segments are more suited to represent the current performance of a runner.
 #[derive(Copy, Clone, Debug)]
 pub struct MedianSegments;
 

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -1,7 +1,6 @@
 //! The comparison module provides all the different automatically generated
-//! comparisons, like the Best Segments and the Average Segments. Additionally,
-//! functions for dealing with comparisons, like shortening a comparison, are
-//! provided.
+//! comparisons, like [`BestSegments`](crate::comparison::best_segments::BestSegments) and [`AverageSegments`](crate::comparison::average_segments::AverageSegments).
+//! Additionally, functions for dealing with comparisons, like shortening a comparison, are provided.
 
 #[cfg(test)]
 mod tests;

--- a/src/comparison/none.rs
+++ b/src/comparison/none.rs
@@ -1,4 +1,4 @@
-//! Defines the Comparison Generator for the None comparison. The None
+//! Defines the Comparison Generator for the `None` comparison. The `None`
 //! Comparison intentionally leaves all split times empty.
 
 use super::ComparisonGenerator;

--- a/src/comparison/worst_segments.rs
+++ b/src/comparison/worst_segments.rs
@@ -1,4 +1,5 @@
-//! Defines the Comparison Generator for calculating the Worst Segments of a Run.
+//! Defines the Comparison Generator for calculating the Worst Segments of a
+//! [`Run`](crate::Run).
 
 use super::ComparisonGenerator;
 use crate::{
@@ -6,7 +7,7 @@ use crate::{
     TimingMethod,
 };
 
-/// The Comparison Generator for calculating the Worst Segments of a Run.
+/// The Comparison Generator for calculating the Worst Segments of a [`Run`](crate::Run).
 #[derive(Copy, Clone, Debug)]
 pub struct WorstSegments;
 

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -1,5 +1,5 @@
-//! The component module provides all the different components available. A
-//! Component allows querying different kinds of information from a Timer. This
+//! The component module provides all available components.
+//! A [`Component`](crate::layout::Component) allows querying different kinds of information from a [`Timer`](crate::Timer). This
 //! information is provided as state objects in a way that can easily be
 //! visualized by any kind of User Interface.
 

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -1,9 +1,10 @@
 //! Provides the Previous Segment Component and relevant types for using it. The
 //! Previous Segment Component is a component that shows how much time was saved
-//! or lost during the previous segment based on the chosen comparison.
-//! Additionally, the potential time save for the previous segment can be
-//! displayed. This component switches to a `Live Segment` view that shows
-//! active time loss whenever the runner is losing time on the current segment.
+//! or lost during the previous [`Segment`](crate::run::Segment) based on the
+//! chosen comparison. Additionally, the potential time save for the previous
+//! [`Segment`](crate::run::Segment) can be displayed. This component switches
+//! to a `Live Segment` view that shows active time loss whenever the runner is
+//! losing time on the current [`Segment`](crate::run::Segment).
 
 use super::key_value;
 use crate::{
@@ -21,10 +22,11 @@ use core::fmt::Write as FmtWrite;
 use serde::{Deserialize, Serialize};
 
 /// The Previous Segment Component is a component that shows how much time was
-/// saved or lost during the previous segment based on the chosen comparison.
-/// Additionally, the potential time save for the previous segment can be
-/// displayed. This component switches to a `Live Segment` view that shows
-/// active time loss whenever the runner is losing time on the current segment.
+/// saved or lost during the previous [`Segment`](crate::run::Segment) based on
+/// the chosen comparison. Additionally, the potential time save for the previous
+/// [`Segment`](crate::run::Segment) can be displayed. This component switches
+/// to a `Live Segment` view that shows active time loss whenever the runner is
+/// losing time on the current [`Segment`](crate::run::Segment).
 #[derive(Default, Clone)]
 pub struct Component {
     settings: Settings,

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -1,9 +1,9 @@
 //! Provides the Splits Component and relevant types for using it. The Splits
 //! Component is the main component for visualizing all the split times. Each
-//! segment is shown in a tabular fashion showing the segment icon, segment
-//! name, the delta compared to the chosen comparison, and the split time. The
-//! list provides scrolling functionality, so not every segment needs to be
-//! shown all the time.
+//! Each [`Segment`](crate::run::Segment) is shown in a tabular fashion showing
+//! the segment icon, segment name, the delta compared to the chosen comparison,
+//! and the split time. The list provides scrolling functionality, so not every
+//! [`Segment`](crate::run::Segment) needs to be shown all the time.
 
 use crate::{
     platform::prelude::*,
@@ -33,9 +33,10 @@ const SETTINGS_PER_TIME_COLUMN: usize = 6;
 const SETTINGS_PER_VARIABLE_COLUMN: usize = 2;
 
 /// The Splits Component is the main component for visualizing all the split
-/// times. Each segment is shown in a tabular fashion showing the segment icon,
-/// segment name, the delta compared to the chosen comparison, and the split
-/// time. The list provides scrolling functionality, so not every segment needs
+/// times. Each [`Segment`](crate::run::Segment) is shown in a tabular fashion
+/// showing the segment icon, segment name, the delta compared to the chosen
+/// comparison, and the split time.
+/// The list provides scrolling functionality, so not every segment needs
 /// to be shown all the time.
 #[derive(Default, Clone)]
 pub struct Component {

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -1,4 +1,4 @@
-//! Provides the Timer Component and relevant types for using it. The Timer
+//! Provides the `Timer` Component and relevant types for using it. The `Timer`
 //! Component is a component that shows the total time of the current attempt as
 //! a digital clock. The color of the time shown is based on a how well the
 //! current attempt is doing compared to the chosen comparison.
@@ -16,7 +16,7 @@ use crate::{
 use core::fmt::Write;
 use serde::{Deserialize, Serialize};
 
-/// The Timer Component is a component that shows the total time of the current
+/// The `Timer` Component is a component that shows the total time of the current
 /// attempt as a digital clock. The color of the time shown is based on a how
 /// well the current attempt is doing compared to the chosen comparison.
 #[derive(Default, Clone)]

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The configuration to use for a Hotkey System. It describes with keys to use
-/// as hotkeys for the different actions.
+/// The configuration to use for a [`HotkeySystem`](crate::HotkeySystem). It describes which [`Hotkey`](livesplit_hotkey::Hotkey) to use as hotkeys for the different actions.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(default)]
 pub struct HotkeyConfig {

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -82,11 +82,11 @@ impl Action {
     }
 }
 
-/// With a Hotkey System the runner can use hotkeys on their keyboard to control
+/// With a `HotkeySystem` the runner can use hotkeys on their keyboard to control
 /// the Timer. The hotkeys are global, so the application doesn't need to be in
 /// focus. The behavior of the hotkeys depends on the platform and is stubbed
-/// out on platforms that don't support hotkeys. You can turn off a Hotkey
-/// System temporarily. By default the Hotkey System is activated.
+/// out on platforms that don't support hotkeys. You can turn off a `HotkeySystem`
+/// temporarily. By default the `HotkeySystem` is activated.
 pub struct HotkeySystem {
     config: HotkeyConfig,
     hook: Hook,

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 
-/// A Component provides information about a run in a way that is easy to
+/// A `Component` provides information about a run in a way that is easy to
 /// visualize. This type can store any of the components provided by this crate.
 #[derive(Clone)]
 pub enum Component {

--- a/src/layout/editor/mod.rs
+++ b/src/layout/editor/mod.rs
@@ -1,5 +1,5 @@
-//! The editor module provides an editor for Layouts. The editor ensures that
-//! all the different invariants of the Layout objects are upheld no matter what
+//! The editor module provides an editor for a [`Layout`]. The editor ensures that
+//! all the different invariants of the [`Layout`] objects are upheld no matter what
 //! kind of operations are being applied. It provides the current state of the
 //! editor as state objects that can be visualized by any kind of User
 //! Interface.
@@ -12,8 +12,8 @@ mod state;
 
 pub use self::state::{Buttons as ButtonsState, State};
 
-/// The Layout Editor allows modifying Layouts while ensuring all the different
-/// invariants of the Layout objects are upheld no matter what kind of
+/// The Layout Editor allows modifying a [`Layout`] while ensuring all the different
+/// invariants of the [`Layout`] objects are upheld no matter what kind of
 /// operations are being applied. It provides the current state of the editor as
 /// state objects that can be visualized by any kind of User Interface.
 pub struct Editor {

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The general settings of the layout that apply to all components.
+/// The general settings of a [`Layout`](crate::layout::Layout) that apply to all components.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GeneralSettings {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,5 +1,6 @@
-//! The layout module provides everything necessary for working with Layouts. A
-//! Layout allows you to combine multiple components together to visualize a
+//! The layout module provides everything necessary for working with a
+//! [`Layout`](crate::layout::Layout). A [`Layout`](crate::layout::Layout)
+//! allows you to combine multiple components together to visualize a
 //! variety of information the runner is interested in.
 
 mod component;

--- a/src/run/attempt.rs
+++ b/src/run/attempt.rs
@@ -1,8 +1,8 @@
 use crate::{AtomicDateTime, Time, TimeSpan};
 
-/// An Attempt describes information about an attempt to run a specific category
+/// An `Attempt` describes information about an attempt to run a specific category
 /// by a specific runner in the past. Every time a new attempt is started and
-/// then reset, an Attempt describing general information about it is created.
+/// then reset, an `Attempt` describing general information about it is created.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Attempt {
     index: i32,
@@ -13,7 +13,7 @@ pub struct Attempt {
 }
 
 impl Attempt {
-    /// Creates a new Attempt, logging an attempt to speedrun a category. You
+    /// Creates a new `Attempt`, logging an attempt to speedrun a category. You
     /// need the provide a unique index for the attempt (The index needs to be
     /// unique for the Run, not across all the Run objects). Additionally you
     /// provide the split time of the last segment. If it is empty, the attempt

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -1,6 +1,6 @@
-//! The editor module provides an editor for Run objects. The editor ensures
-//! that all the different invariants of the Run objects are upheld no matter
-//! what kind of operations are being applied to the Run. It provides the
+//! The editor module provides an editor for [`Run`] objects. The editor ensures
+//! that all the different invariants of the [`Run`] objects are upheld no matter
+//! what kind of operations are being applied to the [`Run`]. It provides the
 //! current state of the editor as state objects that can be visualized by any
 //! kind of User Interface.
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,5 +1,4 @@
-//! The run module provides everything necessary for working with Runs, like
-//! parsing and saving or editing them.
+//! The run module provides everything necessary for working with a `Run`, like parsing and saving or editing them.
 //!
 //! # Examples
 //!

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -47,8 +47,8 @@ impl CustomVariable {
     }
 }
 
-/// The Run Metadata stores additional information about a run, like the
-/// platform and region of the game. All of this information is optional.
+/// The `RunMetadata` struct stores optional information about a run, like the
+/// platform and region of the game.
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunMetadata {
     /// The speedrun.com Run ID of the run. You need to ensure that the record

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -6,8 +6,8 @@ use crate::{
     SegmentHistory, Time, TimeSpan, TimingMethod,
 };
 
-/// A Segment describes a point in a speedrun that is suitable for storing a
-/// split time. This stores the name of that segment, an icon, the split times
+/// A `Segment` describes a point in a speedrun that is suitable for storing a
+/// split time. This stores the name of that `Segment`, an icon, the split times
 /// of different comparisons, and a history of segment times.
 ///
 /// # Examples

--- a/src/run/segment_history.rs
+++ b/src/run/segment_history.rs
@@ -4,10 +4,11 @@ use core::{
     slice::{Iter, IterMut},
 };
 
-/// Stores the segment times achieved for a certain segment. Each segment is
-/// tagged with an index. Only segment times with an index larger than 0 are
-/// considered times actually achieved by the runner, while the others are
-/// artifacts of route changes and similar algorithmic changes.
+/// Stores the [`Segment`](crate::Segment) times achieved for a certain segment.
+/// Each [`Segment`](crate::Segment) is tagged with an index. Only segment times
+/// with an index larger than 0 are considered times actually achieved by the
+/// runner, while the others are artifacts of route changes and similar
+/// algorithmic changes.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct SegmentHistory(Vec<(i32, Time)>);
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,5 +1,5 @@
-//! The settings module provides the ability to customize components and various
-//! other settings.
+//! The `Settings` module provides the ability to customize a
+//! [`Component`](crate::layout::Component) and various other settings.
 
 mod alignment;
 mod color;

--- a/src/settings/semantic_color.rs
+++ b/src/settings/semantic_color.rs
@@ -2,7 +2,7 @@ use super::Color;
 use crate::layout;
 use serde::{Deserialize, Serialize};
 
-/// A Semantic Color describes a color by some meaningful event that is
+/// A `SemanticColor` describes a color by some meaningful event that is
 /// happening. This information can be visualized as a color, but can also be
 /// interpreted in other ways by the consumer of this API.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/timing/atomic_date_time.rs
+++ b/src/timing/atomic_date_time.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use core::ops::Sub;
 
-/// An Atomic Date Time represents a UTC Date Time that tries to be as close to
+/// An Atomic Date Time represents a UTC [`DateTime`] that tries to be as close to
 /// an atomic clock as possible.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AtomicDateTime {

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -5,7 +5,7 @@ use core::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The Accuracy describes how many digits to show for the fractional part of a
+/// The `Accuracy` describes how many digits to show for the fractional part of a
 /// time.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum Accuracy {

--- a/src/timing/formatter/complete.rs
+++ b/src/timing/formatter/complete.rs
@@ -7,7 +7,7 @@ use core::fmt::{Display, Formatter, Result};
 
 pub struct Inner(Option<TimeSpan>);
 
-/// The Complete Time Formatter formats Time Spans in a way that preserves as
+/// The Complete Time Formatter formats a [`TimeSpan`] in a way that preserves as
 /// much information as possible. The hours and minutes are always shown and a
 /// fractional part of 9 digits is used. If there's >24h, then a day prefix is
 /// attached (with the hours wrapping around to 0): `dd.hh:mm:ss.fffffffff`

--- a/src/timing/formatter/days.rs
+++ b/src/timing/formatter/days.rs
@@ -8,7 +8,7 @@ pub struct Inner {
     time: Option<TimeSpan>,
 }
 
-/// The Days Time Formatter formats Time Spans so that times >24h are prefixed
+/// The Days Time Formatter formats a [`TimeSpan`] so that times >24h are prefixed
 /// with the amount of days, wrapping the hours around to 0. There's no
 /// fractional part for times. The minutes are always shown.
 ///

--- a/src/timing/formatter/delta.rs
+++ b/src/timing/formatter/delta.rs
@@ -10,7 +10,7 @@ pub struct Inner {
     accuracy: Accuracy,
 }
 
-/// The Delta Time Formatter formats Time Spans as a comparison of two
+/// The Delta Time Formatter formats a [`TimeSpan`] as a comparison of two
 /// durations, so that it visualizes the difference between both of them.
 /// Therefore it always shows whether it is a positive or negative difference,
 /// by prepending a plus or minus sign. You can choose how many digits of the

--- a/src/timing/formatter/mod.rs
+++ b/src/timing/formatter/mod.rs
@@ -1,5 +1,5 @@
 //! The formatter module provides different Time Formatters that can be used to
-//! format optional Time Spans in various ways.
+//! format a [`TimeSpan`] Option in various ways.
 //!
 //! # Examples
 //!

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -9,7 +9,7 @@ pub struct Inner {
     accuracy: Accuracy,
 }
 
-/// The Regular Time Formatter formats Time Spans to always show the minutes and
+/// The Regular Time Formatter formats a [`TimeSpan`] to always show the minutes and
 /// is configurable by how many digits of the fractional part are shown. By
 /// default no fractional part is shown. This Time Formatter is most suitable
 /// for visualizing split times.

--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -9,7 +9,7 @@ pub struct Inner {
     accuracy: Accuracy,
 }
 
-/// The Segment Time Formatter formats Time Spans for them to be shown as
+/// The Segment Time Formatter formats a [`TimeSpan`] for them to be shown as
 /// Segment Times. This specifically means that the fractional part of the time
 /// is always shown and the minutes and hours are only shown when necessary. The
 /// default accuracy is to show 2 digits of the fractional part, but this can be

--- a/src/timing/time.rs
+++ b/src/timing/time.rs
@@ -71,7 +71,7 @@ impl Time {
     }
 }
 
-/// Represents a Time Span intended to be used as a Real Time.
+/// Represents a [`TimeSpan`](crate::TimeSpan) intended to be used for describing real time.
 pub struct RealTime(pub Option<TimeSpan>);
 
 impl From<RealTime> for Time {
@@ -80,7 +80,7 @@ impl From<RealTime> for Time {
     }
 }
 
-/// Represents a Time Span intended to be used as a Game Time.
+/// Represents a [`TimeSpan`](crate::TimeSpan) intended to be used for describing game time.
 pub struct GameTime(pub Option<TimeSpan>);
 
 impl From<GameTime> for Time {

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -9,57 +9,57 @@ use core::{
 };
 use snafu::{ensure, OptionExt, ResultExt};
 
-/// A Time Span represents a certain span of time.
+/// A `TimeSpan` represents a certain span of time.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TimeSpan(Duration);
 
 impl TimeSpan {
-    /// Creates a new Time Span of zero length.
+    /// Creates a new `TimeSpan` of zero length.
     pub const fn zero() -> Self {
         Self(Duration::ZERO)
     }
 
-    /// Creates a new Time Span from a given amount of seconds.
+    /// Creates a new `TimeSpan` from a given amount of seconds.
     pub fn from_seconds(seconds: f64) -> Self {
         Self(Duration::seconds_f64(seconds))
     }
 
-    /// Creates a new Time Span from a given amount of milliseconds.
+    /// Creates a new `TimeSpan` from a given amount of milliseconds.
     pub fn from_milliseconds(milliseconds: f64) -> Self {
         Self(Duration::seconds_f64(0.001 * milliseconds))
     }
 
-    /// Creates a new Time Span from a given amount of days.
+    /// Creates a new `TimeSpan` from a given amount of days.
     pub fn from_days(days: f64) -> Self {
         Self(Duration::seconds_f64(days * (24.0 * 60.0 * 60.0)))
     }
 
-    /// Converts the Time Span to a Duration from the `time` crate.
+    /// Converts the `TimeSpan` to a `Duration` from the `time` crate.
     pub const fn to_duration(&self) -> Duration {
         self.0
     }
 
     /// Returns the underlying raw seconds and the nanoseconds past the last
-    /// full second that make up the Time Span. This is the most lossless
-    /// representation of a Time Span.
+    /// full second that make up the `TimeSpan`. This is the most lossless
+    /// representation of a `TimeSpan`.
     pub const fn to_seconds_and_subsec_nanoseconds(&self) -> (i64, i32) {
         (self.0.whole_seconds(), self.0.subsec_nanoseconds())
     }
 
-    /// Returns the total amount of seconds (including decimals) this Time Span
+    /// Returns the total amount of seconds (including decimals) this `TimeSpan`
     /// represents.
     pub fn total_seconds(&self) -> f64 {
         self.0.as_seconds_f64()
     }
 
-    /// Returns the total amount of milliseconds (including decimals) this Time
-    /// Span represents.
+    /// Returns the total amount of milliseconds (including decimals) this
+    /// `TimeSpan` represents.
     pub fn total_milliseconds(&self) -> f64 {
         1_000.0 * self.total_seconds()
     }
 
-    /// Parses an optional Time Span from a given textual representation of the
-    /// Time Span. If the given text consists entirely of whitespace or is
+    /// Parses an optional `TimeSpan` from a given textual representation of the
+    /// `TimeSpan`. If the given text consists entirely of whitespace or is
     /// empty, `None` is returned.
     pub fn parse_opt(text: &str) -> Result<Option<TimeSpan>, ParseError> {
         if text.trim().is_empty() {
@@ -70,11 +70,11 @@ impl TimeSpan {
     }
 }
 
-/// The Error type for Time Spans that couldn't be parsed.
+/// The Error type for a `TimeSpan` that couldn't be parsed.
 #[derive(Debug, snafu::Snafu)]
 #[snafu(context(suffix(false)))]
 pub enum ParseError {
-    /// An empty string is not a valid Time Span.
+    /// An empty string is not a valid `TimeSpan`.
     Empty,
     /// The time is too large to be represented.
     Overflow,

--- a/src/timing/time_stamp.rs
+++ b/src/timing/time_stamp.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 use core::ops::Sub;
 
-/// A Time Stamp stores a point in time, that can be used to calculate Time
-/// Spans.
+/// A `TimeStamp` stores a point in time that can be used to calculate a
+/// [`TimeSpan`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TimeStamp(Instant);
 
 impl TimeStamp {
-    /// Creates a new Time Stamp, representing the current point in time.
+    /// Creates a new `TimeStamp`, representing the current point in time.
     pub fn now() -> Self {
         TimeStamp(Instant::now())
     }

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -7,7 +7,7 @@ use core::{mem, ops::Deref};
 #[cfg(test)]
 mod tests;
 
-/// A Timer provides all the capabilities necessary for doing speedrun attempts.
+/// A `Timer` provides all the capabilities necessary for doing speedrun attempts.
 ///
 /// # Examples
 ///
@@ -81,8 +81,7 @@ impl Deref for Snapshot<'_> {
     }
 }
 
-/// A Shared Timer is a wrapper around the Timer that can be shared across
-/// multiple threads with multiple owners.
+/// A `SharedTimer` is a wrapper around the [`Timer`](crate::timing::Timer) that can be shared across multiple threads with multiple owners.
 #[cfg(feature = "std")]
 pub type SharedTimer = alloc::sync::Arc<std::sync::RwLock<Timer>>;
 

--- a/src/timing/timing_method.rs
+++ b/src/timing/timing_method.rs
@@ -1,15 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-/// A Timing Method describes which form of timing is used. This can either be
-/// Real Time or Game Time.
+/// A `TimingMethod` describes which form of timing is used. This can either be
+/// [`TimingMethod::RealTime`] or [`TimingMethod::GameTime`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum TimingMethod {
-    /// Real Time is the unmodified timing that is as close to an atomic clock
+    /// `Real Time` is the unmodified timing that is as close to an atomic clock
     /// as possible.
     RealTime = 0,
-    /// Game Time describes the timing that is provided by the game that is
-    /// being run. This is entirely optional and may either be Real Time with
+    /// `Game Time` describes the timing that is provided by the game that is
+    /// being run. This is entirely optional and may either be `Real Time` with
     /// loading times removed or some time provided by the game.
     GameTime = 1,
 }


### PR DESCRIPTION
#372 

This PR adds type links to the rust docs; It tries to keep code formatting similarly to what was there.