### PR TITLE
Allow auto splitters to query the size of modules

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -100,6 +100,12 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the size of a module in a process.
+//!     pub fn process_get_module_size(
+//!         process: ProcessId,
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!     ) -> Option<NonZeroU64>;
 //!
 //!     /// Sets the tick rate of the runtime. This influences the amount of
 //!     /// times the `update` function is called per second.

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -100,6 +100,12 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the size of a module in a process.
+//!     pub fn process_get_module_size(
+//!         process: ProcessId,
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!     ) -> Option<NonZeroU64>;
 //!
 //!     /// Sets the tick rate of the runtime. This influences the amount of
 //!     /// times the `update` function is called per second.


### PR DESCRIPTION
There are various situations where auto splitters may want to know the size of a process' modules, such as for version detection and for signature scanning a module.