### PR TITLE
Decouple `derive` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    wasmtime:
+      patterns:
+        - "wasmtime*"
+        - "wasi-common"
   reviewers:
   - CryZe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,8 @@ jobs:
           - Linux thumbv7neon
           - Linux aarch64
           - Linux aarch64 musl
-          - Linux mips
           - Linux mips musl
-          - Linux mips64
           - Linux mips64 musl
-          - Linux mips64el
-          - Linux mips64el musl
-          - Linux mipsel
           - Linux mipsel musl
           - Linux powerpc
           - Linux powerpc64
@@ -385,13 +380,6 @@ jobs:
             target: aarch64-unknown-linux-musl
             dylib: skip
 
-          - label: Linux mips
-            target: mips-unknown-linux-gnu
-            auto_splitting: skip
-            networking: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
-
           - label: Linux mips musl
             target: mips-unknown-linux-musl
             auto_splitting: skip
@@ -400,13 +388,6 @@ jobs:
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
 
-          - label: Linux mips64
-            target: mips64-unknown-linux-gnuabi64
-            auto_splitting: skip
-            networking: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
-
           - label: Linux mips64 musl
             target: mips64-unknown-linux-muslabi64
             auto_splitting: skip
@@ -414,28 +395,6 @@ jobs:
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
-
-          - label: Linux mips64el
-            target: mips64el-unknown-linux-gnuabi64
-            auto_splitting: skip
-            networking: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
-
-          - label: Linux mips64el musl
-            target: mips64el-unknown-linux-gnuabi64
-            auto_splitting: skip
-            networking: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
-            dylib: skip
-
-          - label: Linux mipsel
-            target: mipsel-unknown-linux-gnu
-            auto_splitting: skip
-            networking: skip
-            # FIXME: Networking Tests fail due to missing OpenSSL
-            # https://github.com/LiveSplit/livesplit-core/issues/308
 
           - label: Linux mipsel musl
             target: mipsel-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,11 @@ members = ["capi", "capi/bind_gen", "crates/*"]
 
 [dependencies]
 # core
-base64-simd = { version = "0.8.0", default-features = false, features = ["alloc"] }
-bytemuck = { version = "1.9.1", default-features = false, features = ["derive"] }
+base64-simd = { version = "0.8.0", default-features = false, features = [
+    "alloc",
+] }
+bytemuck = { version = "1.9.1", default-features = false }
+bytemuck_derive = { version = "1.4.1", default_features = false }
 cfg-if = "1.0.0"
 itoa = { version = "1.0.3", default-features = false }
 time = { version = "0.3.3", default-features = false }
@@ -44,12 +47,14 @@ libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.7.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.3.0" }
 memchr = { version = "2.3.4", default-features = false }
