### PR TITLE
Activate `WASI` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ wasm-web = [
 ]
 networking = ["std", "splits-io-api"]
 auto-splitting = ["std", "livesplit-auto-splitting", "tokio", "log"]
-unstable-auto-splitting = ["livesplit-auto-splitting?/unstable"]
 
 [lib]
 bench = false

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -19,8 +19,12 @@ sysinfo = { version = "0.29.0", default-features = false, features = [
   "multithread",
 ] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "9.0.2", default-features = false, features = [
+wasmtime = { version = "8.0.1", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = "9.0.2"
+wasmtime-wasi = "8.0.1"
+wasi-common = "8.0.1"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.2", features = ["fileapi"] }

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -15,15 +15,12 @@ proc-maps = { version = "0.3.0", default-features = false }
 read-process-memory = { version = "0.1.4", default-features = false }
 slotmap = { version = "1.0.2", default-features = false }
 snafu = "0.7.0"
-sysinfo = { version = "0.28.1", default-features = false, features = [
+sysinfo = { version = "0.29.0", default-features = false, features = [
   "multithread",
 ] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "8.0.0", default-features = false, features = [
+wasmtime = { version = "9.0.2", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = { version = "8.0.0", optional = true }
-
-[features]
-unstable = ["wasmtime-wasi"]
+wasmtime-wasi = "9.0.2"

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -169,5 +169,6 @@ extern "C" {
 }
 ```
 
-On top of the runtime's API, there's also unstable `WASI` support via the
-`unstable` feature.
+On top of the runtime's API, there's also WASI support. Considering WASI itself
+is still in preview, the API is subject to change. Auto splitters using WASI may
+need to be recompiled in the future.

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -137,6 +137,19 @@ extern "C" {
         idx: u64,
     ) -> Option<MemoryRangeFlags>;
 
+    /// Stores the file system path of the executable in the buffer given. The
+    /// path is a pa thth that is accessiblerough the WASI file system, so a
+    /// Windows path of `C:\foo\bar.exe` would be returned as
+    /// `/mnt/c/foo/bar.exe`. Returns `false` if the buffer is too small. After
+    /// this call, no matter whether it was successful or not, the
+    /// `buf_len_ptr` will be set to the required buffer size. The path is
+    /// guaranteed to be valid UTF-8 and is not nul-terminated.
+    pub fn process_get_path(
+        process: ProcessId,
+        buf_ptr: *mut u8,
+        buf_len_ptr: *mut usize,
+    ) -> bool;
+
     /// Sets the tick rate of the runtime. This influences the amount of
     /// times the `update` function is called per second.
     pub fn runtime_set_tick_rate(ticks_per_second: f64);
@@ -169,6 +182,17 @@ extern "C" {
 }
 ```
 
-On top of the runtime's API, there's also WASI support. Considering WASI itself
-is still in preview, the API is subject to change. Auto splitters using WASI may
-need to be recompiled in the future.
+On top of the runtime's API, there's also WASI support. Considering WASI
+itself is still in preview, the API is subject to change. Auto splitters
+using WASI may need to be recompiled in the future. Limitations of the WASI
+support:
+
+- `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+  nothing.
+- The file system is currently almost entirely empty. The host's file system
+  is accessible through `/mnt`. It is entirely read-only. Windows paths are
+  mapped to `/mnt/c`, `/mnt/d`, etc. to match WSL.
+- There are no environment variables.
+- There are no command line arguments.
+- There is no networking.
+- There is no threading.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -169,8 +169,9 @@
 //! }
 //! ```
 //!
-//! On top of the runtime's API, there's also unstable `WASI` support via the
-//! `unstable` feature.
+//! On top of the runtime's API, there's also WASI support. Considering WASI
+//! itself is still in preview, the API is subject to change. Auto splitters
+//! using WASI may need to be recompiled in the future.
 
 #![warn(
     clippy::complexity,

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -137,6 +137,19 @@
 //!         idx: u64,
 //!     ) -> Option<MemoryRangeFlags>;
 //!
+//!     /// Stores the file system path of the executable in the buffer given. The
+//!     /// path is a path that is accessible through the WASI file system, so a
+//!     /// Windows path of `C:\foo\bar.exe` would be returned as
+//!     /// `/mnt/c/foo/bar.exe`. Returns `false` if the buffer is too small. After
+//!     /// this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The path is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     pub fn process_get_path(
+//!         process: ProcessId,
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
+//!
 //!     /// Sets the tick rate of the runtime. This influences the amount of
 //!     /// times the `update` function is called per second.
 //!     pub fn runtime_set_tick_rate(ticks_per_second: f64);
@@ -171,7 +184,18 @@
 //!
 //! On top of the runtime's API, there's also WASI support. Considering WASI
 //! itself is still in preview, the API is subject to change. Auto splitters
-//! using WASI may need to be recompiled in the future.
+//! using WASI may need to be recompiled in the future. Limitations of the WASI
+//! support:
+//!
+//! - `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+//!   nothing.
+//! - The file system is currently almost entirely empty. The host's file system
+//!   is accessible through `/mnt`. It is entirely read-only. Windows paths are
+//!   mapped to `/mnt/c`, `/mnt/d`, etc. to match WSL.
+//! - There are no environment variables.
+//! - There are no command line arguments.
+//! - There is no networking.
+//! - There is no threading.
 
 #![warn(
     clippy::complexity,

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::{process::Process, settings::UserSetting, timer::Timer, SettingValue, SettingsStore};
 
-use anyhow::{Context as _, Result};
+use anyhow::{format_err, Context as _, Result};
 use slotmap::{Key, KeyData, SlotMap};
 use snafu::Snafu;
 use std::{
@@ -246,10 +246,7 @@ impl<T: Timer> Runtime<T> {
 }
 
 fn build_wasi() -> WasiCtx {
-    let wasi = WasiCtxBuilder::new()
-        .inherit_stdout()
-        .inherit_stderr()
-        .build();
+    let wasi = WasiCtxBuilder::new().build();
 
     #[cfg(windows)]
     {
@@ -382,7 +379,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "runtime_print_message", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
-                let message = read_str(memory, ptr, len)?;
+                let message = get_str(memory, ptr, len)?;
                 context.timer.log(format_args!("{message}"));
                 Ok(())
             }
@@ -394,13 +391,13 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "runtime_get_os", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
-                let len_bytes = read_arr_mut(memory, len_ptr)?;
+                let len_bytes = get_arr_mut(memory, len_ptr)?;
                 let len = u32::from_le_bytes(*len_bytes) as usize;
                 *len_bytes = (OS.len() as u32).to_le_bytes();
                 if len < OS.len() {
                     return Ok(0u32);
                 }
-                let buf = read_slice_mut(memory, ptr, OS.len() as _)?;
+                let buf = get_slice_mut(memory, ptr, OS.len() as _)?;
                 buf.copy_from_slice(OS.as_bytes());
                 Ok(1u32)
             }
@@ -412,13 +409,13 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "runtime_get_arch", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
-                let len_bytes = read_arr_mut(memory, len_ptr)?;
+                let len_bytes = get_arr_mut(memory, len_ptr)?;
                 let len = u32::from_le_bytes(*len_bytes) as usize;
                 *len_bytes = (ARCH.len() as u32).to_le_bytes();
                 if len < ARCH.len() {
                     return Ok(0u32);
                 }
-                let buf = read_slice_mut(memory, ptr, ARCH.len() as _)?;
+                let buf = get_slice_mut(memory, ptr, ARCH.len() as _)?;
                 buf.copy_from_slice(ARCH.as_bytes());
                 Ok(1u32)
             }
@@ -435,8 +432,8 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
              value_len: u32|
              -> Result<()> {
                 let (memory, context) = memory_and_context(&mut caller);
-                let name = read_str(memory, name_ptr, name_len)?;
-                let value = read_str(memory, value_ptr, value_len)?;
+                let name = get_str(memory, name_ptr, name_len)?;
+                let value = get_str(memory, value_ptr, value_len)?;
                 context.timer.set_variable(name, value);
                 Ok(())
             }
@@ -448,7 +445,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "process_attach", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
-                let process_name = read_str(memory, ptr, len)?;
+                let process_name = get_str(memory, ptr, len)?;
                 Ok(
                     if let Ok(p) = Process::with_name(process_name, &mut context.process_list) {
                         context
@@ -471,7 +468,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                     .data_mut()
                     .processes
                     .remove(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle {process}"))?;
+                    .ok_or_else(|| format_err!("Invalid process handle {process}"))?;
                 caller
                     .data_mut()
                     .timer
@@ -489,7 +486,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 let proc = ctx
                     .processes
                     .get(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?;
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?;
                 Ok(proc.is_open(&mut ctx.process_list) as u32)
             }
         })
@@ -500,11 +497,11 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "process_get_module_address", {
             |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
-                let module_name = read_str(memory, ptr, len)?;
+                let module_name = get_str(memory, ptr, len)?;
                 Ok(context
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .module_address(module_name)
                     .unwrap_or_default())
             }
@@ -516,11 +513,11 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .func_wrap("env", "process_get_module_size", {
             |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
-                let module_name = read_str(memory, ptr, len)?;
+                let module_name = get_str(memory, ptr, len)?;
                 Ok(context
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .module_size(module_name)
                     .unwrap_or_default())
             }
@@ -528,6 +525,31 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "process_get_module_size",
+        })?
+        .func_wrap("env", "process_get_path", {
+            |mut caller: Caller<'_, Context<T>>, process: u64, ptr: u32, len_ptr: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let path = context
+                    .processes
+                    .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
+                    .path()
+                    .unwrap_or_default();
+
+                let len_bytes = get_arr_mut(memory, len_ptr)?;
+                let len = u32::from_le_bytes(*len_bytes) as usize;
+                *len_bytes = (path.len() as u32).to_le_bytes();
+                if len < path.len() {
+                    return Ok(0u32);
+                }
+                let buf = get_slice_mut(memory, ptr, path.len() as _)?;
+                buf.copy_from_slice(path.as_bytes());
+                Ok(1u32)
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "process_get_path",
         })?
         .func_wrap("env", "process_read", {
             |mut caller: Caller<'_, Context<T>>,
@@ -539,8 +561,8 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 Ok(context
                     .processes
                     .get(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
-                    .read_mem(address, read_slice_mut(memory, buf_ptr, buf_len)?)
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
+                    .read_mem(address, get_slice_mut(memory, buf_ptr, buf_len)?)
                     .is_ok() as u32)
             }
         })
@@ -554,7 +576,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .get_memory_range_count()
                     .unwrap_or_default() as u64)
             }
@@ -569,7 +591,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .get_memory_range_address(idx as usize)
                     .unwrap_or_default())
             }
@@ -584,7 +606,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .get_memory_range_size(idx as usize)
                     .unwrap_or_default())
             }
@@ -599,7 +621,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                 Ok(ctx
                     .processes
                     .get_mut(ProcessKey::from(KeyData::from_ffi(process as u64)))
-                    .ok_or_else(|| anyhow::format_err!("Invalid process handle: {process}"))?
+                    .ok_or_else(|| format_err!("Invalid process handle: {process}"))?
                     .get_memory_range_flags(idx as usize)
                     .unwrap_or_default())
             }
@@ -616,8 +638,8 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
              description_len: u32,
              default_value: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
-                let key = Box::<str>::from(read_str(memory, key_ptr, key_len)?);
-                let description = read_str(memory, description_ptr, description_len)?.into();
+                let key = Box::<str>::from(get_str(memory, key_ptr, key_len)?);
+                let description = get_str(memory, description_ptr, description_len)?.into();
                 let default_value = default_value != 0;
                 let value_in_store = match context.settings_store.get(&key) {
                     Some(SettingValue::Bool(v)) => *v,
@@ -650,24 +672,24 @@ fn memory_and_context<'a, T: Timer>(
     caller.data().memory.unwrap().data_and_store_mut(caller)
 }
 
-fn read_arr_mut<const N: usize>(memory: &mut [u8], ptr: u32) -> Result<&mut [u8; N]> {
+fn get_arr_mut<const N: usize>(memory: &mut [u8], ptr: u32) -> Result<&mut [u8; N]> {
     assert!(N <= u32::MAX as usize);
-    Ok(read_slice_mut(memory, ptr, N as _)?.try_into().unwrap())
+    Ok(get_slice_mut(memory, ptr, N as _)?.try_into().unwrap())
 }
 
-fn read_slice(memory: &[u8], ptr: u32, len: u32) -> Result<&[u8]> {
+fn get_slice(memory: &[u8], ptr: u32, len: u32) -> Result<&[u8]> {
     memory
         .get(ptr as usize..(ptr + len) as usize)
         .context("Out of bounds pointer and length pair.")
 }
 
-fn read_slice_mut(memory: &mut [u8], ptr: u32, len: u32) -> Result<&mut [u8]> {
+fn get_slice_mut(memory: &mut [u8], ptr: u32, len: u32) -> Result<&mut [u8]> {
     memory
         .get_mut(ptr as usize..(ptr + len) as usize)
         .context("Out of bounds pointer and length pair.")
 }
 
-fn read_str(memory: &[u8], ptr: u32, len: u32) -> Result<&str> {
-    let slice = read_slice(memory, ptr, len)?;
+fn get_str(memory: &[u8], ptr: u32, len: u32) -> Result<&str> {
+    let slice = get_slice(memory, ptr, len)?;
     str::from_utf8(slice).map_err(Into::into)
 }

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "unstable")]
-
 use livesplit_auto_splitting::{Runtime, SettingsStore, Timer, TimerState};
 use std::{
     ffi::OsStr,

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -107,6 +107,19 @@
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
 //!
+//!     /// Stores the file system path of the executable in the buffer given. The
+//!     /// path is a path that is accessible through the WASI file system, so a
+//!     /// Windows path of `C:\foo\bar.exe` would be returned as
+//!     /// `/mnt/c/foo/bar.exe`. Returns `false` if the buffer is too small. After
+//!     /// this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size. The path is
+//!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     pub fn process_get_path(
+//!         process: ProcessId,
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
+//!
 //!     /// Sets the tick rate of the runtime. This influences the amount of
 //!     /// times the `update` function is called per second.
 //!     pub fn runtime_set_tick_rate(ticks_per_second: f64);
@@ -141,7 +154,18 @@
 //!
 //! On top of the runtime's API, there's also WASI support. Considering WASI
 //! itself is still in preview, the API is subject to change. Auto splitters
-//! using WASI may need to be recompiled in the future.
+//! using WASI may need to be recompiled in the future. Limitations of the WASI
+//! support:
+//!
+//! - `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+//!   nothing.
+//! - The file system is currently almost entirely empty. The host's file system
+//!   is accessible through `/mnt`. It is entirely read-only. Windows paths are
+//!   mapped to `/mnt/c`, `/mnt/d`, etc. to match WSL.
+//! - There are no environment variables.
+//! - There are no command line arguments.
+//! - There is no networking.
+//! - There is no threading.
 
 use crate::timing::{SharedTimer, TimerPhase};
 use livesplit_auto_splitting::{

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -138,6 +138,10 @@
 //!     ) -> bool;
 //! }
 //! ```
+//!
+//! On top of the runtime's API, there's also WASI support. Considering WASI
+//! itself is still in preview, the API is subject to change. Auto splitters
+//! using WASI may need to be recompiled in the future.
 
 use crate::timing::{SharedTimer, TimerPhase};
 use livesplit_auto_splitting::{


### PR DESCRIPTION
While WASI itself is still in preview and the API is subject to change, we now activate it by default, but warn the user about it. This should allow writing auto splitters in more languages that support WASI but not freestanding WASM.

Limitations of the WASI support:

- `stout` / `stderr` / `stdin` are unbound. Those streams currently do   nothing.
- The file system is currently almost entirely empty. The host's file system is accessible through `/mnt`. It is entirely read-only. Windows paths are mapped to `/mnt/c`, `/mnt/d`, etc. to match WSL.
- There are no environment variables.
- There are no command line arguments.
- There is no networking.
- There is no threading.