### PR TITLE
Allow custom handling of auto splitter log messages

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }
-log = { version = "0.4.14", default-features = false }
 proc-maps = { version = "0.3.0", default-features = false }
 read-process-memory = { version = "0.1.4", default-features = false }
 slotmap = { version = "1.0.2", default-features = false }

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// Represents the state that a timer is in.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
@@ -35,4 +37,7 @@ pub trait Timer {
     /// Sets a custom key value pair. This may be arbitrary information that the
     /// auto splitter wants to provide for visualization.
     fn set_variable(&mut self, key: &str, value: &str);
+    /// Logs a message either from the auto splitter directly or from the
+    /// runtime.
+    fn log(&mut self, message: fmt::Arguments<'_>);
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -288,6 +288,10 @@ impl AutoSplitTimer for Timer {
     fn set_variable(&mut self, name: &str, value: &str) {
         self.0.write().unwrap().set_custom_variable(name, value)
     }
+
+    fn log(&mut self, message: fmt::Arguments<'_>) {
+        log::info!(target: "Auto Splitter", "{message}");
+    }
 }
 
 async fn run(


### PR DESCRIPTION
Previously we would always log the auto splitter messages with the `log` crate, but this may not necessarily be wanted. We already have a `Timer` trait that abstracts all the interactions of the auto splitter with the timer, so we might as well allow custom handling of the log messages there.