### PR TITLE
Add Tooltips and Titles to Auto Splitters

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -174,8 +174,10 @@ extern "C" {
     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
-    /// Adds a new setting that the user can modify. This will return either
-    /// the specified default value or the value that the user has set.
+    /// Adds a new boolean setting that the user can modify. This will return
+    /// either the specified default value or the value that the user has set.
+    /// The key is used to store the setting and needs to be unique across all
+    /// types of settings.
     pub fn user_settings_add_bool(
         key_ptr: *const u8,
         key_len: usize,
@@ -183,6 +185,25 @@ extern "C" {
         description_len: usize,
         default_value: bool,
     ) -> bool;
+    /// Adds a new title to the user settings. This is used to group settings
+    /// together. The heading level determines the size of the title. The top
+    /// level titles use a heading level of 0. The key needs to be unique across
+    /// all types of settings.
+    pub fn user_settings_add_title(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        heading_level: u32,
+    );
+    /// Adds a tooltip to a setting based on its key. A tooltip is useful for
+    /// explaining the purpose of a setting to the user.
+    pub fn user_settings_set_tooltip(
+        key_ptr: *const u8,
+        key_len: usize,
+        tooltip_ptr: *const u8,
+        tooltip_len: usize,
+    );
 }
 ```
 
@@ -191,7 +212,7 @@ itself is still in preview, the API is subject to change. Auto splitters
 using WASI may need to be recompiled in the future. Limitations of the WASI
 support:
 
-- `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+- `stdout` / `stderr` / `stdin` are unbound. Those streams currently do
   nothing.
 - The file system is currently almost entirely empty. The host's file system
   is accessible through `/mnt`. It is entirely read-only. Windows paths are

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -174,8 +174,10 @@
 //!     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
 //!     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
-//!     /// Adds a new setting that the user can modify. This will return either
-//!     /// the specified default value or the value that the user has set.
+//!     /// Adds a new boolean setting that the user can modify. This will return
+//!     /// either the specified default value or the value that the user has set.
+//!     /// The key is used to store the setting and needs to be unique across all
+//!     /// types of settings.
 //!     pub fn user_settings_add_bool(
 //!         key_ptr: *const u8,
 //!         key_len: usize,
@@ -183,6 +185,25 @@
 //!         description_len: usize,
 //!         default_value: bool,
 //!     ) -> bool;
+//!     /// Adds a new title to the user settings. This is used to group settings
+//!     /// together. The heading level determines the size of the title. The top
+//!     /// level titles use a heading level of 0. The key needs to be unique across
+//!     /// all types of settings.
+//!     pub fn user_settings_add_title(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         heading_level: u32,
+//!     );
+//!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
+//!     /// explaining the purpose of a setting to the user.
+//!     pub fn user_settings_set_tooltip(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         tooltip_ptr: *const u8,
+//!         tooltip_len: usize,
+//!     );
 //! }
 //! ```
 //!
@@ -191,7 +212,7 @@
 //! using WASI may need to be recompiled in the future. Limitations of the WASI
 //! support:
 //!
-//! - `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+//! - `stdout` / `stderr` / `stdin` are unbound. Those streams currently do
 //!   nothing.
 //! - The file system is currently almost entirely empty. The host's file system
 //!   is accessible through `/mnt`. It is entirely read-only. Windows paths are
@@ -218,6 +239,6 @@ mod timer;
 
 pub use process::Process;
 pub use runtime::{CreationError, InterruptHandle, Runtime};
-pub use settings::{SettingValue, SettingsStore, UserSetting};
+pub use settings::{SettingValue, SettingsStore, UserSetting, UserSettingKind};
 pub use time;
 pub use timer::{Timer, TimerState};

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -4,13 +4,35 @@ use std::collections::HashMap;
 #[non_exhaustive]
 pub struct UserSetting {
     /// A unique identifier for this setting. This is not meant to be shown to
-    /// the user and is only used to keep track of the setting.
+    /// the user and is only used to keep track of the setting. This key is used
+    /// to store and retrieve the value of the setting from the
+    /// [`SettingsStore`].
     pub key: Box<str>,
     /// The name of the setting that is shown to the user.
     pub description: Box<str>,
-    /// The default value of the setting. This also specifies the type of the
+    /// An optional tooltip that is shown to the user when hovering over the
     /// setting.
-    pub default_value: SettingValue,
+    pub tooltip: Option<Box<str>>,
+    /// The type of setting and additional information about it.
+    pub kind: UserSettingKind,
+}
+
+/// The type of a [`UserSetting`] and additional information about it.
+pub enum UserSettingKind {
+    /// A title that is shown to the user. It doesn't by itself store a value
+    /// and is instead used to group settings together.
+    Title {
+        /// The heading level of the title. This is used to determine the size
+        /// of the title and which other settings are grouped together with it.
+        /// The top level titles use a heading level of 0.
+        heading_level: u32,
+    },
+    /// A boolean setting. This could be visualized as a checkbox or a slider.
+    Bool {
+        /// The default value of the setting, if it's not available in the
+        /// settings store yet.
+        default_value: bool,
+    },
 }
 
 /// A value that a setting can have.

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -144,8 +144,10 @@
 //!     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
 //!     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
-//!     /// Adds a new setting that the user can modify. This will return either
-//!     /// the specified default value or the value that the user has set.
+//!     /// Adds a new boolean setting that the user can modify. This will return
+//!     /// either the specified default value or the value that the user has set.
+//!     /// The key is used to store the setting and needs to be unique across all
+//!     /// types of settings.
 //!     pub fn user_settings_add_bool(
 //!         key_ptr: *const u8,
 //!         key_len: usize,
@@ -153,6 +155,25 @@
 //!         description_len: usize,
 //!         default_value: bool,
 //!     ) -> bool;
+//!     /// Adds a new title to the user settings. This is used to group settings
+//!     /// together. The heading level determines the size of the title. The top
+//!     /// level titles use a heading level of 0. The key needs to be unique across
+//!     /// all types of settings.
+//!     pub fn user_settings_add_title(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         heading_level: u32,
+//!     );
+//!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
+//!     /// explaining the purpose of a setting to the user.
+//!     pub fn user_settings_set_tooltip(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         tooltip_ptr: *const u8,
+//!         tooltip_len: usize,
+//!     );
 //! }
 //! ```
 //!
@@ -161,7 +182,7 @@
 //! using WASI may need to be recompiled in the future. Limitations of the WASI
 //! support:
 //!
-//! - `stout` / `stderr` / `stdin` are unbound. Those streams currently do
+//! - `stdout` / `stderr` / `stdin` are unbound. Those streams currently do
 //!   nothing.
 //! - The file system is currently almost entirely empty. The host's file system
 //!   is accessible through `/mnt`. It is entirely read-only. Windows paths are


### PR DESCRIPTION
Auto Splitters can now specify tooltips for the user settings. Additionally there's a new type of user setting. Titles allow users to group settings together and give them a name. This is useful for settings that are related to each other. Heading levels can also be specified to create a hierarchy of settings. Unlike ASL, the titles do not by themselves have a value. A user interface could however still allow toggling the grouped settings by clicking on the title.