### PR TITLE
Use the released version of `cosmic-text`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - '*'
 
-# The colors mess with the problem matcher.
-# env:
-  # CARGO_TERM_COLOR: always
-
 jobs:
   build:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
@@ -21,8 +17,8 @@ jobs:
         label:
           # Bare Metal
           - Bare Metal Nvidia PTX 64
-          # FIXME: ouroboros currently can't handle this target.
-          # https://github.com/joshua-maros/ouroboros/issues/81
+          # FIXME: fontdb currently can't handle this target.
+          # The `alloc::sync` module does not exist.
           # - Bare Metal ARM Cortex-M thumbv6m
           - Bare Metal ARM Cortex-M thumbv7em
           - Bare Metal ARM Cortex-M thumbv7em Hardware Float
@@ -131,8 +127,8 @@ jobs:
             no_std: true
             install_target: true
 
-          # FIXME: ouroboros currently can't handle this target.
-          # https://github.com/joshua-maros/ouroboros/issues/81
+          # FIXME: fontdb currently can't handle this target.
+          # The `alloc::sync` module does not exist.
           # - label: Bare Metal ARM Cortex-M thumbv6m
           #   target: thumbv6m-none-eabi
           #   tests: skip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,17 +63,17 @@ image = { version = "0.24.0", features = [
 # Currently doesn't require any additional dependencies.
 
 # Default Text Engine
-cosmic-text = { git = "https://github.com/pop-os/cosmic-text", default-features = false, optional = true }
+cosmic-text = { version = "0.9.0", default-features = false, optional = true }
 
 # Font Loading
 # Currently doesn't require any additional dependencies.
 
 # Software Rendering
-tiny-skia = { version = "0.9.0", default-features = false, features = [
+tiny-skia = { version = "0.11.1", default-features = false, features = [
     "no-std-float",
     "simd",
 ], optional = true }
-tiny-skia-path = { version = "0.9.0", default-features = false, optional = true }
+tiny-skia-path = { version = "0.11.1", default-features = false, optional = true }
 
 # Networking
 splits-io-api = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Ever since we switched to using the `cosmic-text` crate, we've been using their `master` branch, because it did not build correctly on WebAssembly. They just published a new version that fixes this issue.

Additionally this bumps the versions of the `tiny-skia` crates as well.