### PR TITLE
Implement Linked Layouts

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -35,6 +35,7 @@ pub mod layout;
 pub mod layout_editor;
 pub mod layout_editor_state;
 pub mod layout_state;
+pub mod linked_layout;
 pub mod parse_run_result;
 pub mod pb_chance_component;
 pub mod possible_time_save_component;

--- a/capi/src/linked_layout.rs
+++ b/capi/src/linked_layout.rs
@@ -1,0 +1,43 @@
+//! A Linked Layout associates a Layout with a Run. If the Run has a Linked
+//! Layout, it is supposed to be visualized with the Layout that is linked with
+//! it.
+
+use super::{output_str, str};
+use livesplit_core::run::LinkedLayout;
+use std::os::raw::c_char;
+
+/// type
+pub type OwnedLinkedLayout = Box<LinkedLayout>;
+
+/// Creates a new Linked Layout with the path specified. If the path is empty,
+/// the default layout is used instead.
+#[no_mangle]
+pub unsafe extern "C" fn LinkedLayout_new(path: *const c_char) -> OwnedLinkedLayout {
+    let path = str(path);
+    Box::new(if path.is_empty() {
+        LinkedLayout::Default
+    } else {
+        LinkedLayout::Path(path.to_owned())
+    })
+}
+
+/// drop
+#[no_mangle]
+pub extern "C" fn LinkedLayout_drop(this: OwnedLinkedLayout) {
+    drop(this);
+}
+
+/// Checks whether the linked layout is the default layout.
+#[no_mangle]
+pub extern "C" fn LinkedLayout_is_default(this: &LinkedLayout) -> bool {
+    matches!(this, LinkedLayout::Default)
+}
+
+/// Returns the path of the linked layout, if it's not the default layout.
+#[no_mangle]
+pub extern "C" fn LinkedLayout_path(this: &LinkedLayout) -> *const c_char {
+    output_str(match this {
+        LinkedLayout::Path(path) => path,
+        _ => "",
+    })
+}

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -6,6 +6,7 @@ use livesplit_core::{
     run::{
         parser,
         saver::{self, livesplit::IoWrite},
+        LinkedLayout,
     },
     Attempt, Run, RunMetadata, Segment, TimeSpan,
 };
@@ -275,4 +276,11 @@ pub extern "C" fn Run_custom_comparison(this: &Run, index: usize) -> *const c_ch
 #[no_mangle]
 pub extern "C" fn Run_auto_splitter_settings(this: &Run) -> *const c_char {
     output_str(this.auto_splitter_settings())
+}
+
+/// Accesses the linked layout of this Run. If a Layout is linked, it is
+/// supposed to be loaded to visualize the Run.
+#[no_mangle]
+pub extern "C" fn Run_linked_layout(this: &Run) -> Option<&LinkedLayout> {
+    this.linked_layout()
 }

--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -4,11 +4,11 @@
 //! state objects that can be visualized by any kind of User Interface.
 
 use super::{output_vec, str, Json};
-use crate::run::OwnedRun;
-use crate::sum_of_best_cleaner::OwnedSumOfBestCleaner;
+use crate::{
+    linked_layout::OwnedLinkedLayout, run::OwnedRun, sum_of_best_cleaner::OwnedSumOfBestCleaner,
+};
 use livesplit_core::{Run, RunEditor, TimingMethod};
-use std::os::raw::c_char;
-use std::slice;
+use std::{os::raw::c_char, slice};
 
 /// type
 pub type OwnedRunEditor = Box<RunEditor>;
