### PR TITLE
Pass Shaping option as needed

### DIFF
--- a/src/rendering/default_text_engine/mod.rs
+++ b/src/rendering/default_text_engine/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use cosmic_text::{
     fontdb::{Database, Query, Source, ID},
     rustybuzz::ttf_parser::{GlyphId, OutlineBuilder},
-    Attrs, AttrsList, Family, FontSystem, ShapeLine, Stretch, Style, Weight,
+    Attrs, AttrsList, Family, FontSystem, ShapeLine, Shaping, Stretch, Style, Weight,
 };
 use hashbrown::HashMap;
 
@@ -164,7 +164,12 @@ impl<P: SharedOwnership> TextEngine<P> {
     }
 
     fn glyph_width(&mut self, glyph_text: &str, attrs_list: &AttrsList) -> Option<(ID, u16, f32)> {
-        let shape_line = ShapeLine::new(&mut self.font_system, glyph_text, attrs_list);
+        let shape_line = ShapeLine::new(
+            &mut self.font_system,
+            glyph_text,
+            attrs_list,
+            Shaping::Advanced,
+        );
         if let [span] = &*shape_line.spans {
             if let [word] = &*span.words {
                 if let [glyph] = &*word.glyphs {
@@ -209,7 +214,12 @@ impl<P: SharedOwnership> TextEngine<P> {
 
         label.glyphs.clear();
 
-        let shape_line = ShapeLine::new(&mut self.font_system, text, &font.attrs_list);
+        let shape_line = ShapeLine::new(
+            &mut self.font_system,
+            text,
+            &font.attrs_list,
+            Shaping::Advanced,
+        );
         let [mut x, mut y] = [0.0; 2];
 
         if let Some(monotonic) = &font.monotonic {


### PR DESCRIPTION
There seems to currently only be one Shaping option available (Advanced) unless we wanted to require the "swash" feature. While Advanced is more expensive, it should also be the safest option.