### PR TITLE
Adding memory maps lookup functions

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -109,16 +109,16 @@ extern "C" {
     /// Gets the number of memory maps in a given process
     pub fn process_get_map_count(
         process: ProcessId,
-    ) -> Option<NonZeroU64>;
+    ) -> Option<NonZeroU32>;
     /// Gets the address of a memory map by providing its ID
     pub fn process_get_map_address_by_id(
         process: ProcessId,
-        id: u64,
+        id: u32,
     ) -> Option<NonZeroAddress>;
     /// Gets the size of a memory map by providing its ID
     pub fn process_get_map_size_by_id(
         process: ProcessId,
-        id: u64,
+        id: u32,
     ) -> Option<NonZeroU64>;
 
     /// Sets the tick rate of the runtime. This influences the amount of

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -106,27 +106,17 @@ extern "C" {
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroU64>;
-    /// Gets the address of the first memory page matching a given size
-    pub fn process_get_page_address_by_size(
-        process: ProcessId,
-        size: u64,
-    ) -> Option<NonZeroAddress>;
-    /// Gets the address of the last memory page matching a given size
-    pub fn process_get_last_page_address_by_size(
-        process: ProcessId,
-        size: u64,
-    ) -> Option<NonZeroAddress>;
-    /// Gets the number of memory pages in a given process
-    pub fn process_get_pages_count(
+    /// Gets the number of memory maps in a given process
+    pub fn process_get_map_count(
         process: ProcessId,
     ) -> Option<NonZeroU64>;
-    /// Gets the address of a memory page, sorted by ID
-    pub fn process_get_page_address_by_id(
+    /// Gets the address of a memory map by providing its ID
+    pub fn process_get_map_address_by_id(
         process: ProcessId,
         id: u64,
     ) -> Option<NonZeroAddress>;
-    /// Gets the size of a memory page, sorted by ID
-    pub fn process_get_page_size_by_id(
+    /// Gets the size of a memory map by providing its ID
+    pub fn process_get_map_size_by_id(
         process: ProcessId,
         id: u64,
     ) -> Option<NonZeroU64>;

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -106,6 +106,30 @@ extern "C" {
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroU64>;
+    /// Gets the address of the first memory page matching a given size
+    pub fn process_get_page_address_by_size(
+        process: ProcessId,
+        size: u64,
+    ) -> Option<NonZeroAddress>;
+    /// Gets the address of the last memory page matching a given size
+    pub fn process_get_last_page_address_by_size(
+        process: ProcessId,
+        size: u64,
+    ) -> Option<NonZeroAddress>;
+    /// Gets the number of memory pages in a given process
+    pub fn process_get_pages_count(
+        process: ProcessId,
+    ) -> Option<NonZeroU64>;
+    /// Gets the address of a memory page, sorted by ID
+    pub fn process_get_page_address_by_id(
+        process: ProcessId,
+        id: u64,
+    ) -> Option<NonZeroAddress>;
+    /// Gets the size of a memory page, sorted by ID
+    pub fn process_get_page_size_by_id(
+        process: ProcessId,
+        id: u64,
+    ) -> Option<NonZeroU64>;
 
     /// Sets the tick rate of the runtime. This influences the amount of
     /// times the `update` function is called per second.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -106,6 +106,30 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
+//!     /// Gets the address of the first memory page matching a given size
+//!     pub fn process_get_page_address_by_size(
+//!         process: ProcessId,
+//!         size: u64,
+//!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the address of the last memory page matching a given size
+//!     pub fn process_get_last_page_address_by_size(
+//!         process: ProcessId,
+//!         size: u64,
+//!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the number of memory pages in a given process
+//!     pub fn process_get_pages_count(
+//!         process: ProcessId,
+//!     ) -> Option<NonZeroU64>;
+//!     /// Gets the address of a memory page, sorted by ID
+//!     pub fn process_get_page_address_by_id(
+//!         process: ProcessId,
+//!         id: u64.
+//!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the size of a memory page, sorted by ID
+//!     pub fn process_get_page_size_by_id(
+//!         process: ProcessId,
+//!         id: u64,
+//!     ) -> Option<NonZeroU64>;
 //!
 //!     /// Sets the tick rate of the runtime. This influences the amount of
 //!     /// times the `update` function is called per second.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -106,27 +106,17 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
-//!     /// Gets the address of the first memory page matching a given size
-//!     pub fn process_get_page_address_by_size(
-//!         process: ProcessId,
-//!         size: u64,
-//!     ) -> Option<NonZeroAddress>;
-//!     /// Gets the address of the last memory page matching a given size
-//!     pub fn process_get_last_page_address_by_size(
-//!         process: ProcessId,
-//!         size: u64,
-//!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the number of memory pages in a given process
-//!     pub fn process_get_pages_count(
+//!     pub fn process_get_map_count(
 //!         process: ProcessId,
 //!     ) -> Option<NonZeroU64>;
 //!     /// Gets the address of a memory page, sorted by ID
-//!     pub fn process_get_page_address_by_id(
+//!     pub fn process_get_map_address_by_id(
 //!         process: ProcessId,
 //!         id: u64.
 //!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the size of a memory page, sorted by ID
-//!     pub fn process_get_page_size_by_id(
+//!     pub fn process_get_map_size_by_id(
 //!         process: ProcessId,
 //!         id: u64,
 //!     ) -> Option<NonZeroU64>;

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -109,16 +109,16 @@
 //!     /// Gets the number of memory pages in a given process
 //!     pub fn process_get_map_count(
 //!         process: ProcessId,
-//!     ) -> Option<NonZeroU64>;
+//!     ) -> Option<NonZeroU32>;
 //!     /// Gets the address of a memory page, sorted by ID
 //!     pub fn process_get_map_address_by_id(
 //!         process: ProcessId,
-//!         id: u64.
+//!         id: u32.
 //!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the size of a memory page, sorted by ID
 //!     pub fn process_get_map_size_by_id(
 //!         process: ProcessId,
-//!         id: u64,
+//!         id: u32,
 //!     ) -> Option<NonZeroU64>;
 //!
 //!     /// Sets the tick rate of the runtime. This influences the amount of

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -128,7 +128,10 @@ impl Process {
             };
             self.last_check = now;
         }
-        Ok(self.modules.len() as u32)
+        match self.modules.len() {
+            0 => Err(ModuleError::ModuleDoesntExist),
+            x => Ok(x as u32)
+        }
     }
 
     pub fn get_map_address_by_id(&mut self, id: u32) -> Result<Address, ModuleError> {
@@ -143,7 +146,7 @@ impl Process {
             };
             self.last_check = now;
         }
-        if id > self.modules.len() as u32 {
+        if id >= self.modules.len() as u32 {
             return Err(ModuleError::ModuleDoesntExist)
         }
         Ok(self.modules[id as usize].start() as u64)
@@ -161,7 +164,7 @@ impl Process {
             };
             self.last_check = now;
         }
-        if id > self.modules.len() as u32 {
+        if id >= self.modules.len() as u32 {
             return Err(ModuleError::ModuleDoesntExist)
         }
         Ok(self.modules[id as usize].size() as u64)

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -115,4 +115,89 @@ impl Process {
     pub fn read_mem(&self, address: Address, buf: &mut [u8]) -> io::Result<()> {
         self.handle.copy_address(address as usize, buf)
     }
+
+    pub fn get_page_address_by_size(&mut self, size: u64) -> Result<Address, ModuleError> {
+        let now = Instant::now();
+        if now - self.last_check >= Duration::from_secs(1) {
+            self.modules = match proc_maps::get_process_maps(self.pid) {
+                Ok(m) => m,
+                Err(source) => {
+                    self.modules.clear();
+                    return Err(ModuleError::ListModules { source });
+                }
+            };
+            self.last_check = now;
+        }
+        self.modules
+        .iter()
+        .find(|m| m.size() as u64 == size)
+        .context(ModuleDoesntExist)
+        .map(|m| m.start() as u64)
+    }
+
+    pub fn get_last_page_address_by_size(&mut self, size: u64) -> Result<Address, ModuleError> {
+        let now = Instant::now();
+        if now - self.last_check >= Duration::from_secs(1) {
+            self.modules = match proc_maps::get_process_maps(self.pid) {
+                Ok(m) => m,
+                Err(source) => {
+                    self.modules.clear();
+                    return Err(ModuleError::ListModules { source });
+                }
+            };
+            self.last_check = now;
+        }
+        let mut addr: u64 = 0;
+        for page in &self.modules {
+            if page.size() as u64 == size {
+                addr = page.start() as u64
+            }
+        }
+        Ok(addr)
+    }
+
+    pub fn get_pages_count(&mut self) -> Result<u64, ModuleError> {
+        let now = Instant::now();
+        if now - self.last_check >= Duration::from_secs(1) {
+            self.modules = match proc_maps::get_process_maps(self.pid) {
+                Ok(m) => m,
+                Err(source) => {
+                    self.modules.clear();
+                    return Err(ModuleError::ListModules { source });
+                }
+            };
+            self.last_check = now;
+        }
+        Ok(self.modules.len() as u64)
+    }
+
+    pub fn get_page_address_by_id(&mut self, id: u64) -> Result<Address, ModuleError> {
+        let now = Instant::now();
+        if now - self.last_check >= Duration::from_secs(1) {
+            self.modules = match proc_maps::get_process_maps(self.pid) {
+                Ok(m) => m,
+                Err(source) => {
+                    self.modules.clear();
+                    return Err(ModuleError::ListModules { source });
+                }
+            };
+            self.last_check = now;
+        }
+        Ok(self.modules[id as usize].start() as u64)
+    }
+
+    pub fn get_page_size_by_id(&mut self, id: u64) -> Result<u64, ModuleError> {
+        let now = Instant::now();
+        if now - self.last_check >= Duration::from_secs(1) {
+            self.modules = match proc_maps::get_process_maps(self.pid) {
+                Ok(m) => m,
+                Err(source) => {
+                    self.modules.clear();
+                    return Err(ModuleError::ListModules { source });
+                }
+            };
+            self.last_check = now;
+        }
+        Ok(self.modules[id as usize].size() as u64)
+    }
 }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -486,6 +486,81 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
             source,
             name: "process_read",
         })?
+        .func_wrap("env", "process_get_page_address_by_size", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+                let ctx = caller.data_mut();
+                Ok(ctx
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .get_page_address_by_size(ptr)
+                    .unwrap_or_default())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_page_address_by_size",
+        })?
+        .func_wrap("env", "process_get_last_page_address_by_size", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+                let ctx = caller.data_mut();
+                Ok(ctx
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .get_last_page_address_by_size(ptr)
+                    .unwrap_or_default())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_last_page_address_by_size",
+        })?
+        .func_wrap("env", "process_get_pages_count", {
+            |mut caller: Caller<'_, Context<T>>, process: u64| {
+                let ctx = caller.data_mut();
+                Ok(ctx
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .get_pages_count()
+                    .unwrap_or_default())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_pages_count",
+        })?
+        .func_wrap("env", "process_get_page_address_by_id", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+                let ctx = caller.data_mut();
+                Ok(ctx
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .get_page_address_by_id(ptr)
+                    .unwrap_or_default())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_page_address_by_id",
+        })?
+        .func_wrap("env", "process_get_page_size_by_id", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+                let ctx = caller.data_mut();
+                Ok(ctx
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .get_page_size_by_id(ptr)
+                    .unwrap_or_default())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_page_size_by_id",
+        })?
         .func_wrap("env", "user_settings_add_bool", {
             |mut caller: Caller<'_, Context<T>>,
              key_ptr: u32,

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -486,80 +486,50 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
             source,
             name: "process_read",
         })?
