### PR TITLE
Don't store the file path in the `Run`

### DIFF
--- a/benches/balanced_pb.rs
+++ b/benches/balanced_pb.rs
@@ -46,7 +46,7 @@ fn fake_splits(c: &mut Criterion) {
 
 fn actual_splits(c: &mut Criterion) {
     let buf = fs::read_to_string("tests/run_files/livesplit1.6.lss").unwrap();
-    let mut run = livesplit::parse(&buf, None).unwrap();
+    let mut run = livesplit::parse(&buf).unwrap();
     run.comparison_generators_mut().clear();
     run.comparison_generators_mut().push(Box::new(BalancedPB));
 

--- a/benches/layout_state.rs
+++ b/benches/layout_state.rs
@@ -25,7 +25,7 @@ fn artificial() -> (Timer, Layout) {
 
 fn real() -> (Timer, Layout) {
     let buf = fs::read_to_string("tests/run_files/Celeste - Any% (1.2.1.5).lss").unwrap();
-    let run = livesplit::parse(&buf, None).unwrap();
+    let run = livesplit::parse(&buf).unwrap();
 
     let mut timer = Timer::new(run).unwrap();
     timer.start();

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -10,7 +10,7 @@ fn huge_game_icon(c: &mut Criterion) {
     let buf = fs::read_to_string("tests/run_files/livesplit1.6_gametime.lss").unwrap();
 
     c.bench_function("Parse With Huge Game Icon", move |b| {
-        b.iter(|| livesplit::parse(&buf, None).unwrap())
+        b.iter(|| livesplit::parse(&buf).unwrap())
     });
 }
 
@@ -18,7 +18,7 @@ fn lots_of_icons(c: &mut Criterion) {
     let buf = fs::read_to_string("tests/run_files/Celeste - Any% (1.2.1.5).lss").unwrap();
 
     c.bench_function("Parse with lots of Icons", move |b| {
-        b.iter(|| livesplit::parse(&buf, None).unwrap())
+        b.iter(|| livesplit::parse(&buf).unwrap())
     });
 }
 
@@ -26,6 +26,6 @@ fn no_icons(c: &mut Criterion) {
     let buf = fs::read_to_string("tests/run_files/livesplit1.6.lss").unwrap();
 
     c.bench_function("Parse without Icons", move |b| {
-        b.iter(|| livesplit::parse(&buf, None).unwrap())
+        b.iter(|| livesplit::parse(&buf).unwrap())
     });
 }

--- a/benches/scene_management.rs
+++ b/benches/scene_management.rs
@@ -121,7 +121,7 @@ cfg_if::cfg_if! {
         }
 
         fn lss(path: &str) -> Run {
-            livesplit::parse(&file(path), None).unwrap()
+            livesplit::parse(&file(path)).unwrap()
         }
 
         fn lsl(path: &str) -> Layout {

--- a/benches/software_rendering.rs
+++ b/benches/software_rendering.rs
@@ -66,7 +66,7 @@ cfg_if::cfg_if! {
         }
 
         fn lss(path: &str) -> Run {
-            livesplit::parse(&file(path), None).unwrap()
+            livesplit::parse(&file(path)).unwrap()
         }
 
         fn lsl(path: &str) -> Layout {

--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -141,7 +141,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
     for (i, (name, typ)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -417,7 +417,7 @@ namespace LiveSplitCore
                 writer,
                 "{}",
                 r#"
-        public static ParseRunResult Parse(Stream stream, string path, bool loadFiles)
+        public static ParseRunResult Parse(Stream stream, string loadFilesPath)
         {
             var data = new byte[stream.Length];
             stream.Read(data, 0, data.Length);
@@ -425,7 +425,7 @@ namespace LiveSplitCore
             try
             {
                 Marshal.Copy(data, 0, pnt, data.Length);
-                return Parse(pnt, data.Length, path, loadFiles);
+                return Parse(pnt, data.Length, loadFilesPath);
             }
             finally
             {

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -117,7 +117,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
     for (i, (name, typ)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -409,7 +409,7 @@ public class {class} extends {base_class} implements AutoCloseable {{
             writer,
             "{}",
             r#"
-    public static ParseRunResult parse(java.io.InputStream stream, String path, boolean loadFiles) throws java.io.IOException {
+    public static ParseRunResult parse(java.io.InputStream stream, String loadFilesPath) throws java.io.IOException {
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
         byte[] buffer = new byte[1024];
         while (true) {
@@ -420,7 +420,7 @@ public class {class} extends {base_class} implements AutoCloseable {{
         byte[] arr = out.toByteArray();
         java.nio.ByteBuffer nativeBuf = java.nio.ByteBuffer.allocateDirect(arr.length);
         nativeBuf.put(arr);
-        return Run.parse(Native.getDirectBufferPointer(nativeBuf), arr.length, path, loadFiles);
+        return Run.parse(Native.getDirectBufferPointer(nativeBuf), arr.length, loadFilesPath);
     }"#
         )?;
     }

--- a/capi/bind_gen/src/java/jni.rs
+++ b/capi/bind_gen/src/java/jni.rs
@@ -114,7 +114,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
     for (i, (name, typ)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -373,8 +373,8 @@ public class {class} extends {base_class} implements AutoCloseable {{
             writer,
             "{}",
             r#"
-    public static ParseRunResult parse(String data, String path, boolean loadFiles) {
-        ParseRunResult result = new ParseRunResult(LiveSplitCoreNative.Run_parseString(data, path, loadFiles));
+    public static ParseRunResult parse(String data, String loadFilesPath) {
+        ParseRunResult result = new ParseRunResult(LiveSplitCoreNative.Run_parseString(data, loadFilesPath));
         return result;
     }"#
         )?;

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -182,11 +182,11 @@ pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Resu
 
 using namespace LiveSplit;
 
-extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseString(JNIEnv* jni_env, jobject, jstring data, jstring path, jboolean load_files) {
+extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseString(JNIEnv* jni_env, jobject, jstring data, jstring load_files_path) {
     auto cstr_data = jni_env->GetStringUTFChars(data, nullptr);
-    auto cstr_path = jni_env->GetStringUTFChars(path, nullptr);
-    auto result = (jlong)Run_parse(cstr_data, strlen(cstr_data), cstr_path, (uint8_t)load_files);
-    jni_env->ReleaseStringUTFChars(path, cstr_path);
+    auto cstr_load_files_path = jni_env->GetStringUTFChars(load_files_path, nullptr);
+    auto result = (jlong)Run_parse(cstr_data, strlen(cstr_data), cstr_load_files_path);
+    jni_env->ReleaseStringUTFChars(load_files_path, cstr_load_files_path);
     jni_env->ReleaseStringUTFChars(data, cstr_data);
     return result;
 }

--- a/capi/bind_gen/src/kotlin/jni.rs
+++ b/capi/bind_gen/src/kotlin/jni.rs
@@ -136,7 +136,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
     for (i, (name, typ)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -411,8 +411,8 @@ open class {class} : {base_class}, AutoCloseable {{
                 writer,
                 "{}",
                 r#"
-    fun parse(data: String, path: String, loadFiles: Boolean): ParseRunResult {
-        val result = ParseRunResult(LiveSplitCoreNative.Run_parseString(data, path, loadFiles))
+    fun parse(data: String, loadFilesPath: String): ParseRunResult {
+        val result = ParseRunResult(LiveSplitCoreNative.Run_parseString(data, loadFilesPath))
         return result
     }"#
             )?;

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -138,7 +138,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     }
 
     if !type_script {
-        for (name, ty) in function.inputs.iter().skip(if is_static { 0 } else { 1 }) {
+        for (name, ty) in function.inputs.iter().skip(usize::from(!is_static)) {
             write!(
                 writer,
                 r#"
@@ -175,7 +175,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     for (i, (name, ty)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -621,20 +621,20 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
                     writer,
                     "{}",
                     r#"
-    static parseArray(data: Int8Array, path: string, loadFiles: boolean): ParseRunResult {
+    static parseArray(data: Int8Array, loadFilesPath: string): ParseRunResult {
         let buf = Buffer.from(data.buffer);
         if (data.byteLength !== data.buffer.byteLength) {
             buf = buf.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
-        return Run.parse(buf, buf.byteLength, path, loadFiles);
+        return Run.parse(buf, buf.byteLength, loadFilesPath);
     }
-    static parseFile(file: any, path: string, loadFiles: boolean): ParseRunResult {
+    static parseFile(file: any, loadFilesPath: string): ParseRunResult {
         const data = fs.readFileSync(file);
-        return Run.parse(data, data.byteLength, path, loadFiles);
+        return Run.parse(data, data.byteLength, loadFilesPath);
     }
-    static parseString(text: string, path: string, loadFiles: boolean): ParseRunResult {
+    static parseString(text: string, loadFilesPath: string): ParseRunResult {
         const data = new Buffer(text);
-        return Run.parse(data, data.byteLength, path, loadFiles);
+        return Run.parse(data, data.byteLength, loadFilesPath);
     }"#
                 )?;
             } else {
@@ -644,36 +644,33 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
                     r#"
     /**
      * @param {Int8Array} data
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseArray(data, path, loadFiles) {
+    static parseArray(data, loadFilesPath) {
         let buf = Buffer.from(data.buffer);
         if (data.byteLength !== data.buffer.byteLength) {
             buf = buf.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
-        return Run.parse(buf, buf.byteLength, path, loadFiles);
+        return Run.parse(buf, buf.byteLength, loadFilesPath);
     }
     /**
      * @param {string | Buffer | number} file
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseFile(file, path, loadFiles) {
+    static parseFile(file, loadFilesPath) {
         const data = fs.readFileSync(file);
-        return Run.parse(data, data.byteLength, path, loadFiles);
+        return Run.parse(data, data.byteLength, loadFilesPath);
     }
     /**
      * @param {string} text
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseString(text, path, loadFiles) {
+    static parseString(text, loadFilesPath) {
         const data = new Buffer(text);
-        return Run.parse(data, data.byteLength, path, loadFiles);
+        return Run.parse(data, data.byteLength, loadFilesPath);
     }"#
                 )?;
             }

--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -348,7 +348,7 @@ class {class}({base_class}):"#,
                 writer,
                 r#"
     @staticmethod
-    def parse_file(file, path, load_files):
+    def parse_file(file, load_files_path):
         data = file.read()
         if sys.version_info[0] > 2:
             if isinstance(data, str):
@@ -356,7 +356,7 @@ class {class}({base_class}):"#,
         bytes = bytearray(data)
         bufferType = c_byte * len(bytes)
         buffer = bufferType(*bytes)
-        return Run.parse(buffer, len(bytes), path, load_files)"#
+        return Run.parse(buffer, len(bytes), load_files_path)"#
             )?;
         }
 

--- a/capi/bind_gen/src/ruby.rs
+++ b/capi/bind_gen/src/ruby.rs
@@ -114,7 +114,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         )?;
     }
 
-    for (name, typ) in function.inputs.iter().skip(if is_static { 0 } else { 1 }) {
+    for (name, typ) in function.inputs.iter().skip(usize::from(!is_static)) {
         write!(
             writer,
             r"
@@ -150,7 +150,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
     for (i, (name, _)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {

--- a/capi/bind_gen/src/swift/code.rs
+++ b/capi/bind_gen/src/swift/code.rs
@@ -120,7 +120,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
     for (i, (name, ty)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {

--- a/capi/bind_gen/src/wasm.rs
+++ b/capi/bind_gen/src/wasm.rs
@@ -111,7 +111,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     }
 
     if !type_script {
-        for (name, ty) in function.inputs.iter().skip(if is_static { 0 } else { 1 }) {
+        for (name, ty) in function.inputs.iter().skip(usize::from(!is_static)) {
             write!(
                 writer,
                 r#"
@@ -148,7 +148,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     for (i, (name, ty)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -894,15 +894,15 @@ function dealloc(slice) {
                     writer,
                     "{}",
                     r#"
-    static parseArray(data: Int8Array, path: string, loadFiles: boolean): ParseRunResult {
+    static parseArray(data: Int8Array, loadFilesPath: string): ParseRunResult {
         const slice = allocInt8Array(data);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }
-    static parseString(text: string, path: string, loadFiles: boolean): ParseRunResult {
+    static parseString(text: string, loadFilesPath: string): ParseRunResult {
         const slice = allocString(text);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }"#
@@ -914,25 +914,23 @@ function dealloc(slice) {
                     r#"
     /**
      * @param {Int8Array} data
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseArray(data, path, loadFiles) {
+    static parseArray(data, loadFilesPath) {
         const slice = allocInt8Array(data);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }
     /**
      * @param {string} text
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseString(text, path, loadFiles) {
+    static parseString(text, loadFilesPath) {
         const slice = allocString(text);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }"#

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -120,7 +120,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     }
 
     if !type_script {
-        for (name, ty) in function.inputs.iter().skip(if is_static { 0 } else { 1 }) {
+        for (name, ty) in function.inputs.iter().skip(usize::from(!is_static)) {
             write!(
                 writer,
                 r#"
@@ -157,7 +157,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     for (i, (name, ty)) in function
         .inputs
         .iter()
-        .skip(if is_static { 0 } else { 1 })
+        .skip(usize::from(!is_static))
         .enumerate()
     {
         if i != 0 {
@@ -798,15 +798,15 @@ export class {class} extends {base_class} {{"#,
                     writer,
                     "{}",
                     r#"
-    static parseArray(data: Uint8Array, path: string, loadFiles: boolean): ParseRunResult {
+    static parseArray(data: Uint8Array, loadFilesPath: string): ParseRunResult {
         const slice = allocUint8Array(data);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }
-    static parseString(text: string, path: string, loadFiles: boolean): ParseRunResult {
+    static parseString(text: string, loadFilesPath: string): ParseRunResult {
         const slice = allocString(text);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }"#
@@ -818,25 +818,23 @@ export class {class} extends {base_class} {{"#,
                     r#"
     /**
      * @param {Uint8Array} data
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseArray(data, path, loadFiles) {
+    static parseArray(data, loadFilesPath) {
         const slice = allocUint8Array(data);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }
     /**
      * @param {string} text
-     * @param {string} path
-     * @param {boolean} loadFiles
+     * @param {string} loadFilesPath
      * @return {ParseRunResult}
      */
-    static parseString(text, path, loadFiles) {
+    static parseString(text, loadFilesPath) {
         const slice = allocString(text);
-        const result = Run.parse(slice.ptr, slice.len, path, loadFiles);
+        const result = Run.parse(slice.ptr, slice.len, loadFilesPath);
         dealloc(slice);
         return result;
     }"#

--- a/capi/src/general_layout_settings.rs
+++ b/capi/src/general_layout_settings.rs
@@ -8,7 +8,7 @@ pub type OwnedGeneralLayoutSettings = Box<GeneralLayoutSettings>;
 /// Creates a default general layout settings configuration.
 #[no_mangle]
 pub extern "C" fn GeneralLayoutSettings_default() -> OwnedGeneralLayoutSettings {
-    Box::new(GeneralLayoutSettings::default())
+    Default::default()
 }
 
 /// drop

--- a/capi/src/hotkey_config.rs
+++ b/capi/src/hotkey_config.rs
@@ -20,7 +20,7 @@ pub extern "C" fn HotkeyConfig_drop(this: OwnedHotkeyConfig) {
 /// Creates a new Hotkey Configuration with default settings.
 #[no_mangle]
 pub extern "C" fn HotkeyConfig_new() -> OwnedHotkeyConfig {
-    Box::new(HotkeyConfig::default())
+    Default::default()
 }
 
 /// Encodes generic description of the settings available for the hotkey

--- a/capi/src/layout_state.rs
+++ b/capi/src/layout_state.rs
@@ -7,14 +7,16 @@
 //! - Using the wrong getter function on the wrong type of component.
 
 use crate::{output_vec, Json};
-use livesplit_core::component::{
-    blank_space::State as BlankSpaceComponentState,
-    detailed_timer::State as DetailedTimerComponentState, graph::State as GraphComponentState,
-    key_value::State as KeyValueComponentState, separator::State as SeparatorComponentState,
-    splits::State as SplitsComponentState, text::State as TextComponentState,
-    timer::State as TimerComponentState, title::State as TitleComponentState,
+use livesplit_core::{
+    component::{
+        blank_space::State as BlankSpaceComponentState,
+        detailed_timer::State as DetailedTimerComponentState, graph::State as GraphComponentState,
+        key_value::State as KeyValueComponentState, separator::State as SeparatorComponentState,
+        splits::State as SplitsComponentState, text::State as TextComponentState,
+        timer::State as TimerComponentState, title::State as TitleComponentState,
+    },
+    layout::{ComponentState, LayoutState},
 };
-use livesplit_core::layout::{ComponentState, LayoutState};
 use std::os::raw::c_char;
 
 /// type
@@ -24,7 +26,7 @@ pub type OwnedLayoutState = Box<LayoutState>;
 /// layout state that gets updated over time.
 #[no_mangle]
 pub extern "C" fn LayoutState_new() -> OwnedLayoutState {
-    Box::new(LayoutState::default())
+    Default::default()
 }
 
 /// drop

--- a/src/networking/splits_io.rs
+++ b/src/networking/splits_io.rs
@@ -40,7 +40,7 @@ pub async fn download_run(
     id: &str,
 ) -> Result<composite::ParsedRun<'static>, DownloadError> {
     let bytes = api::run::download(client, id).await.context(Download)?;
-    let run = composite::parse(&bytes, None, false).context(Parse)?;
+    let run = composite::parse(&bytes, None).context(Parse)?;
     Ok(run.into_owned())
 }
 

--- a/src/platform/wasm/web/time.rs
+++ b/src/platform/wasm/web/time.rs
@@ -19,9 +19,7 @@ thread_local! {
 impl Instant {
     pub fn now() -> Self {
         let secs = PERFORMANCE.with(|p| p.now()) * 0.001;
-        let nanos = (secs.fract() * 1_000_000_000.0) as _;
-        let secs = secs as _;
-        Instant(Duration::new(secs, nanos))
+        Instant(Duration::seconds_f64(secs))
     }
 }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -35,7 +35,7 @@ pub use segment_history::SegmentHistory;
 
 use crate::{
     comparison::{default_generators, personal_best, ComparisonGenerator, RACE_COMPARISON_PREFIX},
-    platform::{path::PathBuf, prelude::*},
+    platform::prelude::*,
     settings::Image,
     util::PopulateString,
     AtomicDateTime, Time, TimeSpan, TimingMethod,
@@ -69,7 +69,6 @@ pub struct Run {
     attempt_history: Vec<Attempt>,
     metadata: RunMetadata,
     has_been_modified: bool,
-    path: Option<PathBuf>,
     segments: Vec<Segment>,
     custom_comparisons: Vec<String>,
     comparison_generators: ComparisonGenerators,
@@ -113,7 +112,6 @@ impl Run {
             attempt_history: Vec::new(),
             metadata: RunMetadata::new(),
             has_been_modified: false,
-            path: None,
             segments: Vec::new(),
             custom_comparisons: vec![personal_best::NAME.to_string()],
             comparison_generators: ComparisonGenerators(default_generators()),
@@ -161,18 +159,6 @@ impl Run {
         S: PopulateString,
     {
         name.populate(&mut self.category_name);
-    }
-
-    /// Returns the path of the associated splits file in the file system.
-    #[inline]
-    pub const fn path(&self) -> &Option<PathBuf> {
-        &self.path
-    }
-
-    /// Sets the path of the associated splits file in the file system.
-    #[inline]
-    pub fn set_path(&mut self, path: Option<PathBuf>) {
-        self.path = path;
     }
 
     /// Returns the amount of runs that have been attempted with these splits.

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -2,7 +2,7 @@
 
 use super::super::ComparisonError;
 use crate::{
-    platform::{path::PathBuf, prelude::*},
+    platform::prelude::*,
     util::xml::{
         helper::{
             attribute, attribute_escaped_err, end_tag, optional_attribute_escaped_err,
@@ -427,10 +427,8 @@ fn parse_attempt_history(version: Version, reader: &mut Reader<'_>, run: &mut Ru
     }
 }
 
-/// Attempts to parse a LiveSplit splits file. In addition to the source to
-/// parse, you can provide a path to the splits file, which helps saving the
-/// splits file again later.
-pub fn parse(source: &str, path: Option<PathBuf>) -> Result<Run> {
+/// Attempts to parse a LiveSplit splits file.
+pub fn parse(source: &str) -> Result<Run> {
     let mut reader = Reader::new(source);
 
     let mut image_buf = Vec::new();
@@ -495,8 +493,6 @@ pub fn parse(source: &str, path: Option<PathBuf>) -> Result<Run> {
             source: XmlError::ElementNotFound,
         });
     }
-
-    run.set_path(path);
 
     Ok(run)
 }

--- a/src/run/parser/mod.rs
+++ b/src/run/parser/mod.rs
@@ -10,17 +10,15 @@
 //! ```no_run
 //! use livesplit_core::run::parser::composite;
 //! use std::fs;
-//! use std::path::PathBuf;
+//! use std::path::Path;
 //!
 //! // Load the file.
-//! let path = PathBuf::from("path/to/splits_file");
-//! let file = fs::read(&path).expect("Failed reading the file.");
+//! let path = Path::new("path/to/splits_file");
+//! let file = fs::read(path).expect("Failed reading the file.");
 //!
-//! // We want to load additional files from the file system, like segment icons.
-//! let load_files = true;
-//!
-//! // Actually parse the file.
-//! let result = composite::parse(&file, Some(path), load_files);
+//! // Actually parse the file. We also pass the path to load additional files from
+//! // the file system, like segment icons.
+//! let result = composite::parse(&file, Some(path));
 //! let parsed = result.expect("Not a valid splits file.");
 //!
 //! // Print out the detected file format.

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -3,7 +3,10 @@
 use super::super::ComparisonError;
 use crate::{
     comparison::RACE_COMPARISON_PREFIX,
-    platform::{path::PathBuf, prelude::*},
+    platform::{
+        path::{Path, PathBuf},
+        prelude::*,
+    },
     timing, RealTime, Run, Segment, Time, TimeSpan,
 };
 #[cfg(feature = "std")]
@@ -76,13 +79,11 @@ fn parse_time_optional(time: &str) -> StdResult<Option<TimeSpan>, timing::ParseE
 /// this to `None`. Only client-side applications should provide the path here.
 pub fn parse(
     source: &str,
-    #[allow(unused)] path_for_loading_other_files: Option<PathBuf>,
+    #[allow(unused)] path_for_loading_other_files: Option<&Path>,
 ) -> Result<Run> {
     let mut run = Run::new();
     #[cfg(feature = "std")]
     let mut buf = Vec::new();
-    #[cfg(feature = "std")]
-    let mut path = path_for_loading_other_files;
 
     let mut lines = source.lines();
 
@@ -101,6 +102,9 @@ pub fn parse(
             .parse()
             .context(ParseOffset)?,
     );
+
+    #[cfg(feature = "std")]
+    let mut path = path_for_loading_other_files.map(Path::to_path_buf);
 
     #[cfg(feature = "std")]
     catch! {

--- a/tests/balanced_pb.rs
+++ b/tests/balanced_pb.rs
@@ -26,7 +26,7 @@ fn t(r: &str, g: &str) -> Time {
 
 #[test]
 fn balanced_pb() {
-    let mut run = livesplit::parse(run_files::LIVESPLIT_1_6_GAMETIME, None).unwrap();
+    let mut run = livesplit::parse(run_files::LIVESPLIT_1_6_GAMETIME).unwrap();
     run.comparison_generators_mut().clear();
     run.comparison_generators_mut().push(Box::new(BalancedPB));
     run.regenerate_comparisons();

--- a/tests/escaped_lss.rs
+++ b/tests/escaped_lss.rs
@@ -12,7 +12,7 @@ fn escaping_works_for_segment_name() {
     saver::livesplit::save_run(&run, &mut buf).unwrap();
     assert!(buf.contains("A &lt; B"));
 
-    run = parser::livesplit::parse(&buf, None).unwrap();
+    run = parser::livesplit::parse(&buf).unwrap();
     assert_eq!(run.segment(0).name(), "A < B");
 }
 
@@ -26,6 +26,6 @@ fn escaping_works_for_auto_splitter_settings() {
     saver::livesplit::save_run(&run, &mut buf).unwrap();
     assert!(buf.contains("A &lt; B"));
 
-    run = parser::livesplit::parse(&buf, None).unwrap();
+    run = parser::livesplit::parse(&buf).unwrap();
     assert_eq!(run.auto_splitter_settings(), "<Hi>A &lt; B</Hi>");
 }

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -17,7 +17,7 @@ use livesplit_core::{
 use std::fs;
 
 fn lss(data: &str) -> Run {
-    livesplit::parse(data, None).unwrap()
+    livesplit::parse(data).unwrap()
 }
 
 fn lsl(data: &str) -> Layout {

--- a/tests/split_parsing.rs
+++ b/tests/split_parsing.rs
@@ -14,7 +14,7 @@ mod parse {
 
     #[track_caller]
     fn livesplit(data: &str) -> Run {
-        livesplit::parse(data, None).unwrap()
+        livesplit::parse(data).unwrap()
     }
 
     #[track_caller]
@@ -24,12 +24,12 @@ mod parse {
 
     #[test]
     fn livesplit_fuzz_crash() {
-        livesplit::parse(run_files::LIVESPLIT_FUZZ_CRASH, None).unwrap_err();
+        livesplit::parse(run_files::LIVESPLIT_FUZZ_CRASH).unwrap_err();
     }
 
     #[test]
     fn livesplit_fuzz_crash_utf8() {
-        livesplit::parse(run_files::LIVESPLIT_FUZZ_CRASH_UTF8, None).unwrap_err();
+        livesplit::parse(run_files::LIVESPLIT_FUZZ_CRASH_UTF8).unwrap_err();
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod parse {
 
     #[test]
     fn llanfair_gered_doesnt_parse_as_livesplit() {
-        livesplit::parse(run_files::LLANFAIR_GERED, None).unwrap_err();
+        livesplit::parse(run_files::LLANFAIR_GERED).unwrap_err();
     }
 
     #[test]
@@ -182,46 +182,46 @@ mod parse {
 
     #[test]
     fn speedrun_igt_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::SPEEDRUN_IGT.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::SPEEDRUN_IGT.as_bytes(), None).unwrap();
         assert!(matches!(run.kind, TimerKind::SpeedRunIGT));
     }
 
     #[test]
     fn splits_io_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::GENERIC_SPLITS_IO.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::GENERIC_SPLITS_IO.as_bytes(), None).unwrap();
         assert!(matches!(run.kind, TimerKind::Generic(_)));
     }
 
     #[test]
     fn portal2_live_timer_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::PORTAL2_LIVE_TIMER1.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::PORTAL2_LIVE_TIMER1.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::Portal2LiveTimer);
     }
 
     #[test]
     fn splitterino_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::SPLITTERINO.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::SPLITTERINO.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::Splitterino);
     }
 
     #[test]
     fn urn_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::URN.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::URN.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::Urn);
     }
 
     #[test]
     fn source_live_time_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::SOURCE_LIVE_TIMER.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::SOURCE_LIVE_TIMER.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::SourceLiveTimer);
     }
 
     #[test]
     fn flitter_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::FLITTER.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::FLITTER.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::Flitter);
 
-        let run = composite::parse(run_files::FLITTER_SMALL.as_bytes(), None, false).unwrap();
+        let run = composite::parse(run_files::FLITTER_SMALL.as_bytes(), None).unwrap();
         assert_eq!(run.kind, TimerKind::Flitter);
     }
 }


### PR DESCRIPTION
It basically always makes more sense to track this in the actual application. This has been an artifact from being ported from the original LiveSplit since the very beginning, but was never actually used by any frontend. The desktop version now also doesn't end up using it, so it's time to finally remove it.