### PR TITLE
Allow auto splitters to skip and undo splits

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -73,6 +73,10 @@ extern "C" {
     pub fn timer_start();
     /// Splits the current segment.
     pub fn timer_split();
+    /// Skips the current split.
+    pub fn timer_skip_split();
+    /// Undoes the previous split.
+    pub fn timer_undo_split();
     /// Resets the timer.
     pub fn timer_reset();
     /// Sets a custom key value pair. This may be arbitrary information that

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -73,6 +73,10 @@
 //!     pub fn timer_start();
 //!     /// Splits the current segment.
 //!     pub fn timer_split();
+//!     /// Skips the current split.
+//!     pub fn timer_skip_split();
+//!     /// Undoes the previous split.
+//!     pub fn timer_undo_split();
 //!     /// Resets the timer.
 //!     pub fn timer_reset();
 //!     /// Sets a custom key value pair. This may be arbitrary information that

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -322,6 +322,28 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
         })?
         .func_wrap(
             "env",
+            "timer_skip_split",
+            |mut caller: Caller<'_, Context<T>>| {
+                caller.data_mut().timer.skip_split();
+            },
+        )
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "timer_skip_split",
+        })?
+        .func_wrap(
+            "env",
+            "timer_undo_split",
+            |mut caller: Caller<'_, Context<T>>| {
+                caller.data_mut().timer.undo_split();
+            },
+        )
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "timer_undo_split",
+        })?
+        .func_wrap(
+            "env",
             "timer_reset",
             |mut caller: Caller<'_, Context<T>>| {
                 caller.data_mut().timer.reset();

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -24,6 +24,10 @@ pub trait Timer {
     fn start(&mut self);
     /// Splits the current segment.
     fn split(&mut self);
+    /// Skips the current split.
+    fn skip_split(&mut self);
+    /// Undoes the previous split.
+    fn undo_split(&mut self);
     /// Resets the timer.
     fn reset(&mut self);
     /// Sets the game time.

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -16,6 +16,8 @@ impl Timer for DummyTimer {
     }
     fn start(&mut self) {}
     fn split(&mut self) {}
+    fn skip_split(&mut self) {}
+    fn undo_split(&mut self) {}
     fn reset(&mut self) {}
     fn set_game_time(&mut self, _time: time::Duration) {}
     fn pause_game_time(&mut self) {}

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -59,6 +59,10 @@
 //!     pub fn timer_start();
 //!     /// Splits the current segment.
 //!     pub fn timer_split();
+//!     /// Skips the current split.
+//!     pub fn timer_skip_split();
+//!     /// Undoes the previous split.
+//!     pub fn timer_undo_split();
 //!     /// Resets the timer.
 //!     pub fn timer_reset();
 //!     /// Sets a custom key value pair. This may be arbitrary information that
@@ -326,6 +330,14 @@ impl AutoSplitTimer for Timer {
 
     fn split(&mut self) {
         self.0.write().unwrap().split()
+    }
+
+    fn skip_split(&mut self) {
+        self.0.write().unwrap().skip_split()
+    }
+
+    fn undo_split(&mut self) {
+        self.0.write().unwrap().undo_split()
     }
 
     fn reset(&mut self) {


### PR DESCRIPTION
This exposes two new functions for auto splitters to use: `timer_skip_split` and `timer_undo_split`. While these might not necessarily be recommended to use, there are some cases where they make sense.