-simdutf8 = { version = "0.1.4", default-features = false, features = ["aarch64_neon"] }
-serde = { version = "1.0.98", default-features = false, features = [
-    "alloc",
-    "derive",
+simdutf8 = { version = "0.1.4", default-features = false, features = [
+    "aarch64_neon",
 ] }
-serde_json = { version = "1.0.60", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.186", default-features = false, features = ["alloc"] }
+serde_derive = { version = "1.0.186", default_features = false }
+serde_json = { version = "1.0.60", default-features = false, features = [
+    "alloc",
+] }
 smallstr = { version = "0.3.0", default-features = false }
 snafu = { version = "0.7.0", default-features = false }
 unicase = "2.6.0"

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -21,23 +21,41 @@ windows-sys = { version = "0.48.0", features = [
 [target.'cfg(target_os = "linux")'.dependencies]
 crossbeam-channel = { version = "0.5.6", optional = true }
 evdev = { version = "0.12.1", optional = true }
-mio = { version = "0.8.0", default-features = false, features = ["os-ext", "os-poll"], optional = true }
+mio = { version = "0.8.0", default-features = false, features = [
+    "os-ext",
+    "os-poll",
+], optional = true }
 nix = { version = "0.26.1", features = ["user"], optional = true }
 promising-future = { version = "0.2.4", optional = true }
 x11-dl = { version = "2.20.0", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.54", optional = true }
-web-sys = { version = "0.3.28", default-features = false, features = ["Gamepad", "GamepadButton", "EventTarget", "KeyboardEvent", "Navigator", "Window"], optional = true }
+web-sys = { version = "0.3.28", default-features = false, features = [
+    "EventTarget",
+    "Gamepad",
+    "GamepadButton",
+    "KeyboardEvent",
+    "Navigator",
+    "Window",
+], optional = true }
 js-sys = { version = "0.3.28", default-features = false, optional = true }
 
 [dependencies]
 cfg-if = "1.0.0"
-serde = { version = "1.0.98", default-features = false, features = ["derive", "alloc"] }
-snafu = { version = "0.7.0", default-features = false }
+serde = { version = "1.0.186", default-features = false, features = ["alloc"] }
 bitflags = "2.0.1"
 
 [features]
 default = ["std"]
-std = ["snafu/std", "serde/std", "crossbeam-channel", "evdev", "mio", "nix", "promising-future", "windows-sys", "x11-dl"]
+std = [
+    "crossbeam-channel",
+    "evdev",
+    "mio",
+    "nix",
+    "promising-future",
+    "serde/std",
+    "windows-sys",
+    "x11-dl",
+]
 wasm-web = ["wasm-bindgen", "web-sys", "js-sys"]

--- a/crates/livesplit-hotkey/src/key_code.rs
+++ b/crates/livesplit-hotkey/src/key_code.rs
@@ -1201,7 +1201,7 @@ impl<'de> serde::de::Visitor<'de> for KeyCodeVisitor {
 }
 
 /// Every [`KeyCode`] is grouped into one of these classes.
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
 pub enum KeyCodeClass {
     /// The *writing system keys* are those that change meaning (i.e., they
     /// produce different key values) based on the current locale and keyboard
@@ -1246,6 +1246,78 @@ pub enum KeyCodeClass {
     Gamepad,
     /// These keys are supported by some browsers.
     NonStandard,
+}
+
+impl KeyCodeClass {
+    /// Returns the name of the key code.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::WritingSystem => "WritingSystem",
+            Self::Functional => "Functional",
+            Self::ControlPad => "ControlPad",
+            Self::ArrowPad => "ArrowPad",
+            Self::Numpad => "Numpad",
+            Self::Function => "Function",
+            Self::Media => "Media",
+            Self::Legacy => "Legacy",
+            Self::Gamepad => "Gamepad",
+            Self::NonStandard => "NonStandard",
+        }
+    }
+}
+
+impl FromStr for KeyCodeClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "WritingSystem" => Self::WritingSystem,
+            "Functional" => Self::Functional,
+            "ControlPad" => Self::ControlPad,
+            "ArrowPad" => Self::ArrowPad,
+            "Numpad" => Self::Numpad,
+            "Function" => Self::Function,
+            "Media" => Self::Media,
+            "Legacy" => Self::Legacy,
+            "Gamepad" => Self::Gamepad,
+            "NonStandard" => Self::NonStandard,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl Serialize for KeyCodeClass {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.name())
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyCodeClass {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(KeyCodeClassVisitor)
+    }
+}
+
+struct KeyCodeClassVisitor;
+
+impl<'de> serde::de::Visitor<'de> for KeyCodeClassVisitor {
+    type Value = KeyCodeClass;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a valid key code class")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        KeyCodeClass::from_str(v).map_err(|()| serde::de::Error::custom("invalid key code class"))
+    }
 }
 
 impl KeyCode {

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -1,4 +1,4 @@
-use std::thread::JoinHandle;
+use std::{fmt, thread::JoinHandle};
 
 use crate::{Hotkey, KeyCode};
 use crossbeam_channel::Sender;
@@ -10,7 +10,7 @@ mod evdev_impl;
 mod x11_impl;
 
 /// The error type for this crate.
-#[derive(Debug, Copy, Clone, snafu::Snafu)]
+#[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
 pub enum Error {
     /// The hotkey was already registered.
@@ -27,6 +27,22 @@ pub enum Error {
     OpenXServerConnection,
     /// The background thread stopped unexpectedly.
     ThreadStopped,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::AlreadyRegistered => "The hotkey was already registered.",
+            Self::NotRegistered => "The hotkey to unregister was not registered.",
+            Self::EvDev => "Failed fetching events from evdev.",
+            Self::EPoll => "Failed polling the event file descriptors.",
+            Self::NoXLib => "Failed dynamically linking to X11.",
+            Self::OpenXServerConnection => "Failed opening a connection to the X11 server.",
+            Self::ThreadStopped => "The background thread stopped unexpectedly.",
+        })
+    }
 }
 
 /// The result type for this crate.

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -24,12 +24,13 @@ use crate::{Hotkey, KeyCode, Modifiers};
 use std::{
     collections::{hash_map::Entry, HashMap},
     ffi::c_void,
+    fmt,
     sync::{mpsc::channel, Arc, Mutex},
     thread,
 };
 
 /// The error type for this crate.
-#[derive(Debug, snafu::Snafu)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// The hotkey was already registered.
@@ -44,6 +45,21 @@ pub enum Error {
     CouldntGetCurrentRunLoop,
     /// The background thread stopped unexpectedly.
     ThreadStoppedUnexpectedly,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::AlreadyRegistered => "The hotkey was already registered.",
+            Self::NotRegistered => "The hotkey to unregister was not registered.",
+            Self::CouldntCreateEventTap => "Failed creating the event tap.",
+            Self::CouldntCreateRunLoopSource => "Failed creating the run loop source.",
+            Self::CouldntGetCurrentRunLoop => "Failed getting the current run loop.",
+            Self::ThreadStoppedUnexpectedly => "The background thread stopped unexpectedly.",
+        })
+    }
 }
 
 /// The result type for this crate.

