### PR TITLE
Switch from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,11 @@ web-sys = { version = "0.3.28", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-# We need winapi to use GDI to resolve fonts on Windows.
-winapi = { version = "0.3.9", features = ["wingdi"], optional = true }
+# We need windows-sys to use GDI to resolve fonts on Windows.
+windows-sys = { version = "0.48.0", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+], optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "l4re", target_os = "android", target_os = "macos", target_os = "ios"))'.dependencies]
 # We need libc for our own implementation of Instant
@@ -126,7 +129,7 @@ std = [
     "snafu/std",
     "time/local-offset",
     "tiny-skia?/std",
-    "winapi",
+    "windows-sys",
 ]
 more-image-formats = [
     "image?/bmp",

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -27,4 +27,4 @@ wasmtime-wasi = "8.0.1"
 wasi-common = "8.0.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.2", features = ["fileapi"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem"] }

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -10,10 +10,12 @@ keywords = ["speedrun", "timer", "livesplit", "hotkey", "keyboard"]
 edition = "2021"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.2", features = [
-    "libloaderapi",
-    "processthreadsapi",
-    "winuser"
+windows-sys = { version = "0.48.0", features = [
+    "Win32_Foundation",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
 ], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -37,5 +39,5 @@ bitflags = "2.0.1"
 
 [features]
 default = ["std"]
-std = ["snafu/std", "serde/std", "crossbeam-channel", "evdev", "mio", "nix", "promising-future", "winapi", "x11-dl"]
+std = ["snafu/std", "serde/std", "crossbeam-channel", "evdev", "mio", "nix", "promising-future", "windows-sys", "x11-dl"]
 wasm-web = ["wasm-bindgen", "web-sys", "js-sys"]


### PR DESCRIPTION
The `winapi` crate is the traditional way for interacting with the Windows API. However, nowadays Microsoft is providing a more up-to-date crate called `windows-sys`. This replaces the `winapi` dependency with `windows-sys`. The only real disadvantage is that they release major versions more often, resulting in more duplicates in the `Cargo.lock`.