### PR TITLE
Update various dependencies and fix a bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,7 +331,7 @@ jobs:
           - label: Linux i586 musl
             target: i586-unknown-linux-musl
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux i686
@@ -359,42 +359,44 @@ jobs:
             os: ubuntu-latest
             cross: skip
             install_target: true
+            # FIXME: The tests don't run because without cross we can't
+            # successfully link anything.
             tests: skip
             dylib: skip
 
           - label: Linux arm
             target: arm-unknown-linux-gnueabi
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
 
           - label: Linux arm musl
             target: arm-unknown-linux-musleabi
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux arm Hardware Float
             target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux arm musl Hardware Float
             target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux armv5te
             target: armv5te-unknown-linux-gnueabi
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux armv5te musl
             target: armv5te-unknown-linux-musleabi
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux armv7 Hardware Float
@@ -405,7 +407,7 @@ jobs:
           - label: Linux armv7 musl Hardware Float
             target: armv7-unknown-linux-musleabihf
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
             dylib: skip
 
           - label: Linux aarch64
@@ -419,10 +421,6 @@ jobs:
             networking: skip
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
-            software_rendering: skip
-            # TODO: The software rendering is apparently not working on big
-            # endian platforms. Almost definitely caused by tiny-skia. This may
-            # or may not be intentional.
 
           - label: Linux mips64
             target: mips64-unknown-linux-gnuabi64
@@ -431,10 +429,6 @@ jobs:
             networking: skip
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
-            software_rendering: skip
-            # TODO: The software rendering is apparently not working on big
-            # endian platforms. Almost definitely caused by tiny-skia. This may
-            # or may not be intentional.
 
           - label: Linux mips64el
             target: mips64el-unknown-linux-gnuabi64
@@ -455,23 +449,34 @@ jobs:
           - label: Linux mipsel musl
             target: mipsel-unknown-linux-musl
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
+            networking: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
 
           - label: Linux powerpc
             target: powerpc-unknown-linux-gnu
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
+            networking: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux powerpc64le
             target: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
-            tests: skip
+            auto_splitting: skip
+            networking: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux s390x
             target: s390x-unknown-linux-gnu
             os: ubuntu-latest
-            tests: skip
+            networking: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           # These got removed from cross
           # - label: Linux powerpc64
@@ -661,7 +666,6 @@ jobs:
           SKIP_CROSS: ${{ matrix.cross }}
           SKIP_AUTO_SPLITTING: ${{ matrix.auto_splitting }}
           SKIP_NETWORKING: ${{ matrix.networking }}
-          SKIP_SOFTWARE_RENDERING: ${{ matrix.software_rendering }}
 
       - name: Prepare Release
         if: startsWith(github.ref, 'refs/tags/') && matrix.release == ''

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -18,10 +18,6 @@ main() {
         features="$features,networking"
     fi
 
-    if [ "$SKIP_SOFTWARE_RENDERING" != "skip" ]; then
-        features="$features,software-rendering"
-    fi
-
     if [ "$TARGET" = "wasm32-wasi" ]; then
         curl https://wasmtime.dev/install.sh -sSf | bash
         export PATH="$HOME/.wasmtime/bin:$PATH"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,12 +63,12 @@ image = { version = "0.24.0", features = [
 # Currently doesn't require any additional dependencies.
 
 # Path-based Text Engine
-rustybuzz = { version = "0.6.0", default-features = false, features = [
+rustybuzz = { version = "0.7.0", default-features = false, features = [
     "libm",
 ], optional = true }
 
 # Font Loading
-fontdb = { version = "0.11.2", optional = true }
+fontdb = { version = "0.12.0", optional = true }
 
 # Software Rendering
 tiny-skia = { version = "0.8.2", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ library, not both, you can run either one of the following commands:
 # Shared Library
 cargo rustc --release -p livesplit-core-capi --crate-type cdylib
 # Static Library
-cargo rustc --release -p capi --crate-type staticlib
+cargo rustc --release -p livesplit-core-capi --crate-type staticlib
 ```
 
 If you want to build the bindings for the library too, you need to go into the

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -17,11 +17,11 @@ slotmap = { version = "1.0.2", default-features = false }
 snafu = "0.7.0"
 sysinfo = { version = "0.27.0", default-features = false, features = ["multithread"] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "4.0.0", default-features = false, features = [
+wasmtime = { version = "5.0.0", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = { version = "4.0.0", optional = true }
+wasmtime-wasi = { version = "5.0.0", optional = true }
 
 [features]
 unstable = ["wasmtime-wasi"]

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -359,7 +359,6 @@ impl Run {
     #[inline]
     pub fn set_linked_layout(&mut self, linked_layout: Option<LinkedLayout>) {
         self.linked_layout = linked_layout;
-        self.mark_as_modified();
     }
 
     /// Returns the amount of segments stored in this Run.


### PR DESCRIPTION
This updates all the outdated dependencies and fixes a bug where setting the linked layout through the run's method would mark the run as modified. This therefore was even the case right after parsing a run. Additionally tiny-skia can render on big endian systems now. I'm using this as an opportunity to run the tests on all systems in CI now that might be able to run more tests now.