### PR TITLE
Expose attached processes and linear memory

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -216,6 +216,7 @@ mod runtime;
 mod settings;
 mod timer;
 
+pub use process::Process;
 pub use runtime::{CreationError, InterruptHandle, Runtime};
 pub use settings::{SettingValue, SettingsStore, UserSetting};
 pub use time;


### PR DESCRIPTION
This exposes the attached processes and the linear memory of an auto splitter so they can be used for debugging purposes.

This also fixes a few bugs.