--- a/crates/livesplit-hotkey/src/other/mod.rs
+++ b/crates/livesplit-hotkey/src/other/mod.rs
@@ -1,10 +1,19 @@
 use crate::{Hotkey, KeyCode};
-use alloc::string::String;
+use alloc::{fmt, string::String};
 
 /// The error type for this crate.
-#[derive(Debug, snafu::Snafu)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
 
 /// The result type for this crate.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/crates/livesplit-hotkey/src/wasm_web/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm_web/mod.rs
@@ -6,12 +6,13 @@ use web_sys::{window, Event, Gamepad, GamepadButton, KeyboardEvent};
 use std::{
     cell::{Cell, RefCell},
     collections::hash_map::{Entry, HashMap},
+    fmt,
     rc::Rc,
     sync::{Arc, Mutex},
 };
 
 /// The error type for this crate.
-#[derive(Debug, snafu::Snafu)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// The hotkey was already registered.
@@ -20,6 +21,18 @@ pub enum Error {
     NotRegistered,
     /// Failed creating the hook.
     FailedToCreateHook,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::AlreadyRegistered => "The hotkey was already registered.",
+            Self::NotRegistered => "The hotkey to unregister was not registered.",
+            Self::FailedToCreateHook => "Failed creating the hook.",
+        })
+    }
 }
 
 /// The result type for this crate.

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -2,7 +2,7 @@ use crate::{Hotkey, KeyCode, Modifiers};
 use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
-    mem, ptr,
+    fmt, mem, ptr,
     sync::{
         mpsc::{channel, Sender},
         Arc, Mutex,
@@ -28,7 +28,7 @@ use windows_sys::Win32::{
 const MSG_EXIT: u32 = 0x400;
 
 /// The error type for this crate.
-#[derive(Debug, snafu::Snafu)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// The hotkey was already registered.
@@ -41,6 +41,20 @@ pub enum Error {
     ThreadStopped,
     /// An error occurred in the message loop.
     MessageLoop,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::AlreadyRegistered => "The hotkey was already registered.",
+            Self::NotRegistered => "The hotkey to unregister was not registered.",
+            Self::WindowsHook => "An error in the Windows API occurred.",
+            Self::ThreadStopped => "The background thread stopped unexpectedly.",
+            Self::MessageLoop => "An error occurred in the message loop.",
+        })
+    }
 }
 
 /// The result type for this crate.

--- a/crates/livesplit-title-abbreviations/src/lib.rs
+++ b/crates/livesplit-title-abbreviations/src/lib.rs
@@ -9,8 +9,7 @@ use unicase::UniCase;
 
 fn ends_with_roman_numeral(name: &str) -> bool {
     name.split_whitespace()
-        .rev()
-        .next()
+        .next_back()
         .is_some_and(|n| n.bytes().all(|c| matches!(c, b'I' | b'V' | b'X')))
 }
 

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -3,9 +3,11 @@
 //! anything other than a background. It mostly serves as padding between other
 //! components.
 
-use crate::platform::prelude::*;
-use crate::settings::{Field, Gradient, SettingsDescription, Value};
-use serde::{Deserialize, Serialize};
+use crate::{
+    platform::prelude::*,
+    settings::{Field, Gradient, SettingsDescription, Value},
+};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Blank Space Component is simply an empty component that doesn't show
 /// anything other than a background. It mostly serves as padding between other

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -8,7 +8,7 @@ use crate::{
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     Timer,
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Current Comparison Component is a component that shows the name of the
 /// comparison that is currently selected to be compared against.

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Current Pace Component is a component that shows a prediction of the
 /// current attempt's final time, if the current attempt's pace matches the

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     GeneralLayoutSettings, Segment, TimeSpan, TimerPhase,
 };
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -18,7 +18,7 @@ use crate::{
     GeneralLayoutSettings, TimeSpan, Timer, TimerPhase,
 };
 use alloc::borrow::Cow;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 const WIDTH: f32 = 1.0;
 const HEIGHT: f32 = 1.0;

