### PR TITLE
Implement more Detailed Timer Settings

### DIFF
--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -530,6 +530,21 @@ export interface DetailedTimerComponentStateJson {
      * that there is no icon.
      */
     icon_change: string | null,
+    /**
+     * The color of the segment name if it's shown. If `null` is specified, the
+     * color is taken from the layout.
+     */
+    segment_name_color: Color | null,
+    /**
+     * The color of the comparison names if they are shown. If `null` is
+     * specified, the color is taken from the layout.
+     */
+    comparison_names_color: Color | null,
+    /**
+     * The color of the comparison times if they are shown. If `null` is
+     * specified, the color is taken from the layout.
+     */
+    comparison_times_color: Color | null,
 }
 
 /** The state object describing a comparison to visualize. */

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -114,8 +114,9 @@ impl SkillCurve {
             let diff = max - min;
 
             if diff != 0.0 {
+                let r_diff = diff.recip();
                 for (weight, _) in weighted_segment_times.iter_mut() {
-                    *weight = (*weight - min) / diff;
+                    *weight = (*weight - min) * r_diff;
                 }
             }
         }

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -46,6 +46,9 @@ pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()
                         settings.segment_timer.accuracy = a;
                     })
                 }
+                "SegmentTimesAccuracy" => {
+                    accuracy(reader, |v| settings.comparison_times_accuracy = v)
+                }
                 "TimerAccuracy" => {
                     // Version < 1.5
                     settings.timer.digits_format = DigitsFormat::SingleDigitSeconds;
@@ -57,8 +60,16 @@ pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()
                     accuracy(reader, |v| settings.segment_timer.accuracy = v)
                 }
                 "TimerColor" => color(reader, |v| settings.timer.color_override = Some(v)),
+                "SegmentTimerColor" => {
+                    color(reader, |v| settings.segment_timer.color_override = Some(v))
+                }
+                "SegmentLabelsColor" => {
+                    color(reader, |v| settings.comparison_names_color = Some(v))
+                }
+                "SegmentTimesColor" => color(reader, |v| settings.comparison_times_color = Some(v)),
                 "DisplayIcon" => parse_bool(reader, |b| settings.display_icon = b),
                 "ShowSplitName" => parse_bool(reader, |b| settings.show_segment_name = b),
+                "SplitNameColor" => color(reader, |v| settings.segment_name_color = Some(v)),
                 "Comparison" => comparison_override(reader, |v| settings.comparison1 = v),
                 "Comparison2" => comparison_override(reader, |v| settings.comparison2 = v),
                 "HideComparison" => parse_bool(reader, |b| settings.hide_second_comparison = b),
@@ -68,15 +79,10 @@ pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()
                 _ => {
                     // FIXME:
                     // Width
-                    // SegmentTimesAccuracy
-                    // SegmentTimerColor
-                    // SegmentLabelsColor
-                    // SegmentTimesColor
                     // SegmentLabelsFont
                     // SegmentTimesFont
                     // SplitNameFont
                     // IconSize
-                    // SplitNameColor
                     // DecimalsSize
                     // SegmentTimerDecimalsSize
                     end_tag(reader)
@@ -88,12 +94,11 @@ pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()
     })?;
 
     if !timer_override_color {
-        // FIXME: This isn't actually exposed in the Detailed Timer's settings.
         settings.timer.color_override = None;
     }
     settings.background = background_builder.build();
 
-    settings.segment_timer.height = (total_height as f32 * segment_timer_ratio) as u32;
+    settings.segment_timer.height = (total_height as f32 * segment_timer_ratio + 0.5) as u32;
     settings.timer.height = total_height - settings.segment_timer.height;
 
     component.set_settings(settings);

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -47,8 +47,6 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
 ) {
     context.render_background([width, height], &component.background);
 
-    let text_color = solid(&layout_state.text_color);
-
     let vertical_padding = vertical_padding(height);
     let icon_size = height - 2.0 * vertical_padding;
 
@@ -63,7 +61,8 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         PADDING
     };
 
-    let top_height = 0.55 * height;
+    let total_height = component.timer.height + component.segment_timer.height;
+    let top_height = (component.timer.height as f32 / total_height as f32) * height;
     let bottom_height = height - top_height;
 
     let timer_end = timer::render(
@@ -74,12 +73,18 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     );
 
     if let Some(segment_name) = &component.segment_name {
+        let segment_name_color = solid(
+            &component
+                .segment_name_color
+                .unwrap_or(layout_state.text_color),
+        );
+
         context.render_text_ellipsis(
             segment_name,
             &mut cache.segment_name,
             [left_side, 0.6 * top_height],
             0.5 * top_height,
-            text_color,
+            segment_name_color,
             timer_end,
         );
     }
@@ -100,6 +105,12 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     let comparison2_y = 0.8 * bottom_height + top_height;
     let mut time_width = 0.0;
 
+    let comparison_names_color = solid(
+        &component
+            .comparison_names_color
+            .unwrap_or(layout_state.text_color),
+    );
+
     let comparison1_y = if let Some(comparison) = &component.comparison2 {
         name_end = context
             .render_text_ellipsis(
@@ -107,7 +118,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                 &mut cache.comparison2_name,
                 [left_side, comparison2_y],
                 comparison_text_scale,
-                text_color,
+                comparison_names_color,
                 segment_timer_end,
             )
             .max(name_end);
@@ -132,7 +143,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                 &mut cache.comparison1_name,
                 [left_side, comparison1_y],
                 comparison_text_scale,
-                text_color,
+                comparison_names_color,
                 segment_timer_end,
             )
             .max(name_end);
