### PR TITLE
Fix Clippy Warnings for Rust 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ splits-io-api = { version = "0.3.0", optional = true }
 
 # Auto Splitting
 livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
-tokio = { version = "1.17.0", default-features = false, features = [
+tokio = { version = "1.24.2", default-features = false, features = [
     "rt",
     "sync",
     "time",

--- a/capi/bind_gen/src/c.rs
+++ b/capi/bind_gen/src/c.rs
@@ -69,12 +69,11 @@ extern "C" {
     for name in classes.keys() {
         writeln!(
             writer,
-            r#"struct {0}_s;
-typedef struct {0}_s *restrict {0};
-typedef struct {0}_s *restrict {0}RefMut;
-typedef struct {0}_s const* {0}Ref;
-"#,
-            name
+            r#"struct {name}_s;
+typedef struct {name}_s *restrict {name};
+typedef struct {name}_s *restrict {name}RefMut;
+typedef struct {name}_s const* {name}Ref;
+"#
         )?;
     }
 

--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -124,8 +124,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         write!(
             writer,
             r#"
-        public {}("#,
-            class_name
+        public {class_name}("#
         )?;
     } else {
         write!(
@@ -189,7 +188,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if is_constructor {
             write!(writer, "this.ptr = ")?;
         } else if function.output.is_custom {
-            write!(writer, r#"var result = new {}("#, return_type)?;
+            write!(writer, r#"var result = new {return_type}("#)?;
         } else {
             write!(writer, "var result = ")?;
             if return_type_ll == "UIntPtr" {
@@ -288,18 +287,17 @@ namespace LiveSplitCore
     )?;
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         write_class_comments(&mut writer, &class.comments)?;
 
         write!(
             writer,
             r#"
-    public class {class}
+    public class {class_name_ref}
     {{
-        internal IntPtr ptr;"#,
-            class = class_name_ref
+        internal IntPtr ptr;"#
         )?;
 
         for function in &class.shared_fns {
@@ -331,13 +329,12 @@ namespace LiveSplitCore
         write!(
             writer,
             r#"
-        internal {base_class}(IntPtr ptr)
+        internal {class_name_ref}(IntPtr ptr)
         {{
             this.ptr = ptr;
         }}
     }}
-"#,
-            base_class = class_name_ref
+"#
         )?;
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -345,10 +342,8 @@ namespace LiveSplitCore
         write!(
             writer,
             r#"
-    public class {class} : {base_class}
-    {{"#,
-            class = class_name_ref_mut,
-            base_class = class_name_ref
+    public class {class_name_ref_mut} : {class_name_ref}
+    {{"#
         )?;
 
         for function in &class.mut_fns {
@@ -358,10 +353,9 @@ namespace LiveSplitCore
         write!(
             writer,
             r#"
-        internal {class}(IntPtr ptr) : base(ptr) {{ }}
+        internal {class_name_ref_mut}(IntPtr ptr) : base(ptr) {{ }}
     }}
-"#,
-            class = class_name_ref_mut
+"#
         )?;
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -369,14 +363,12 @@ namespace LiveSplitCore
         write!(
             writer,
             r#"
-    public class {class} : {base_class}, IDisposable
+    public class {class_name} : {class_name_ref_mut}, IDisposable
     {{
         private void Drop()
         {{
             if (ptr != IntPtr.Zero)
-            {{"#,
-            class = class_name,
-            base_class = class_name_ref_mut
+            {{"#
         )?;
 
         if let Some(function) = class.own_fns.iter().find(|f| f.method == "drop") {
@@ -394,7 +386,7 @@ namespace LiveSplitCore
                 ptr = IntPtr.Zero;
             }}
         }}
-        ~{class}()
+        ~{class_name}()
         {{
             Drop();
         }}
@@ -402,8 +394,7 @@ namespace LiveSplitCore
         {{
             Drop();
             GC.SuppressFinalize(this);
-        }}"#,
-            class = class_name
+        }}"#
         )?;
 
         for function in class.static_fns.iter().chain(class.own_fns.iter()) {
@@ -438,9 +429,8 @@ namespace LiveSplitCore
         writeln!(
             writer,
             r#"
-        internal {class}(IntPtr ptr) : base(ptr) {{ }}
-    }}"#,
-            class = class_name
+        internal {class_name}(IntPtr ptr) : base(ptr) {{ }}
+    }}"#
         )?;
     }
 

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -100,8 +100,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         write!(
             writer,
             r#"
-    public {}("#,
-            class_name
+    public {class_name}("#
         )?;
     } else {
         write!(
@@ -163,13 +162,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if is_constructor {
             write!(writer, "this.ptr = ")?;
         } else if function.output.is_custom {
-            write!(
-                writer,
-                r#"{ret_type} result = new {ret_type}("#,
-                ret_type = return_type
-            )?;
+            write!(writer, r#"{return_type} result = new {return_type}("#)?;
         } else {
-            write!(writer, "{} result = ", return_type)?;
+            write!(writer, "{return_type} result = ")?;
         }
     }
 
@@ -259,7 +254,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
 
 fn write_class_ref<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
+    let class_name_ref = format!("{class_name}Ref");
 
     write!(
         writer,
@@ -274,9 +269,8 @@ import com.sun.jna.*;
     write!(
         writer,
         r#"
-public class {class} {{
-    Pointer ptr;"#,
-        class = class_name_ref
+public class {class_name_ref} {{
+    Pointer ptr;"#
     )?;
 
     for function in &class.shared_fns {
@@ -304,18 +298,17 @@ public class {class} {{
     write!(
         writer,
         r#"
-    {class}(Pointer ptr) {{
+    {class_name_ref}(Pointer ptr) {{
         this.ptr = ptr;
     }}
-}}"#,
-        class = class_name_ref
+}}"#
     )
 }
 
 fn write_class_ref_mut<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref = format!("{class_name}Ref");
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     write!(
         writer,
@@ -330,9 +323,7 @@ import com.sun.jna.*;
     write!(
         writer,
         r#"
-public class {class} extends {base_class} {{"#,
-        class = class_name_ref_mut,
-        base_class = class_name_ref
+public class {class_name_ref_mut} extends {class_name_ref} {{"#
     )?;
 
     for function in &class.mut_fns {
@@ -342,17 +333,16 @@ public class {class} extends {base_class} {{"#,
     write!(
         writer,
         r#"
-    {class}(Pointer ptr) {{
+    {class_name_ref_mut}(Pointer ptr) {{
         super(ptr);
     }}
-}}"#,
-        class = class_name_ref_mut
+}}"#
     )
 }
 
 fn write_class<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     write!(
         writer,
@@ -367,11 +357,9 @@ import com.sun.jna.*;
     write!(
         writer,
         r#"
-public class {class} extends {base_class} implements AutoCloseable {{
+public class {class_name} extends {class_name_ref_mut} implements AutoCloseable {{
     private void drop() {{
-        if (ptr != Pointer.NULL) {{"#,
-        class = class_name,
-        base_class = class_name_ref_mut
+        if (ptr != Pointer.NULL) {{"#
     )?;
 
     if let Some(function) = class.own_fns.iter().find(|f| f.method == "drop") {
@@ -428,11 +416,10 @@ public class {class} extends {base_class} implements AutoCloseable {{
     write!(
         writer,
         r#"
-    {class}(Pointer ptr) {{
+    {class_name}(Pointer ptr) {{
         super(ptr);
     }}
-}}"#,
-        class = class_name
+}}"#
     )
 }
 
@@ -502,12 +489,12 @@ pub fn write<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>) -> Resu
     path.pop();
 
     for (class_name, class) in classes {
-        path.push(format!("{}Ref", class_name));
+        path.push(format!("{class_name}Ref"));
         path.set_extension("java");
         write_class_ref(&path, class_name, class)?;
         path.pop();
 
-        path.push(format!("{}RefMut", class_name));
+        path.push(format!("{class_name}RefMut"));
         path.set_extension("java");
         write_class_ref_mut(&path, class_name, class)?;
         path.pop();

--- a/capi/bind_gen/src/java/jni.rs
+++ b/capi/bind_gen/src/java/jni.rs
@@ -97,8 +97,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         write!(
             writer,
             r#"
-    public {}("#,
-            class_name
+    public {class_name}("#
         )?;
     } else {
         write!(
@@ -160,13 +159,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         if is_constructor {
             write!(writer, "this.ptr = ")?;
         } else if function.output.is_custom {
-            write!(
-                writer,
-                r#"{ret_type} result = new {ret_type}("#,
-                ret_type = return_type
-            )?;
+            write!(writer, r#"{return_type} result = new {return_type}("#)?;
         } else {
-            write!(writer, "{} result = ", return_type)?;
+            write!(writer, "{return_type} result = ")?;
         }
     }
 
@@ -241,7 +236,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
 
 fn write_class_ref<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
+    let class_name_ref = format!("{class_name}Ref");
 
     writeln!(writer, r#"package livesplitcore;"#)?;
 
@@ -250,9 +245,8 @@ fn write_class_ref<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> 
     write!(
         writer,
         r#"
-public class {class} {{
-    long ptr;"#,
-        class = class_name_ref
+public class {class_name_ref} {{
+    long ptr;"#
     )?;
 
     for function in &class.shared_fns {
@@ -280,18 +274,17 @@ public class {class} {{
     write!(
         writer,
         r#"
-    {class}(long ptr) {{
+    {class_name_ref}(long ptr) {{
         this.ptr = ptr;
     }}
-}}"#,
-        class = class_name_ref
+}}"#
     )
 }
 
 fn write_class_ref_mut<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref = format!("{class_name}Ref");
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     writeln!(writer, r#"package livesplitcore;"#)?;
 
@@ -300,9 +293,7 @@ fn write_class_ref_mut<P: AsRef<Path>>(path: P, class_name: &str, class: &Class)
     write!(
         writer,
         r#"
-public class {class} extends {base_class} {{"#,
-        class = class_name_ref_mut,
-        base_class = class_name_ref
+public class {class_name_ref_mut} extends {class_name_ref} {{"#
     )?;
 
     for function in &class.mut_fns {
@@ -312,17 +303,16 @@ public class {class} extends {base_class} {{"#,
     write!(
         writer,
         r#"
-    {class}(long ptr) {{
+    {class_name_ref_mut}(long ptr) {{
         super(ptr);
     }}
-}}"#,
-        class = class_name_ref_mut
+}}"#
     )
 }
 
 fn write_class<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     writeln!(writer, r#"package livesplitcore;"#)?;
 
@@ -331,11 +321,9 @@ fn write_class<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Resu
     write!(
         writer,
         r#"
-public class {class} extends {base_class} implements AutoCloseable {{
+public class {class_name} extends {class_name_ref_mut} implements AutoCloseable {{
     private void drop() {{
-        if (ptr != 0) {{"#,
-        class = class_name,
-        base_class = class_name_ref_mut
+        if (ptr != 0) {{"#
     )?;
 
     if let Some(function) = class.own_fns.iter().find(|f| f.method == "drop") {
@@ -383,11 +371,10 @@ public class {class} extends {base_class} implements AutoCloseable {{
     write!(
         writer,
         r#"
-    {class}(long ptr) {{
+    {class_name}(long ptr) {{
         super(ptr);
     }}
-}}"#,
-        class = class_name
+}}"#
     )
 }
 
@@ -459,12 +446,12 @@ pub fn write<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>) -> Resu
     path.pop();
 
     for (class_name, class) in classes {
-        path.push(format!("{}Ref", class_name));
+        path.push(format!("{class_name}Ref"));
         path.set_extension("java");
         write_class_ref(&path, class_name, class)?;
         path.pop();
 
-        path.push(format!("{}RefMut", class_name));
+        path.push(format!("{class_name}RefMut"));
         path.set_extension("java");
         write_class_ref_mut(&path, class_name, class)?;
         path.pop();

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -100,8 +100,7 @@ extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jn
             write!(
                 writer,
                 r#"auto cstr_{name} = jni_env->GetStringUTFChars({name}, nullptr);
-    "#,
-                name = name
+    "#
             )?;
         }
     }
@@ -110,7 +109,7 @@ extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jn
         if return_type == "jstring" {
             write!(writer, r#"auto result = jni_env->NewStringUTF("#)?;
         } else {
-            write!(writer, r#"auto result = ({})("#, return_type)?;
+            write!(writer, r#"auto result = ({return_type})("#)?;
         }
     }
 
@@ -126,11 +125,11 @@ extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jn
             writer,
             "{}",
             if name == "this" {
-                format!("({})self", ty_name)
+                format!("({ty_name})self")
             } else if jni_type == "jstring" {
-                format!("cstr_{}", name)
+                format!("cstr_{name}")
             } else {
-                format!("({}){}", ty_name, name)
+                format!("({ty_name}){name}")
             }
         )?;
     }
@@ -149,8 +148,7 @@ extern "C" JNIEXPORT {} Java_livesplitcore_LiveSplitCoreNative_{}_1{}(JNIEnv* jn
             write!(
                 writer,
                 r#"
-    jni_env->ReleaseStringUTFChars({name}, cstr_{name});"#,
-                name = name
+    jni_env->ReleaseStringUTFChars({name}, cstr_{name});"#
             )?;
         }
     }

--- a/capi/bind_gen/src/kotlin/jni.rs
+++ b/capi/bind_gen/src/kotlin/jni.rs
@@ -128,8 +128,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         write!(
             writer,
             r#"
-    fun {}("#,
-            method
+    fun {method}("#
         )?;
     }
 
@@ -157,7 +156,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         "#
         )?;
     } else if has_return_type {
-        write!(writer, r#"): {}"#, return_type)?;
+        write!(writer, r#"): {return_type}"#)?;
         if function.output.is_nullable && function.output.is_custom {
             write!(writer, "?")?;
         }
@@ -191,11 +190,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         if is_constructor {
             write!(writer, "this.ptr = ")?;
         } else if function.output.is_custom {
-            write!(
-                writer,
-                r#"val result = {ret_type}("#,
-                ret_type = return_type
-            )?;
+            write!(writer, r#"val result = {return_type}("#)?;
         } else {
             write!(writer, "val result = ")?;
         }
@@ -270,7 +265,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
 
 fn write_class_ref<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
+    let class_name_ref = format!("{class_name}Ref");
 
     writeln!(writer, r#"package livesplitcore"#)?;
 
@@ -279,8 +274,7 @@ fn write_class_ref<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> 
     write!(
         writer,
         r#"
-open class {class} internal constructor(var ptr: Long) {{"#,
-        class = class_name_ref
+open class {class_name_ref} internal constructor(var ptr: Long) {{"#
     )?;
 
     for function in &class.shared_fns {
@@ -316,8 +310,8 @@ open class {class} internal constructor(var ptr: Long) {{"#,
 
 fn write_class_ref_mut<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref = format!("{}Ref", class_name);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref = format!("{class_name}Ref");
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     writeln!(writer, r#"package livesplitcore"#)?;
 
@@ -326,9 +320,7 @@ fn write_class_ref_mut<P: AsRef<Path>>(path: P, class_name: &str, class: &Class)
     write!(
         writer,
         r#"
-open class {class} internal constructor(ptr: Long) : {base_class}(ptr) {{"#,
-        class = class_name_ref_mut,
-        base_class = class_name_ref
+open class {class_name_ref_mut} internal constructor(ptr: Long) : {class_name_ref}(ptr) {{"#
     )?;
 
     for function in &class.mut_fns {
@@ -344,7 +336,7 @@ open class {class} internal constructor(ptr: Long) : {base_class}(ptr) {{"#,
 
 fn write_class<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Result<()> {
     let mut writer = BufWriter::new(File::create(path)?);
-    let class_name_ref_mut = format!("{}RefMut", class_name);
+    let class_name_ref_mut = format!("{class_name}RefMut");
 
     writeln!(writer, r#"package livesplitcore"#)?;
 
@@ -353,11 +345,9 @@ fn write_class<P: AsRef<Path>>(path: P, class_name: &str, class: &Class) -> Resu
     write!(
         writer,
         r#"
-open class {class} : {base_class}, AutoCloseable {{
+open class {class_name} : {class_name_ref_mut}, AutoCloseable {{
     private fun drop() {{
-        if (ptr != 0L) {{"#,
-        class = class_name,
-        base_class = class_name_ref_mut
+        if (ptr != 0L) {{"#
     )?;
 
     if let Some(function) = class.own_fns.iter().find(|f| f.method == "drop") {
@@ -508,12 +498,12 @@ pub fn write<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>) -> Resu
     path.pop();
 
     for (class_name, class) in classes {
-        path.push(format!("{}Ref", class_name));
+        path.push(format!("{class_name}Ref"));
         path.set_extension("kt");
         write_class_ref(&path, class_name, class)?;
         path.pop();
 
-        path.push(format!("{}RefMut", class_name));
+        path.push(format!("{class_name}RefMut"));
         path.set_extension("kt");
         write_class_ref_mut(&path, class_name, class)?;
         path.pop();

--- a/capi/bind_gen/src/kotlin/mod.rs
+++ b/capi/bind_gen/src/kotlin/mod.rs
@@ -1,9 +1,10 @@
-use crate::jni_cpp;
-use crate::{Class, Result};
-use std::collections::BTreeMap;
-use std::fs::{create_dir_all, File};
-use std::io::BufWriter;
-use std::path::Path;
+use crate::{jni_cpp, Class, Result};
+use std::{
+    collections::BTreeMap,
+    fs::{create_dir_all, File},
+    io::BufWriter,
+    path::Path,
+};
 
 mod jni;
 

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -152,8 +152,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             write!(
                 writer,
                 r#"
-     * @return {{{}}}"#,
-                return_type_with_null
+     * @return {{{return_type_with_null}}}"#
             )?;
         }
 
@@ -190,9 +189,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     if type_script && has_return_type {
         write!(
             writer,
-            r#"): {} {{
-        "#,
-            return_type_with_null
+            r#"): {return_type_with_null} {{
+        "#
         )?;
     } else {
         write!(
@@ -217,11 +215,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
 
     if has_return_type {
         if function.output.is_custom {
-            write!(
-                writer,
-                r#"const result = new {}("#,
-                return_type_without_null
-            )?;
+            write!(writer, r#"const result = new {return_type_without_null}("#)?;
         } else {
             write!(writer, "const result = ")?;
         }
@@ -368,8 +362,8 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
     )?;
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         write_class_comments(&mut writer, &class.comments)?;
 
@@ -462,11 +456,7 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
         )?;
 
         if !type_script {
-            writeln!(
-                writer,
-                r#"exports.{base_class} = {base_class};"#,
-                base_class = class_name_ref
-            )?;
+            writeln!(writer, r#"exports.{class_name_ref} = {class_name_ref};"#)?;
         }
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -544,8 +534,7 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
         if !type_script {
             writeln!(
                 writer,
-                r#"exports.{base_class} = {base_class};"#,
-                base_class = class_name_ref_mut
+                r#"exports.{class_name_ref_mut} = {class_name_ref_mut};"#
             )?;
         }
 
@@ -564,18 +553,16 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
             write!(
                 writer,
                 r#"
-    with<T>(closure: (obj: {class}) => T): T {{"#,
-                class = class_name
+    with<T>(closure: (obj: {class_name}) => T): T {{"#
             )?;
         } else {
             write!(
                 writer,
                 r#"
     /**
-     * @param {{function({class})}} closure
+     * @param {{function({class_name})}} closure
      */
-    with(closure) {{"#,
-                class = class_name
+    with(closure) {{"#
             )?;
         }
 
@@ -729,8 +716,7 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
             } else {
                 format!(
                     r#"
-exports.{base_class} = {base_class};"#,
-                    base_class = class_name
+exports.{class_name} = {class_name};"#
                 )
             }
         )?;

--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -142,7 +142,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
 
     if has_return_type {
         if function.output.is_custom {
-            write!(writer, r#"result = {}("#, return_type)?;
+            write!(writer, r#"result = {return_type}("#)?;
         } else {
             write!(writer, "result = ")?;
         }
@@ -160,9 +160,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             if name == "this" {
                 "self.ptr".to_string()
             } else if typ.is_custom {
-                format!("{}.ptr", name)
+                format!("{name}.ptr")
             } else if typ.name == "c_char" {
-                format!("{}.encode()", name)
+                format!("{name}.encode()")
             } else {
                 name.to_string()
             }
@@ -259,14 +259,13 @@ livesplit_core_native.{}.restype = {}"#,
     writeln!(writer)?;
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         write!(
             writer,
             r#"
-class {class}:"#,
-            class = class_name_ref
+class {class_name_ref}:"#
         )?;
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -281,9 +280,7 @@ class {class}:"#,
     def __init__(self, ptr):
         self.ptr = ptr
 
-class {class}({base_class}):"#,
-            class = class_name_ref_mut,
-            base_class = class_name_ref
+class {class_name_ref_mut}({class_name_ref}):"#
         )?;
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -298,9 +295,7 @@ class {class}({base_class}):"#,
     def __init__(self, ptr):
         self.ptr = ptr
 
-class {class}({base_class}):"#,
-            class = class_name,
-            base_class = class_name_ref_mut
+class {class_name}({class_name_ref_mut}):"#
         )?;
 
         write_class_comments(&mut writer, &class.comments)?;

--- a/capi/bind_gen/src/swift/code.rs
+++ b/capi/bind_gen/src/swift/code.rs
@@ -104,8 +104,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
         write!(
             writer,
             "
-    public init{}(",
-            return_suffix
+    public init{return_suffix}("
         )?;
     } else {
         write!(
@@ -143,9 +142,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
     } else if has_return_type {
         write!(
             writer,
-            ") -> {}{} {{
-        ",
-            return_type, return_suffix
+            ") -> {return_type}{return_suffix} {{
+        "
         )?;
     } else {
         write!(
@@ -242,8 +240,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function) -> Result<()> {
             write!(
                 writer,
                 "
-        return {}(ptr: result)",
-                return_type,
+        return {return_type}(ptr: result)",
             )?;
         } else {
             write!(
@@ -265,20 +262,19 @@ pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Resu
     writeln!(writer, "import CLiveSplitCore")?;
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         let comment = write_class_comments(&mut writer, &class.comments)?;
 
         write!(
             writer,
             "
-public class {class} {{
+public class {class_name_ref} {{
     var ptr: UnsafeMutableRawPointer?
     init(ptr: UnsafeMutableRawPointer?) {{
         self.ptr = ptr
-    }}",
-            class = class_name_ref
+    }}"
         )?;
 
         for function in &class.shared_fns {
@@ -307,10 +303,7 @@ public class {class} {{
             "
 }}
 {comment}
-public class {class}: {base_class} {{",
-            comment = comment,
-            class = class_name_ref_mut,
-            base_class = class_name_ref
+public class {class_name_ref_mut}: {class_name_ref} {{"
         )?;
 
         for function in &class.mut_fns {
@@ -322,12 +315,9 @@ public class {class}: {base_class} {{",
             "
 }}
 {comment}
-public class {class} : {base_class} {{
+public class {class_name} : {class_name_ref_mut} {{
     private func drop() {{
-        if self.ptr != nil {{",
-            comment = comment,
-            class = class_name,
-            base_class = class_name_ref_mut
+        if self.ptr != nil {{"
         )?;
 
         if let Some(function) = class.own_fns.iter().find(|f| f.method == "drop") {

--- a/capi/bind_gen/src/wasm.rs
+++ b/capi/bind_gen/src/wasm.rs
@@ -125,8 +125,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             write!(
                 writer,
                 r#"
-     * @return {{{}}}"#,
-                return_type_with_null
+     * @return {{{return_type_with_null}}}"#
             )?;
         }
 
@@ -163,9 +162,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     if type_script && has_return_type {
         write!(
             writer,
-            r#"): {} {{
-        "#,
-            return_type_with_null
+            r#"): {return_type_with_null} {{
+        "#
         )?;
     } else {
         write!(
@@ -209,11 +207,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
 
     if has_return_type {
         if function.output.is_custom {
-            write!(
-                writer,
-                r#"const result = new {}("#,
-                return_type_without_null
-            )?;
+            write!(writer, r#"const result = new {return_type_without_null}("#)?;
         } else {
             write!(writer, "const result = ")?;
         }
@@ -630,8 +624,8 @@ function dealloc(slice) {
     }
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         write_class_comments(&mut writer, &class.comments)?;
 
@@ -728,11 +722,7 @@ function dealloc(slice) {
         )?;
 
         if !type_script {
-            writeln!(
-                writer,
-                r#"exports.{base_class} = {base_class};"#,
-                base_class = class_name_ref
-            )?;
+            writeln!(writer, r#"exports.{class_name_ref} = {class_name_ref};"#)?;
         }
 
         write_class_comments(&mut writer, &class.comments)?;
@@ -802,8 +792,7 @@ function dealloc(slice) {
         if !type_script {
             writeln!(
                 writer,
-                r#"exports.{base_class} = {base_class};"#,
-                base_class = class_name_ref_mut
+                r#"exports.{class_name_ref_mut} = {class_name_ref_mut};"#
             )?;
         }
 
@@ -828,8 +817,7 @@ function dealloc(slice) {
      * early yourself anywhere within the scope. The scope's return value gets
      * carried to the outside of this function.
      */
-    with<T>(closure: (obj: {class}) => T): T {{"#,
-                class = class_name
+    with<T>(closure: (obj: {class_name}) => T): T {{"#
             )?;
         } else {
             write!(
@@ -840,10 +828,9 @@ function dealloc(slice) {
      * disposed once this function returns. You are free to dispose the object
      * early yourself anywhere within the scope. The scope's return value gets
      * carried to the outside of this function.
-     * @param {{function({class})}} closure
+     * @param {{function({class_name})}} closure
      */
-    with(closure) {{"#,
-                class = class_name
+    with(closure) {{"#
             )?;
         }
 
@@ -993,8 +980,7 @@ function dealloc(slice) {
             } else {
                 format!(
                     r#"
-exports.{base_class} = {base_class};"#,
-                    base_class = class_name
+exports.{class_name} = {class_name};"#
                 )
             }
         )?;

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -134,8 +134,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
             write!(
                 writer,
                 r#"
-     * @return {{{}}}"#,
-                return_type_with_null
+     * @return {{{return_type_with_null}}}"#
             )?;
         }
 
@@ -172,9 +171,8 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     if type_script && has_return_type {
         write!(
             writer,
-            r#"): {} {{
-        "#,
-            return_type_with_null
+            r#"): {return_type_with_null} {{
+        "#
         )?;
     } else {
         write!(
@@ -218,11 +216,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
 
     if has_return_type {
         if function.output.is_custom {
-            write!(
-                writer,
-                r#"const result = new {}("#,
-                return_type_without_null
-            )?;
+            write!(writer, r#"const result = new {return_type_without_null}("#)?;
         } else {
             write!(writer, "const result = ")?;
         }
@@ -491,16 +485,15 @@ function dealloc(slice) {
     }
 
     for (class_name, class) in classes {
-        let class_name_ref = format!("{}Ref", class_name);
-        let class_name_ref_mut = format!("{}RefMut", class_name);
+        let class_name_ref = format!("{class_name}Ref");
+        let class_name_ref_mut = format!("{class_name}RefMut");
 
         write_class_comments(&mut writer, &class.comments)?;
 
         write!(
             writer,
             r#"
-export class {class} {{"#,
-            class = class_name_ref,
+export class {class_name_ref} {{"#,
         )?;
 
         if type_script {
@@ -654,9 +647,7 @@ export class {class} {{"#,
         write!(
             writer,
             r#"
-export class {class} extends {base_class} {{"#,
-            class = class_name_ref_mut,
-            base_class = class_name_ref,
+export class {class_name_ref_mut} extends {class_name_ref} {{"#,
         )?;
 
         for function in &class.mut_fns {
@@ -717,9 +708,7 @@ export class {class} extends {base_class} {{"#,
         write!(
             writer,
             r#"
-export class {class} extends {base_class} {{"#,
-            class = class_name,
-            base_class = class_name_ref_mut,
+export class {class_name} extends {class_name_ref_mut} {{"#,
         )?;
 
         if type_script {
@@ -732,8 +721,7 @@ export class {class} extends {base_class} {{"#,
      * early yourself anywhere within the scope. The scope's return value gets
      * carried to the outside of this function.
      */
-    with<T>(closure: (obj: {class}) => T): T {{"#,
-                class = class_name
+    with<T>(closure: (obj: {class_name}) => T): T {{"#
             )?;
         } else {
             write!(
@@ -744,10 +732,9 @@ export class {class} extends {base_class} {{"#,
      * disposed once this function returns. You are free to dispose the object
      * early yourself anywhere within the scope. The scope's return value gets
      * carried to the outside of this function.
-     * @param {{function({class})}} closure
+     * @param {{function({class_name})}} closure
      */
-    with(closure) {{"#,
-                class = class_name
+    with(closure) {{"#
             )?;
         }
 

--- a/capi/src/potential_clean_up.rs
+++ b/capi/src/potential_clean_up.rs
@@ -5,8 +5,7 @@
 
 use super::output_vec;
 use livesplit_core::run::editor::cleaning::PotentialCleanUp;
-use std::io::Write;
-use std::os::raw::c_char;
+use std::{io::Write, os::raw::c_char};
 
 /// type
 pub type OwnedPotentialCleanUp = Box<PotentialCleanUp<'static>>;
@@ -23,5 +22,5 @@ pub extern "C" fn PotentialCleanUp_drop(this: OwnedPotentialCleanUp) {
 /// to a Run.
 #[no_mangle]
 pub extern "C" fn PotentialCleanUp_message(this: &PotentialCleanUp<'static>) -> *const c_char {
-    output_vec(|s| write!(s, "{}", this).unwrap())
+    output_vec(|s| write!(s, "{this}").unwrap())
 }

--- a/src/run/parser/speedrun_igt.rs
+++ b/src/run/parser/speedrun_igt.rs
@@ -454,9 +454,9 @@ pub fn parse(source: &str) -> Result<Run> {
             "trade_with_villager" => "Trade with Villager".into(),
             name => {
                 if let Some(rem) = name.strip_prefix("portal_no_") {
-                    format!("Portal No. {}", rem).into()
+                    format!("Portal No. {rem}").into()
                 } else if let Some(rem) = name.strip_prefix("got_shell_") {
-                    format!("Got Nautilus Shell {}", rem).into()
+                    format!("Got Nautilus Shell {rem}").into()
                 } else {
                     let mut new_name = String::with_capacity(name.len());
                     let mut last_is_space = true;

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -3,10 +3,7 @@
 use super::super::ComparisonError;
 use crate::{
     comparison::RACE_COMPARISON_PREFIX,
-    platform::{
-        path::{Path, PathBuf},
-        prelude::*,
-    },
+    platform::{path::Path, prelude::*},
     timing, RealTime, Run, Segment, Time, TimeSpan,
 };
 #[cfg(feature = "std")]
@@ -190,12 +187,12 @@ pub fn parse(
 }
 
 #[cfg(feature = "std")]
-fn parse_history(run: &mut Run, path: Option<PathBuf>) -> StdResult<(), ()> {
+fn parse_history(run: &mut Run, path: Option<std::path::PathBuf>) -> StdResult<(), ()> {
     if let Some(mut path) = path {
         path.set_extension("");
         let mut path = path.into_os_string();
         path.push("-RunLog.txt");
-        let path = PathBuf::from(path);
+        let path = std::path::PathBuf::from(path);
 
         let file = std::fs::read_to_string(path).map_err(drop)?;
         let mut lines = file.lines();


### PR DESCRIPTION
This mostly inlines more format arguments into the format string.