--- a/src/component/key_value.rs
+++ b/src/component/key_value.rs
@@ -8,7 +8,7 @@ use crate::{
     settings::{Color, Gradient, SemanticColor},
 };
 use alloc::borrow::Cow;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The state object describes the information to visualize for a key value
 /// based component.

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -12,7 +12,7 @@ use crate::{
     timing::Snapshot,
 };
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The PB Chance Component is a component that shows how likely it is to beat
 /// the Personal Best. If there is no active attempt it shows the general chance

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Write as FmtWrite;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Possible Time Save Component is a component that shows how much time the
 /// chosen comparison could've saved for the current segment, based on the Best

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Write as FmtWrite;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Previous Segment Component is a component that shows how much time was
 /// saved or lost during the previous [`Segment`](crate::run::Segment) based on

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -3,7 +3,7 @@
 //! separators between components.
 
 use crate::settings::{SettingsDescription, Value};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Separator Component is a simple component that only serves to render
 /// separators between components.

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -12,7 +12,7 @@ use crate::{
     GeneralLayoutSettings, Segment, TimeSpan, TimingMethod,
 };
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The settings of an individual column showing timing information on each
 /// split.

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     GeneralLayoutSettings,
 };
 use core::cmp::{max, min};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -8,13 +8,15 @@
 //! around for historical reasons.
 
 use super::key_value;
-use crate::analysis::sum_of_segments::calculate_best;
-use crate::platform::prelude::*;
-use crate::settings::{Color, Field, Gradient, SettingsDescription, Value};
-use crate::timing::formatter::{Accuracy, Regular, TimeFormatter};
-use crate::Timer;
+use crate::{
+    analysis::sum_of_segments::calculate_best,
+    platform::prelude::*,
+    settings::{Color, Field, Gradient, SettingsDescription, Value},
+    timing::formatter::{Accuracy, Regular, TimeFormatter},
+    Timer,
+};
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Sum of Best Segments Component shows the fastest possible time to
 /// complete a run of this category, based on information collected from all the

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::mem;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -14,7 +14,7 @@ use crate::{
     GeneralLayoutSettings, TimeSpan, TimerPhase, TimingMethod,
 };
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The `Timer` Component is a component that shows the total time of the current
 /// attempt as a digital clock. The color of the time shown is based on a how
