### PR TITLE
Proc polling fix

### DIFF
--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -66,8 +66,6 @@ impl Process {
     }
 
     pub fn is_open(&self, process_list: &mut ProcessList) -> bool {
-        // FIXME: We can actually ask the list to only refresh the individual process.
-        process_list.refresh();
         process_list.is_open(sysinfo::Pid::from_u32(self.pid as u32))
     }
 

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -6,7 +6,7 @@ use std::{
     result, str,
     time::{Duration, Instant},
 };
-use sysinfo::{ProcessRefreshKind, RefreshKind, System, SystemExt};
+use sysinfo::{ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt};
 use wasmtime::{
     Caller, Config, Engine, Extern, Linker, Memory, Module, OptLevel, Store, Trap, TypedFunc,
 };
@@ -133,7 +133,7 @@ impl ProcessList {
     }
 
     pub fn is_open(&self, pid: sysinfo::Pid) -> bool {
-        self.system.process(pid).is_some()
+        matches!(self.system.process(pid), Some(proc) if proc.status() != sysinfo::ProcessStatus::Zombie)
     }
 }
 

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -132,7 +132,14 @@ impl ProcessList {
         self.system.processes_by_name(name)
     }
 
-    pub fn is_open(&self, pid: sysinfo::Pid) -> bool {
+    pub fn is_open(&mut self, pid: sysinfo::Pid) -> bool {
+        if !self
+            .system
+            .refresh_process_specifics(pid, ProcessRefreshKind::new())
+        {
+            return false;
+        }
+
         matches!(self.system.process(pid), Some(proc) if proc.status() != sysinfo::ProcessStatus::Zombie)
     }
 }


### PR DESCRIPTION
This PR makes it so that when checking if a process is open, only that process's status is refreshed, and not the status of every process on the machine. It also checks if a process is a zombie process on linux and considers it closed. In the future, consider also doing this check before attaching.