### PR TITLE
Add `OS` and `Arch` querying to the Auto Splitting Runtime

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,14 @@
+# Temporary workaround because Rust 1.68+ requires more up to date containers.
+
+[target.i686-linux-android]
+image = "ghcr.io/cross-rs/i686-linux-android:main"
+[target.x86_64-linux-android]
+image = "ghcr.io/cross-rs/x86_64-linux-android:main"
+[target.arm-linux-androideabi]
+image = "ghcr.io/cross-rs/arm-linux-androideabi:main"
+[target.armv7-linux-androideabi]
+image = "ghcr.io/cross-rs/armv7-linux-androideabi:main"
+[target.thumbv7neon-linux-androideabi]
+image = "ghcr.io/cross-rs/thumbv7neon-linux-androideabi:main"
+[target.aarch64-linux-android]
+image = "ghcr.io/cross-rs/aarch64-linux-android:main"

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -112,6 +112,20 @@ extern "C" {
     pub fn runtime_set_tick_rate(ticks_per_second: f64);
     /// Prints a log message for debugging purposes.
     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
+    /// Stores the name of the operating system that the runtime is running
+    /// on in the buffer given. Returns `false` if the buffer is too small.
+    /// After this call, no matter whether it was successful or not, the
+    /// `buf_len_ptr` will be set to the required buffer size. The name is
+    /// guaranteed to be valid UTF-8 and is not nul-terminated.
+    /// Example values: `windows`, `linux`, `macos`
+    pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+    /// Stores the name of the architecture that the runtime is running on
+    /// in the buffer given. Returns `false` if the buffer is too small.
+    /// After this call, no matter whether it was successful or not, the
+    /// `buf_len_ptr` will be set to the required buffer size. The name is
+    /// guaranteed to be valid UTF-8 and is not nul-terminated.
+    /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
+    pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
     /// Adds a new setting that the user can modify. This will return either
     /// the specified default value or the value that the user has set.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -112,6 +112,20 @@
 //!     pub fn runtime_set_tick_rate(ticks_per_second: f64);
 //!     /// Prints a log message for debugging purposes.
 //!     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
+//!     /// Stores the name of the operating system that the runtime is running
+//!     /// on in the buffer given. Returns `false` if the buffer is too small.
+//!     /// After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The name is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     /// Example values: `windows`, `linux`, `macos`
+//!     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+//!     /// Stores the name of the architecture that the runtime is running on
+//!     /// in the buffer given. Returns `false` if the buffer is too small.
+//!     /// After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The name is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
+//!     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
 //!     /// Adds a new setting that the user can modify. This will return either
 //!     /// the specified default value or the value that the user has set.

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -112,6 +112,20 @@
 //!     pub fn runtime_set_tick_rate(ticks_per_second: f64);
 //!     /// Prints a log message for debugging purposes.
 //!     pub fn runtime_print_message(text_ptr: *const u8, text_len: usize);
+//!     /// Stores the name of the operating system that the runtime is running
+//!     /// on in the buffer given. Returns `false` if the buffer is too small.
+//!     /// After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The name is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     /// Example values: `windows`, `linux`, `macos`
+//!     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+//!     /// Stores the name of the architecture that the runtime is running on
+//!     /// in the buffer given. Returns `false` if the buffer is too small.
+//!     /// After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The name is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
+//!     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
 //!     /// Adds a new setting that the user can modify. This will return either
 //!     /// the specified default value or the value that the user has set.


### PR DESCRIPTION
This adds two new functions to the auto splitting runtime that allow an auto splitter to query the operating system and architecture of the platform that the runtime is running on. This allows an auto splitter to dynamically adapt to the different platforms, such that for example Linux and Windows can both be supported by the same auto splitter.