-        .func_wrap("env", "process_get_page_address_by_size", {
-            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
-                let ctx = caller.data_mut();
-                Ok(ctx
-                    .processes
-                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .get_page_address_by_size(ptr)
-                    .unwrap_or_default())
-            }
-        })
-        .map_err(|source| CreationError::LinkFunction {
-            source,
-            name: "process_get_page_address_by_size",
-        })?
-        .func_wrap("env", "process_get_last_page_address_by_size", {
-            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
-                let ctx = caller.data_mut();
-                Ok(ctx
-                    .processes
-                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .get_last_page_address_by_size(ptr)
-                    .unwrap_or_default())
-            }
-        })
-        .map_err(|source| CreationError::LinkFunction {
-            source,
-            name: "process_get_last_page_address_by_size",
-        })?
-        .func_wrap("env", "process_get_pages_count", {
+        .func_wrap("env", "process_get_map_count", {
             |mut caller: Caller<'_, Context<T>>, process: u64| {
                 let ctx = caller.data_mut();
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
                     .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .get_pages_count()
+                    .get_map_count()
                     .unwrap_or_default())
             }
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
-            name: "process_get_pages_count",
+            name: "process_get_map_count",
         })?
-        .func_wrap("env", "process_get_page_address_by_id", {
-            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+        .func_wrap("env", "process_get_map_address_by_id", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u32| {
                 let ctx = caller.data_mut();
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
                     .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .get_page_address_by_id(ptr)
+                    .get_map_address_by_id(ptr)
                     .unwrap_or_default())
             }
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
-            name: "process_get_page_address_by_id",
+            name: "process_get_map_address_by_id",
         })?
-        .func_wrap("env", "process_get_page_size_by_id", {
-            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u64| {
+        .func_wrap("env", "process_get_map_size_by_id", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u32| {
                 let ctx = caller.data_mut();
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
                     .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .get_page_size_by_id(ptr)
+                    .get_map_size_by_id(ptr)
                     .unwrap_or_default())
             }
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
-            name: "process_get_page_size_by_id",
+            name: "process_get_map_size_by_id",
         })?
         .func_wrap("env", "user_settings_add_bool", {
             |mut caller: Caller<'_, Context<T>>,


### PR DESCRIPTION
This pull requests enables autosplitters to query for mapped regions in the virtual address space of a target process, essentially providing a similar functionality to OG LiveSplit's `Process.MemoryPages()` method.
The main function is `process_get_map_count()`, which essentially returns the number of maps (in OG LiveSplit they are called MemoryPages). The end user can then use this index (in a loop or in whichever other function they like) to recover the map's address and size, via the functions `process_get_map_address_by_id()` and `process_get_map_size_by_id()`.

This functionality is of pivotal improtance for a number of programs (especially emulators) in which querying for memory maps is a easier and way more effective way than trying to find a pointer path. 