### PR TITLE
Fixes for C# bindings

### DIFF
--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -191,9 +191,9 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             write!(writer, r#"var result = new {return_type}("#)?;
         } else {
             write!(writer, "var result = ")?;
-            if return_type_ll == "UIntPtr" {
+            if return_type_ll == "UIntPtr" && return_type == "ulong" {
                 write!(writer, "(ulong)")?;
-            } else if return_type_ll == "IntPtr" {
+            } else if return_type_ll == "IntPtr" && return_type == "long" {
                 write!(writer, "(long)")?;
             }
         }
@@ -211,12 +211,12 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
             "{}",
             if name == "this" {
                 "this.ptr".to_string()
+            } else if typ.is_custom {
+                format!("{}.ptr", name.to_lower_camel_case())
             } else if ty_name == "UIntPtr" {
                 format!("(UIntPtr){}", name.to_lower_camel_case())
             } else if ty_name == "IntPtr" {
                 format!("(IntPtr){}", name.to_lower_camel_case())
-            } else if typ.is_custom {
-                format!("{}.ptr", name.to_lower_camel_case())
             } else {
                 name.to_lower_camel_case()
             }
@@ -416,7 +416,7 @@ namespace LiveSplitCore
             try
             {
                 Marshal.Copy(data, 0, pnt, data.Length);
-                return Parse(pnt, data.Length, loadFilesPath);
+                return Parse(pnt, (ulong)data.Length, loadFilesPath);
             }
             finally
             {

--- a/capi/src/time_span.rs
+++ b/capi/src/time_span.rs
@@ -42,3 +42,17 @@ pub unsafe extern "C" fn TimeSpan_parse(text: *const c_char) -> NullableOwnedTim
 pub extern "C" fn TimeSpan_total_seconds(this: &TimeSpan) -> f64 {
     this.total_seconds()
 }
+
+/// Returns the total amount of whole seconds (excluding decimals) this Time
+/// Span represents.
+#[no_mangle]
+pub extern "C" fn TimeSpan_whole_seconds(this: &TimeSpan) -> i64 {
+    this.to_seconds_and_subsec_nanoseconds().0
+}
+
+/// Returns the number of nanoseconds past the last full second that makes up
+/// the Time Span.
+#[no_mangle]
+pub extern "C" fn TimeSpan_subsec_nanoseconds(this: &TimeSpan) -> i32 {
+    this.to_seconds_and_subsec_nanoseconds().1
+}


### PR DESCRIPTION
- Fix issues with custom types being cast to `IntPtr`/`long`/`ulong` incorrectly
- Expose whole seconds and nanoseconds for `TimeSpan`s in the C API