### PR TITLE
Introduce a new `max-opt` Cargo Profile

### DIFF
--- a/.github/workflows/before_deploy.sh
+++ b/.github/workflows/before_deploy.sh
@@ -14,13 +14,13 @@ main() {
     (cd capi/bind_gen && cargo run)
 
     cp -r capi/bindings $stage/
-    cp target/$TARGET/release/livesplit_core.dll $stage/livesplit_core.dll 2>/dev/null || :
-    cp target/$TARGET/release/livesplit_core.lib $stage/livesplit_core.lib 2>/dev/null || :
-    cp target/$TARGET/release/liblivesplit_core.a $stage/liblivesplit_core.a 2>/dev/null || :
-    cp target/$TARGET/release/liblivesplit_core.so $stage/liblivesplit_core.so 2>/dev/null || :
-    cp target/$TARGET/release/livesplit*.js* $stage/. 2>/dev/null || :
-    cp target/$TARGET/release/deps/*.wasm $stage/livesplit.wasm 2>/dev/null || :
-    cp target/$TARGET/release/liblivesplit_core.dylib $stage/liblivesplit_core.dylib 2>/dev/null || :
+    cp target/$TARGET/max-opt/livesplit_core.dll $stage/livesplit_core.dll 2>/dev/null || :
+    cp target/$TARGET/max-opt/livesplit_core.lib $stage/livesplit_core.lib 2>/dev/null || :
+    cp target/$TARGET/max-opt/liblivesplit_core.a $stage/liblivesplit_core.a 2>/dev/null || :
+    cp target/$TARGET/max-opt/liblivesplit_core.so $stage/liblivesplit_core.so 2>/dev/null || :
+    cp target/$TARGET/max-opt/livesplit*.js* $stage/. 2>/dev/null || :
+    cp target/$TARGET/max-opt/deps/*.wasm $stage/livesplit.wasm 2>/dev/null || :
+    cp target/$TARGET/max-opt/liblivesplit_core.dylib $stage/liblivesplit_core.dylib 2>/dev/null || :
 
     cd $stage
     if [ "$OS_NAME" = "windows-latest" ]; then

--- a/.github/workflows/build_shared.sh
+++ b/.github/workflows/build_shared.sh
@@ -7,7 +7,7 @@ main() {
     fi
     local release_flag=""
     if [ "$IS_DEPLOY" = "true" ]; then
-        release_flag="--release"
+        release_flag="--profile max-opt"
     fi
 
     $cargo rustc -p livesplit-core-capi --crate-type cdylib --target $TARGET $release_flag $FEATURES

--- a/.github/workflows/build_static.sh
+++ b/.github/workflows/build_static.sh
@@ -7,7 +7,7 @@ main() {
     fi
     local release_flag=""
     if [ "$IS_DEPLOY" = "true" ]; then
-        release_flag="--release"
+        release_flag="--profile max-opt"
     fi
 
     if [ "$NO_STD" = "true" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,9 +180,11 @@ harness = false
 name = "software_rendering"
 harness = false
 
-[profile.release]
+[profile.max-opt]
+inherits = "release"
 lto = true
 panic = "abort"
+codegen-units = 1
 
-[profile.release.build-override]
+[profile.max-opt.build-override]
 opt-level = 0


### PR DESCRIPTION
This introduces a new Cargo profile called `max-opt` that does as many optimizations as possible. Previously we used the `release` profile for that, but doing all these optimizations rarely makes sense locally and instead only when deploying on the CI. Additionally I've noticed that reducing the `codegen-units` to 1 allows for even more optimizations, but slows compilation down even further. For both of these reasons the `release` profile is now back to its original configuration in Cargo and the `max-opt` profile is used for CI.