### PR TITLE
Update `wasmtime` to `12.0.1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           - Linux mips musl
           - Linux mips64 musl
           - Linux mipsel musl
+          - Linux mips64el musl
           - Linux powerpc
           - Linux powerpc64
           - Linux powerpc64le
@@ -398,6 +399,14 @@ jobs:
 
           - label: Linux mipsel musl
             target: mipsel-unknown-linux-musl
+            auto_splitting: skip
+            networking: skip
+            # FIXME: Networking Tests fail due to missing OpenSSL
+            # https://github.com/LiveSplit/livesplit-core/issues/308
+            dylib: skip
+
+          - label: Linux mips64el musl
+            target: mips64el-unknown-linux-muslabi64
             auto_splitting: skip
             networking: skip
             # FIXME: Networking Tests fail due to missing OpenSSL

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }
+async-trait = "0.1.73"
 proc-maps = { version = "0.3.0", default-features = false }
 read-process-memory = { version = "0.1.4", default-features = false }
 slotmap = { version = "1.0.2", default-features = false }
@@ -19,12 +20,12 @@ sysinfo = { version = "0.29.0", default-features = false, features = [
   "multithread",
 ] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "8.0.1", default-features = false, features = [
+wasmtime = { version = "12.0.1", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = "8.0.1"
-wasi-common = "8.0.1"
+wasmtime-wasi = "12.0.1"
+wasi-common = "12.0.1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem"] }


### PR DESCRIPTION
We were stuck on an old version of `wasmtime` because they removed the ability to mark the file system as read only. We now wrap the file system implementation and simply error out on anything that would write to it. This is potentially a little buggier, but they plan on bringing the feature back eventually anyway, so this implementation should be fine in the meantime. I'm doing this upgrade, because their master branch contains a bunch of improvements that we would want, such as `serde` being decoupled from its `derive` crate and the debug support now finally working. Unfortunately those are not released yet, but at least we can now easily upgrade `wasmtime` again.