### PR TITLE
Fix compatibility with `wasm-bindgen` v0.2.84

### DIFF
--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -347,6 +347,7 @@ pub fn write<W: Write>(
             "{}{}",
             r#"// tslint:disable
 import * as wasm from "./livesplit_core_bg.wasm";
+import "./livesplit_core.js";
 
 declare class TextEncoder {
     constructor(label?: string, options?: TextEncoding.TextEncoderOptions);
@@ -440,6 +441,7 @@ function dealloc(slice: Slice) {
             writer,
             "{}",
             r#"import * as wasm from "./livesplit_core_bg.wasm";
+import "./livesplit_core.js";
 
 const encoder = new TextEncoder("UTF-8");
 const decoder = new TextDecoder("UTF-8");


### PR DESCRIPTION
The latest version of `wasm-bindgen` sets the WASM file through code in the `livesplit_core.js`, but we never even import that, so things start to break when running it.