### PR TITLE
Fix Hotkey Modifiers on macOS

### DIFF
--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -16,9 +16,6 @@ winapi = { version = "0.3.2", features = [
     "winuser"
 ], optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2.7"
-
 [target.'cfg(target_os = "linux")'.dependencies]
 crossbeam-channel = { version = "0.5.6", optional = true }
 evdev = { version = "0.12.1", optional = true }

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -27,8 +27,6 @@ cfg_if::cfg_if! {
         mod linux;
         use self::linux as platform;
     } else if #[cfg(target_os = "macos")] {
-        #[macro_use]
-        extern crate objc;
         mod macos;
         use self::macos as platform;
     } else if #[cfg(all(target_family = "wasm", target_os = "unknown", feature = "wasm-web"))] {

--- a/crates/livesplit-hotkey/src/macos/cg.rs
+++ b/crates/livesplit-hotkey/src/macos/cg.rs
@@ -186,8 +186,25 @@ pub type EventTapCallBack = Option<
     ) -> EventRef,
 >;
 
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct EventFlags: u64 {
+        const CAPS_LOCK = 1 << 16;
+        const SHIFT = 1 << 17;
+        const CONTROL = 1 << 18;
+        const OPTION = 1 << 19;
+        const COMMAND = 1 << 20;
+        const NUMERIC_PAD = 1 << 21;
+        const HELP = 1 << 22;
+        const FUNCTION = 1 << 23;
+    }
+}
+
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
+    pub fn CGEventGetFlags(event: EventRef) -> EventFlags;
+
     pub fn CGEventTapCreate(
         tap: EventTapLocation,
         place: EventTapPlacement,


### PR DESCRIPTION
It turns out that the modifier flags are actually provided as part of the event flags of the key down event. So we don't need to listen for the flags to change anymore. We also accidentally interpreted the key code of the flags changed event, which was often 0 (maybe always?), causing us to interpret the flags changed event as a press of the `A` key.

Special thanks to kcr_ for helping us test this.