### PR TITLE
Switch to `fontdb` for Font Loading

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -4,12 +4,10 @@ main() {
     local cargo=cross
 
     # all features except those that sometimes should be skipped.
-    local features="--features std,more-image-formats,image-shrinking,rendering,path-based-text-engine,wasm-web"
+    local features="--features std,more-image-formats,image-shrinking,rendering,path-based-text-engine,wasm-web,font-loading"
 
     if [ "$SKIP_CROSS" = "skip" ]; then
         cargo=cargo
-        # font-loading doesn't work with cross
-        features="$features,font-loading"
     fi
 
     if [ "$SKIP_AUTO_SPLITTING" != "skip" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ rustybuzz = { version = "0.6.0", default-features = false, features = [
 ], optional = true }
 
 # Font Loading
-font-kit = { version = "0.11.0", optional = true }
+fontdb = { version = "0.11.2", optional = true }
 
 # Software Rendering
 tiny-skia = { version = "0.8.2", default-features = false, features = [
@@ -144,7 +144,7 @@ more-image-formats = [
 image-shrinking = ["std", "more-image-formats"]
 rendering = ["more-image-formats", "image?/gif"]
 path-based-text-engine = ["rendering", "rustybuzz"]
-font-loading = ["std", "path-based-text-engine", "font-kit"]
+font-loading = ["std", "path-based-text-engine", "fontdb"]
 software-rendering = ["path-based-text-engine", "tiny-skia", "tiny-skia-path"]
 wasm-web = [
     "std",

--- a/src/settings/font.rs
+++ b/src/settings/font.rs
@@ -91,7 +91,24 @@ pub enum Weight {
 
 impl Weight {
     /// The numeric value of the weight.
-    pub const fn value(self) -> f32 {
+    pub const fn to_u16(self) -> u16 {
+        match self {
+            Weight::Thin => 100,
+            Weight::ExtraLight => 200,
+            Weight::Light => 300,
+            Weight::SemiLight => 350,
+            Weight::Normal => 400,
+            Weight::Medium => 500,
+            Weight::SemiBold => 600,
+            Weight::Bold => 700,
+            Weight::ExtraBold => 800,
+            Weight::Black => 900,
+            Weight::ExtraBlack => 950,
+        }
+    }
+
+    /// The numeric value of the weight.
+    pub const fn to_f32(self) -> f32 {
         match self {
             Weight::Thin => 100.0,
             Weight::ExtraLight => 200.0,


### PR DESCRIPTION
We previously used `font-kit` which uses various native APIs for finding and matching all the fonts. It's much harder to compile, especially with `cross` and also brings in lots of functionality that we don't even need. `fontdb` is a much simpler crate written in pure Rust that brings everything that we need. It's previous matching algorithm wasn't as good as it didn't take Name ID 16 into account, but that's now fixed.