@@ -127,6 +127,16 @@ pub unsafe extern "C" fn RunEditor_set_game_icon(
 #[no_mangle]
 pub extern "C" fn RunEditor_remove_game_icon(this: &mut RunEditor) {
     this.remove_game_icon();
+}
+
+/// Sets the Linked Layout of the Run. If a Layout
+/// is linked, it is supposed to be loaded to visualize the Run.
+#[no_mangle]
+pub extern "C" fn set_linked_layout(
+    this: &mut RunEditor,
+    linked_layout: Option<OwnedLinkedLayout>,
+) {
+    this.set_linked_layout(linked_layout.map(|l| *l));
 }
 
 /// Sets the speedrun.com Run ID of the run. You need to ensure that the

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -4,7 +4,7 @@
 //! current state of the editor as state objects that can be visualized by any
 //! kind of User Interface.
 
-use super::{ComparisonError, ComparisonResult};
+use super::{ComparisonError, ComparisonResult, LinkedLayout};
 use crate::{
     comparison,
     platform::prelude::*,
@@ -298,6 +298,13 @@ impl Editor {
     /// Removes the game's icon.
     pub fn remove_game_icon(&mut self) {
         self.run.set_game_icon([]);
+        self.raise_run_edited();
+    }
+
+    /// Sets the [`LinkedLayout`] of the [`Run`]. If a [`Layout`](crate::Layout)
+    /// is linked, it is supposed to be loaded to visualize the [`Run`].
+    pub fn set_linked_layout(&mut self, linked_layout: Option<LinkedLayout>) {
+        self.run.set_linked_layout(linked_layout);
         self.raise_run_edited();
     }
 

--- a/src/run/linked_layout.rs
+++ b/src/run/linked_layout.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use crate::platform::prelude::*;
+
+/// A `LinkedLayout` associates a [`Layout`](crate::Layout) with a
+/// [`Run`](crate::Run). If the [`Run`](crate::Run) has a `LinkedLayout`, it is
+/// supposed to be visualized with the [`Layout`](crate::Layout) that is linked
+/// with it.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum LinkedLayout {
+    /// The default [`Layout`](crate::Layout) is associated with the
+    /// [`Run`](crate::Run).
+    Default,
+    /// A [`Layout`](crate::Layout) that is specified through its path on the
+    /// file system is associated with the [`Run`](crate::Run).
+    Path(String),
+}

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -3,6 +3,7 @@
 use super::super::ComparisonError;
 use crate::{
     platform::prelude::*,
+    run::LinkedLayout,
     util::xml::{
         helper::{
             attribute, attribute_escaped_err, end_tag, optional_attribute_escaped_err,
@@ -483,6 +484,15 @@ pub fn parse(source: &str) -> Result<Run> {
                 let settings = run.auto_splitter_settings_mut();
                 reencode_children(reader, settings).map_err(Into::into)
             }
+            "LayoutPath" => text(reader, |t| {
+                run.set_linked_layout(if t == "?default" {
+                    Some(LinkedLayout::Default)
+                } else if t.is_empty() {
+                    None
+                } else {
+                    Some(LinkedLayout::Path(t.into_owned()))
+                });
+            }),
             _ => end_tag(reader),
         })
     })?;

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -26,6 +26,7 @@
 
 use crate::{
     platform::prelude::*,
+    run::LinkedLayout,
     settings::Image,
     timing::formatter::{Complete, TimeFormatter},
     util::xml::{AttributeWriter, DisplayValue, Text, Writer, NO_ATTRIBUTES},
@@ -206,6 +207,16 @@ pub fn save_run<W: fmt::Write>(run: &Run, writer: W) -> fmt::Result {
                 },
             )
         })?;
+
+        writer.tag_with_text_content(
+            "LayoutPath",
+            NO_ATTRIBUTES,
+            match run.linked_layout() {
+                Some(LinkedLayout::Default) => "?default",
+                Some(LinkedLayout::Path(path)) => path,
+                None => "",
+            },
+        )?;
 
         writer.tag_with_text_content(
             "Offset",

--- a/src/run/tests/linked_layout.rs
+++ b/src/run/tests/linked_layout.rs
@@ -1,0 +1,35 @@
+use crate::{run::LinkedLayout, Run};
+
+#[test]
+fn changing_does_nothing_when_run_doesnt_have_a_linked_layout() {
+    let mut run = Run::new();
+
+    assert_eq!(run.linked_layout(), None);
+    assert!(!run.layout_path_changed(None::<&str>));
+    assert_eq!(run.linked_layout(), None);
+    assert!(!run.layout_path_changed(Some("foo")));
+    assert_eq!(run.linked_layout(), None);
+}
+
+#[test]
+fn changes_properly() {
+    let mut run = Run::new();
+
+    run.set_linked_layout(Some(LinkedLayout::Default));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Default));
+
+    assert!(!run.layout_path_changed(None::<&str>));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Default));
+
+    assert!(run.layout_path_changed(Some("foo")));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Path("foo".into())));
+
+    assert!(run.layout_path_changed(Some("bar")));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Path("bar".into())));
+
+    assert!(!run.layout_path_changed(Some("bar")));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Path("bar".into())));
+
+    assert!(run.layout_path_changed(None::<&str>));
+    assert_eq!(run.linked_layout(), Some(&LinkedLayout::Default));
+}

--- a/src/run/tests/mod.rs
+++ b/src/run/tests/mod.rs
@@ -2,4 +2,5 @@ mod comparison;
 mod empty_run;
 mod extended_category_name;
 mod fixing;
+mod linked_layout;
 mod metadata;

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -704,6 +704,21 @@ impl Timer {
         }
     }
 
+    /// Notifies the `Timer` that the currently loaded [`Layout`](crate::Layout)
+    /// has changed. If the [`Run`] has a
+    /// [`LinkedLayout`](crate::run::LinkedLayout), it will be updated
+    /// accordingly. Specify [`None`] if the default [`Layout`](crate::Layout)
+    /// should be linked.
+    #[inline]
+    pub fn layout_path_changed<S>(&mut self, path: Option<S>)
+    where
+        S: PopulateString,
+    {
+        if self.run.layout_path_changed(path) {
+            self.run.mark_as_modified();
+        }
+    }
+
     fn update_attempt_history(&mut self) {
         let time = if self.phase == Ended {
             self.current_time()


### PR DESCRIPTION
This implements linked layouts that allow you to associate splits with layouts. This means that a timer application can automatically open the layout that's meant to be used for a particular splits file, improving the user experience a lot. This already landed in the original LiveSplit, so while the way it is stored in the XML is not ideal, in particular with the way the default layout is annotated, we will have to support it for backwards compatibility anyway. Further changes can be made in the future.

cc @Relacibo

Continuation of #436 