@@ -148,6 +159,11 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
 
     let time_x = name_end + PADDING + time_width;
 
+    let comparison_times_color = solid(
+        &component
+            .comparison_times_color
+            .unwrap_or(layout_state.text_color),
+    );
     if let Some(comparison) = &component.comparison2 {
         context.render_numbers(
             &comparison.time,
@@ -155,7 +171,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             Layer::Bottom,
             [time_x, comparison2_y],
             comparison_text_scale,
-            text_color,
+            comparison_times_color,
         );
     }
     if let Some(comparison) = &component.comparison1 {
@@ -165,7 +181,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             Layer::Bottom,
             [time_x, comparison1_y],
             comparison_text_scale,
-            text_color,
+            comparison_times_color,
         );
     }
 }

--- a/src/rendering/component/mod.rs
+++ b/src/rendering/component/mod.rs
@@ -99,7 +99,9 @@ pub fn width(component: &ComponentState) -> f32 {
 pub fn height(component: &ComponentState) -> f32 {
     match component {
         ComponentState::BlankSpace(state) => state.size as f32 * PSEUDO_PIXELS,
-        ComponentState::DetailedTimer(_) => 2.5,
+        ComponentState::DetailedTimer(state) => {
+            (state.timer.height + state.segment_timer.height) as f32 * PSEUDO_PIXELS
+        }
         ComponentState::Graph(state) => state.height as f32 * PSEUDO_PIXELS,
         ComponentState::KeyValue(state) => {
             if state.display_two_rows {

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -102,7 +102,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         );
         (TEXT_ALIGN_TOP, width - PADDING)
     } else {
-        (height / 2.0 + TEXT_ALIGN_CENTER, line2_end_x)
+        (0.5 * height + TEXT_ALIGN_CENTER, line2_end_x)
     };
 
     context.render_abbreviated_text_align(

--- a/src/run/parser/composite.rs
+++ b/src/run/parser/composite.rs
@@ -66,6 +66,7 @@ impl ParsedRun<'_> {
     }
 }
 
+#[inline(always)]
 const fn parsed(run: Run, kind: TimerKind<'_>) -> ParsedRun<'_> {
     ParsedRun { run, kind }
 }

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use bytemuck::{Pod, Zeroable};
 use image::{
-    codecs::{farbfeld, hdr, ico, jpeg, pnm, tga, tiff, webp},
+    codecs::{bmp, farbfeld, hdr, ico, jpeg, pnm, tga, tiff, webp},
     guess_format, load_from_memory_with_format, ImageDecoder, ImageEncoder, ImageFormat,
 };
 use std::io::Cursor;
@@ -51,9 +51,7 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Option<Cow<'_, [u8]>> {
         ImageFormat::Pnm => pnm::PnmDecoder::new(data).ok()?.dimensions(),
         ImageFormat::Tiff => tiff::TiffDecoder::new(Cursor::new(data)).ok()?.dimensions(),
         ImageFormat::Tga => tga::TgaDecoder::new(Cursor::new(data)).ok()?.dimensions(),
-        // We always want to re-encode BMP images so we might as well skip the
-        // dimension checking.
-        ImageFormat::Bmp => (0, 0),
+        ImageFormat::Bmp => bmp::BmpDecoder::new(Cursor::new(data)).ok()?.dimensions(),
         ImageFormat::Ico => ico::IcoDecoder::new(Cursor::new(data)).ok()?.dimensions(),
         ImageFormat::Hdr => hdr::HdrAdapter::new(data).ok()?.dimensions(),
         ImageFormat::Farbfeld => farbfeld::FarbfeldDecoder::new(data).ok()?.dimensions(),

--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -27,11 +27,14 @@ pub struct SegmentTime {
 }
 
 impl SegmentTime {
+    /// The default accuracy that the segment times are formatted with.
+    pub const DEFAULT_ACCURACY: Accuracy = Accuracy::Hundredths;
+
     /// Creates a new Segment Time Formatter that uses hundredths for showing
     /// the fractional part.
     pub const fn new() -> Self {
         SegmentTime {
-            accuracy: Accuracy::Hundredths,
+            accuracy: Self::DEFAULT_ACCURACY,
         }
     }
 

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -106,9 +106,9 @@ fn all_components() {
 
     let state = layout.state(&timer.snapshot());
 
-    check_dims(&state, [300, 800], "4en3ocnJJ/E=", "all_components");
+    check_dims(&state, [300, 800], "4WH3ocnJI/E=", "all_components");
 
-    check_dims(&state, [150, 800], "SXfHSWVpRlc=", "all_components_thin");
+    check_dims(&state, [150, 800], "SXPHSWVpRlc=", "all_components_thin");
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn dark_layout() {
 
     check(
         &layout.state(&timer.snapshot()),
-        "T8QIQABIw4c=",
+        "b8AIQABIwYM=",
         "dark_layout",
     );
 }


### PR DESCRIPTION
This implements the following settings / features for the Detailed Timer:
1. The ability to set / override the colors of the timer, segment timer, segment name, comparison names and comparison times.
2. The ability to turn off the gradient of the timer and segment timer.
3. The ability to set the accuracy of the comparison times.

This also fixes a bug where the scene manager did not take into account the sizes of the timer and segment timer at all.

I also included a fix for BMP images. We previously didn't read the dimensions of BMP images at all, because we would re-encode them as PNG anyway. However we may also want to shrink their dimensions, which was always skipped because the dimension was never read from the BMP file.