### PR TITLE
Update `wasmtime` to `v6.0.1`

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -17,11 +17,11 @@ slotmap = { version = "1.0.2", default-features = false }
 snafu = "0.7.0"
 sysinfo = { version = "0.28.1", default-features = false, features = ["multithread"] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "5.0.0", default-features = false, features = [
+wasmtime = { version = "6.0.1", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = { version = "5.0.0", optional = true }
+wasmtime-wasi = { version = "6.0.1", optional = true }
 
 [features]
 unstable = ["wasmtime-wasi"]


### PR DESCRIPTION
This seems to fix a bug with the debug info.