### PR TITLE
Support WASI Reactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 ]
 edition = "2021"
 resolver = "2"
-rust-version = "1.63"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -82,7 +82,7 @@ impl Process {
         self.refresh_memory_ranges()?;
         self.memory_ranges
             .iter()
-            .find(|m| m.filename().map_or(false, |f| f.ends_with(module)))
+            .find(|m| m.filename().is_some_and(|f| f.ends_with(module)))
             .context(ModuleDoesntExist)
             .map(|m| m.start() as u64)
     }
@@ -92,7 +92,7 @@ impl Process {
         Ok(self
             .memory_ranges
             .iter()
-            .filter(|m| m.filename().map_or(false, |f| f.ends_with(module)))
+            .filter(|m| m.filename().is_some_and(|f| f.ends_with(module)))
             .map(|m| m.size() as u64)
             .sum())
     }

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -193,10 +193,11 @@ impl<T: Timer> Runtime<T> {
         if uses_wasi {
             store.data_mut().timer.log(format_args!("This auto splitter uses WASI. The API is subject to change, because WASI is still in preview. Auto splitters using WASI may need to be recompiled in the future."));
 
-            // TODO: _start is kind of correct, but not in the long term. They are
-            // intending for us to use a different function for libraries. Look into
-            // reactors.
-            if let Ok(func) = instance.get_typed_func(&mut store, "_start") {
+            // These may be different in future WASI versions.
+            if let Ok(func) = instance.get_typed_func(&mut store, "_initialize") {
+                func.call(&mut store, ())
+                    .map_err(|source| CreationError::WasiStart { source })?;
+            } else if let Ok(func) = instance.get_typed_func(&mut store, "_start") {
                 func.call(&mut store, ())
                     .map_err(|source| CreationError::WasiStart { source })?;
             }

--- a/crates/livesplit-title-abbreviations/src/lib.rs
+++ b/crates/livesplit-title-abbreviations/src/lib.rs
@@ -8,13 +8,14 @@ use unicase::UniCase;
 // FIXME: Use generators once those work on stable Rust.
 
 fn ends_with_roman_numeral(name: &str) -> bool {
-    name.split_whitespace().rev().next().map_or(false, |n| {
-        n.chars().all(|c| c == 'I' || c == 'V' || c == 'X')
-    })
+    name.split_whitespace()
+        .rev()
+        .next()
+        .is_some_and(|n| n.bytes().all(|c| matches!(c, b'I' | b'V' | b'X')))
 }
 
 fn ends_with_numeric(name: &str) -> bool {
-    name.chars().last().map_or(false, |c| c.is_numeric())
+    name.chars().last().is_some_and(|c| c.is_numeric())
 }
 
 fn series_subtitle_handling(name: &str, split_token: &str, list: &mut Vec<Box<str>>) -> bool {
@@ -225,8 +226,7 @@ pub fn abbreviate_category(category: &str) -> Vec<Box<str>> {
 #[cfg(test)]
 mod tests {
     use super::abbreviate;
-    use alloc::boxed::Box;
-    use alloc::vec;
+    use alloc::{boxed::Box, vec};
 
     // The tests using actual game titles can be thrown out or edited if any
     // major changes need to be made to the abbreviation algorithm. Do not

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -282,8 +282,8 @@ pub fn check_live_delta(
 
         if split_delta && current_time > current_split
             || catch! { current_segment? > best_segment? }.unwrap_or(false)
-                && best_segment_delta.map_or(false, |d| d > TimeSpan::zero())
-            || comparison_delta.map_or(false, |d| d > TimeSpan::zero())
+                && best_segment_delta.is_some_and(|d| d > TimeSpan::zero())
+            || comparison_delta.is_some_and(|d| d > TimeSpan::zero())
         {
             return if split_delta {
                 catch! { current_time? - current_split? }
@@ -324,12 +324,12 @@ pub fn split_color(
             .checked_sub(1)
             .and_then(|n| last_delta(timer.run(), n, comparison, method));
         if time_difference < TimeSpan::zero() {
-            if show_segment_deltas && last_delta.map_or(false, |d| time_difference > d) {
+            if show_segment_deltas && last_delta.is_some_and(|d| time_difference > d) {
                 SemanticColor::AheadLosingTime
             } else {
                 SemanticColor::AheadGainingTime
             }
-        } else if show_segment_deltas && last_delta.map_or(false, |d| time_difference < d) {
+        } else if show_segment_deltas && last_delta.is_some_and(|d| time_difference < d) {
             SemanticColor::BehindGainingTime
         } else {
             SemanticColor::BehindLosingTime
@@ -356,6 +356,6 @@ pub fn check_best_segment(timer: &Timer, segment_index: usize, method: TimingMet
     let current_segment = previous_segment_time(timer, segment_index, method);
     let best_segment = timer.run().segment(segment_index).best_segment_time()[method];
     best_segment.map_or(true, |b| {
-        current_segment.map_or(false, |c| c < b) || delta.map_or(false, |d| d < TimeSpan::zero())
+        current_segment.is_some_and(|c| c < b) || delta.is_some_and(|d| d < TimeSpan::zero())
     })
 }

--- a/src/platform/normal/mod.rs
+++ b/src/platform/normal/mod.rs
@@ -7,7 +7,10 @@ cfg_if::cfg_if! {
     // guarantees "real time" nor does it guarantee measuring "uptime" (the time
     // the OS has been awake rather than suspended), meaning that you can't
     // actually rely on it in practice. In livesplit-core we definitely want
-    // real time rather than uptime. Various operating systems are problematic:
+    // real time rather than uptime. The problem in std is being tracked here:
+    // https://github.com/rust-lang/rust/issues/87906
+    //
+    // Various operating systems are problematic:
     //
     // # Linux, BSD and other Unixes
     //

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -567,7 +567,7 @@ impl Run {
     fn fix_comparison_times_and_history(&mut self, method: TimingMethod) {
         // Remove negative Best Segment Times
         for segment in &mut self.segments {
-            if segment.best_segment_time_mut()[method].map_or(false, |t| t < TimeSpan::zero()) {
+            if segment.best_segment_time_mut()[method].is_some_and(|t| t < TimeSpan::zero()) {
                 segment.best_segment_time_mut()[method] = None;
             }
         }

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -317,7 +317,7 @@ impl Timer {
         if self.phase == Running
             && current_time
                 .real_time
-                .map_or(false, |t| t >= TimeSpan::zero())
+                .is_some_and(|t| t >= TimeSpan::zero())
         {
             // FIXME: We shouldn't need to collect here.
             let variables = self
@@ -744,7 +744,7 @@ impl Timer {
                 if split
                     .best_segment_time()
                     .real_time
-                    .map_or(true, |b| current_segment.map_or(false, |c| c < b))
+                    .map_or(true, |b| current_segment.is_some_and(|c| c < b))
                 {
                     new_best_segment.real_time = current_segment;
                 }
@@ -756,7 +756,7 @@ impl Timer {
                 if split
                     .best_segment_time()
                     .game_time
-                    .map_or(true, |b| current_segment.map_or(false, |c| c < b))
+                    .map_or(true, |b| current_segment.is_some_and(|c| c < b))
                 {
                     new_best_segment.game_time = current_segment;
                 }
@@ -774,7 +774,7 @@ impl Timer {
                 last_segment.personal_best_split_time()[method],
             )
         };
-        if split_time.map_or(false, |s| pb_split_time.map_or(true, |pb| s < pb)) {
+        if split_time.is_some_and(|s| pb_split_time.map_or(true, |pb| s < pb)) {
             self.set_run_as_pb();
         }
     }


### PR DESCRIPTION
This adds support for WASI Reactors. Unlike WASI Commands, they use `_initialize` instead of `_start` to initialize their internal state.

This also adds some cleanups, such as `is_some_and`, that got introduced in the latest Rust version.