@@ -380,14 +380,14 @@ fn calculate_live_segment_time(
 
 // FIXME: Workaround for #[serde(flatten)] not being a thing on enums.
 mod serialize {
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
     #[serde(untagged)]
     pub enum DeltaGradient {
         Gradient(super::Gradient),
         Delta(Delta),
     }
 
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
     #[allow(clippy::enum_variant_names)]
     pub enum Delta {
         DeltaPlain,

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use core::fmt::Write;
 use livesplit_title_abbreviations::{abbreviate as abbreviate_title, abbreviate_category};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use smallstr::SmallString;
 
 #[cfg(test)]

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -11,7 +11,7 @@ use crate::{
     Timer,
 };
 use core::fmt::Write;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The Total Playtime Component is a component that shows the total amount of
 /// time that the current category has been played for.

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -5,7 +5,7 @@ use crate::{
     platform::prelude::*,
     settings::{Field, SettingsDescription, Value},
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The configuration to use for a [`HotkeySystem`](crate::HotkeySystem). It describes which [`Hotkey`](livesplit_hotkey::Hotkey) to use as hotkeys for the different actions.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/layout/component_settings.rs
+++ b/src/layout/component_settings.rs
@@ -1,11 +1,13 @@
 use super::Component;
-use crate::component::{
-    blank_space, current_comparison, current_pace, delta, detailed_timer, graph, pb_chance,
-    possible_time_save, previous_segment, segment_time, separator, splits, sum_of_best, text,
-    timer, title, total_playtime,
+use crate::{
+    component::{
+        blank_space, current_comparison, current_pace, delta, detailed_timer, graph, pb_chance,
+        possible_time_save, previous_segment, segment_time, separator, splits, sum_of_best, text,
+        timer, title, total_playtime,
+    },
+    platform::prelude::*,
 };
-use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The settings for one of the components available.
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/layout/component_state.rs
+++ b/src/layout/component_state.rs
@@ -1,8 +1,10 @@
-use crate::component::{
-    blank_space, detailed_timer, graph, key_value, separator, splits, text, timer, title,
+use crate::{
+    component::{
+        blank_space, detailed_timer, graph, key_value, separator, splits, text, timer, title,
+    },
+    platform::prelude::*,
 };
-use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The state object for one of the components available.
 #[derive(Serialize, Deserialize)]

--- a/src/layout/editor/state.rs
+++ b/src/layout/editor/state.rs
@@ -1,7 +1,6 @@
 use super::Editor;
-use crate::platform::prelude::*;
-use crate::settings::SettingsDescription;
-use serde::{Deserialize, Serialize};
+use crate::{platform::prelude::*, settings::SettingsDescription};
+use serde_derive::{Deserialize, Serialize};
 
 /// Represents the current state of the Layout Editor in order to visualize it
 /// properly.

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -3,7 +3,7 @@ use crate::{
     platform::prelude::*,
     settings::{Color, Field, Font, Gradient, SettingsDescription, Value},
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The general settings of a [`Layout`](crate::layout::Layout) that apply to all components.
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/layout/layout_direction.rs
+++ b/src/layout/layout_direction.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes the direction the components of a layout are laid out in.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/layout/layout_settings.rs
+++ b/src/layout/layout_settings.rs
@@ -1,6 +1,6 @@
 use super::{ComponentSettings, GeneralSettings};
 use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes a whole layout by its settings in a way that can easily be
 /// serialized and deserialized.

--- a/src/layout/layout_state.rs
+++ b/src/layout/layout_state.rs
@@ -3,7 +3,7 @@ use crate::{
     platform::prelude::*,
     settings::{Color, Font, Gradient},
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The state object describes the information to visualize for the layout.
 #[derive(Default, Serialize, Deserialize)]

--- a/src/layout/parser/font_resolving/name.rs
+++ b/src/layout/parser/font_resolving/name.rs
@@ -4,7 +4,7 @@ use crate::{
     platform::prelude::*,
     util::byte_parsing::{big_endian::U16, pod, slice},
 };
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 #[repr(C)]

--- a/src/rendering/default_text_engine/color_font/colr.rs
+++ b/src/rendering/default_text_engine/color_font/colr.rs
@@ -2,7 +2,7 @@ use crate::util::byte_parsing::{
     big_endian::{U16, U32 as O32},
     pod, slice,
 };
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 #[repr(C)]

--- a/src/rendering/default_text_engine/color_font/cpal.rs
+++ b/src/rendering/default_text_engine/color_font/cpal.rs
@@ -4,7 +4,7 @@ use crate::util::byte_parsing::{
     big_endian::{U16, U32 as O32},
     pod, slice,
 };
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 #[repr(C)]

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -99,7 +99,7 @@ use crate::{
     settings::{Color, Gradient},
 };
 use alloc::borrow::Cow;
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 use core::iter;
 
 pub use self::{

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -6,7 +6,7 @@ use crate::{
     settings::{CachedImageId, ImageData},
     timing::formatter::{none_wrapper::EmptyWrapper, Accuracy, SegmentTime, TimeFormatter},
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Represents the current state of the Run Editor in order to visualize it
 /// properly.

--- a/src/run/linked_layout.rs
+++ b/src/run/linked_layout.rs
@@ -1,5 +1,5 @@
 use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A `LinkedLayout` associates a [`Layout`](crate::Layout) with a
 /// [`Run`](crate::Run). If the [`Run`](crate::Run) has a `LinkedLayout`, it is

--- a/src/run/parser/flitter/mod.rs
+++ b/src/run/parser/flitter/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{comparison::world_record, platform::prelude::*, Run, Segment, Time, TimeSpan};
 use core::result::Result as StdResult;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 mod s_expressions;
 

--- a/src/run/parser/source_live_timer.rs
+++ b/src/run/parser/source_live_timer.rs
@@ -3,7 +3,7 @@
 use crate::{platform::prelude::*, GameTime, Run, Segment, TimeSpan};
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_json::Error as JsonError;
 
 /// The Error type for splits files that couldn't be parsed by the

--- a/src/run/parser/speedrun_igt.rs
+++ b/src/run/parser/speedrun_igt.rs
@@ -1,7 +1,7 @@
 //! Provides the parser for SpeedrunIGT splits files.
 
 use alloc::borrow::Cow;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use time::Duration;
 
 use crate::{

--- a/src/run/parser/splits_io.rs
+++ b/src/run/parser/splits_io.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
 
 /// The Error type for splits files that couldn't be parsed by the generic

--- a/src/run/parser/splitterino.rs
+++ b/src/run/parser/splitterino.rs
@@ -3,7 +3,7 @@
 use crate::{platform::prelude::*, Run, Segment, Time, TimeSpan};
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_json::Error as JsonError;
 
 /// The Error type for splits files that couldn't be parsed by the Splitterino

--- a/src/run/parser/splitty.rs
+++ b/src/run/parser/splitty.rs
@@ -3,7 +3,7 @@
 use crate::{platform::prelude::*, Run, Segment, Time, TimeSpan, TimingMethod};
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_json::Error as JsonError;
 
 /// The Error type for splits files that couldn't be parsed by the Splitty

--- a/src/run/parser/urn.rs
+++ b/src/run/parser/urn.rs
@@ -3,7 +3,7 @@
 use crate::{platform::prelude::*, Run, Segment, Time, TimeSpan};
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_json::Error as JsonError;
 
 /// The Error type for splits files that couldn't be parsed by the Urn

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -5,7 +5,7 @@ use crate::{
         PopulateString,
     },
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A custom variable is a key value pair storing additional information about a
 /// run. Unlike the speedrun.com variables, these can be fully custom and don't

--- a/src/settings/alignment.rs
+++ b/src/settings/alignment.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes the Alignment of the Title in the Title Component.
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/settings/field.rs
+++ b/src/settings/field.rs
@@ -1,6 +1,6 @@
 use super::Value;
 use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A Field describes a single setting by its name and its current value.
 #[derive(Serialize, Deserialize)]

--- a/src/settings/font.rs
+++ b/src/settings/font.rs
@@ -1,5 +1,5 @@
 use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes a Font to visualize text with. Depending on the platform, a font
 /// that matches the settings most closely is chosen. The settings may be

--- a/src/settings/gradient.rs
+++ b/src/settings/gradient.rs
@@ -1,5 +1,5 @@
 use super::Color;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes a Gradient for coloring a region with more than just a single
 /// color.

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 use image::{
     codecs::{bmp, farbfeld, hdr, ico, jpeg, pnm, tga, tiff, webp},
     guess_format, load_from_memory_with_format, ImageDecoder, ImageEncoder, ImageFormat,

--- a/src/settings/semantic_color.rs
+++ b/src/settings/semantic_color.rs
@@ -1,6 +1,6 @@
 use super::Color;
 use crate::layout;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A `SemanticColor` describes a color by some meaningful event that is
 /// happening. This information can be visualized as a color, but can also be

--- a/src/settings/settings_description.rs
+++ b/src/settings/settings_description.rs
@@ -1,6 +1,6 @@
 use super::Field;
 use crate::platform::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A generic description of the settings available and their current values.
 #[derive(Default, Serialize, Deserialize)]

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -11,7 +11,7 @@ use crate::{
     TimingMethod,
 };
 use core::result::Result as StdResult;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Describes the kind of a column.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::{Display, Formatter, Result},
     str,
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The `Accuracy` describes how many digits to show for the fractional part of a
 /// time.

--- a/src/timing/formatter/digits_format.rs
+++ b/src/timing/formatter/digits_format.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A Digits Format describes how many digits of a time to always shown. The
 /// times are prefixed by zeros to fill up the remaining digits.

--- a/src/timing/timing_method.rs
+++ b/src/timing/timing_method.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A `TimingMethod` describes which form of timing is used. This can either be
 /// [`TimingMethod::RealTime`] or [`TimingMethod::GameTime`].

--- a/src/util/byte_parsing.rs
+++ b/src/util/byte_parsing.rs
@@ -4,7 +4,7 @@ use bytemuck::AnyBitPattern;
 
 pub mod big_endian {
     use super::strip_pod;
-    use bytemuck::{Pod, Zeroable};
+    use bytemuck_derive::{Pod, Zeroable};
     use core::fmt;
 
     #[derive(Copy, Clone, Pod, Zeroable)]


### PR DESCRIPTION
This decouples the `derive` dependencies from their main dependencies. This allows them to compile in parallel, ensuring faster compile times. Additionally the `livesplit-hotkey` crate now doesn't depend on any `derive` dependency anymore, as it barely needed them.