### PR TITLE
Allow the auto splitters to add settings

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -112,6 +112,16 @@
 //!     pub fn runtime_set_tick_rate(ticks_per_second: f64);
 //!     /// Prints a log message for debugging purposes.
 //!     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
+//!
+//!     /// Adds a new setting that the user can modify. This will return either
+//!     /// the specified default value or the value that the user has set.
+//!     pub fn user_settings_add_bool(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         default_value: bool,
+//!     ) -> bool;
 //! }
 //! ```
 //!
@@ -130,8 +140,10 @@
 
 mod process;
 mod runtime;
+mod settings;
 mod timer;
 
 pub use runtime::{CreationError, InterruptHandle, RunError, Runtime};
+pub use settings::{SettingValue, SettingsStore, UserSetting};
 pub use time;
 pub use timer::{Timer, TimerState};

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+/// A setting that is meant to be shown to and modified by the user.
+#[non_exhaustive]
+pub struct UserSetting {
+    /// A unique identifier for this setting. This is not meant to be shown to
+    /// the user and is only used to keep track of the setting.
+    pub key: Box<str>,
+    /// The name of the setting that is shown to the user.
+    pub description: Box<str>,
+    /// The default value of the setting. This also specifies the type of the setting.
+    pub default_value: SettingValue,
+}
+
+/// A value that a setting can have.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub enum SettingValue {
+    /// A boolean value.
+    Bool(bool),
+}
+
+/// Stores all the settings of an auto splitter. Currently this only stores
+/// values that are modified. So there may be settings that are registered as
+/// user settings, but because the user didn't modify them, they are not stored
+/// here yet.
+#[derive(Clone, Default)]
+pub struct SettingsStore {
+    values: HashMap<Box<str>, SettingValue>,
+}
+
+impl SettingsStore {
+    /// Creates a new empty settings store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets a setting to the new value. If the key of the setting doesn't exist
+    /// yet it will be stored as a new value. Otherwise the value will be
+    /// updated.
+    pub fn set(&mut self, key: Box<str>, value: SettingValue) {
+        self.values.insert(key, value);
+    }
+
+    /// Accesses the value of a setting by its key. While the setting may exist
+    /// as part of the user settings, it may not have been stored into the
+    /// settings store yet, so it may not exist, despite being registered.
+    pub fn get(&self, key: &str) -> Option<&SettingValue> {
+        self.values.get(key)
+    }
+
+    /// Iterates over all the setting keys and their values in the settings
+    /// store.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &SettingValue)> {
+        self.values.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+}

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "unstable")]
 
-use livesplit_auto_splitting::{Runtime, Timer, TimerState};
+use livesplit_auto_splitting::{Runtime, SettingsStore, Timer, TimerState};
 use std::{
     ffi::OsStr,
     fmt, fs,
@@ -61,12 +61,16 @@ fn compile(crate_name: &str) -> anyhow::Result<Runtime<DummyTimer>> {
         })
         .unwrap();
 
-    Ok(Runtime::new(&wasm_path, DummyTimer)?)
+    Ok(Runtime::new(
+        &std::fs::read(wasm_path).unwrap(),
+        DummyTimer,
+        SettingsStore::new(),
+    )?)
 }
 
 fn run(crate_name: &str) -> anyhow::Result<()> {
     let mut runtime = compile(crate_name)?;
-    runtime.step()?;
+    runtime.update()?;
     Ok(())
 }
 
@@ -144,7 +148,7 @@ fn infinite_loop() {
         interrupt.interrupt();
     });
 
-    assert!(runtime.step().is_err());
+    assert!(runtime.update().is_err());
 }
 
 // FIXME: Test Network

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -431,7 +431,7 @@ fn parse_attempt_history(version: Version, reader: &mut Reader<'_>, run: &mut Ru
 /// parse, you can provide a path to the splits file, which helps saving the
 /// splits file again later.
 pub fn parse(source: &str, path: Option<PathBuf>) -> Result<Run> {
-    let reader = &mut Reader::new(source);
+    let mut reader = Reader::new(source);
 
     let mut image_buf = Vec::new();
 
@@ -439,7 +439,7 @@ pub fn parse(source: &str, path: Option<PathBuf>) -> Result<Run> {
 
     let mut required_flags = 0u8;
 
-    parse_base(reader, "Run", |reader, attributes| {
+    parse_base(&mut reader, "Run", |reader, attributes| {
         let mut version = Version(1, 0, 0, 0);
         type_hint(optional_attribute_escaped_err(attributes, "version", |t| {
             version = parse_version(t)?;


### PR DESCRIPTION
The auto splitters can now specify settings that are meant to be shown to and modified by the user. For now there are only boolean values. Also to keep things simple, the auto splitters are reloaded when the settings are changed. When registering the settings their values are returned, so there doesn't need to be a separate "reload" API for now. This however means that whenever there is such a reloading API, the auto splitters probably would have to get updated to properly get notified. This is acceptable breakage for such an early API though.