### PR TITLE
Add Process Listing and Attach by PID to Autosplitting API

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }
 async-trait = "0.1.73"
+bytemuck = { version = "1.14.0", features = ["min_const_generics"] }
 proc-maps = { version = "0.3.0", default-features = false }
 read-process-memory = { version = "0.1.4", default-features = false }
 slotmap = { version = "1.0.2", default-features = false }

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -34,7 +34,10 @@ pub struct Address(pub u64);
 pub struct NonZeroAddress(pub NonZeroU64);
 
 #[repr(transparent)]
-pub struct ProcessId(NonZeroU64);
+pub struct Process(NonZeroU64);
+
+#[repr(transparent)]
+pub struct ProcessId(u64);
 
 #[repr(transparent)]
 pub struct TimerState(u32);
@@ -56,13 +59,13 @@ pub struct MemoryRangeFlags(NonZeroU64);
 
 impl MemoryRangeFlags {
     /// The memory range is readable.
-    pub const READ: Self = Self(NonZeroU64::new(1 << 1).unwrap());
+    pub const READ: Self = Self(match NonZeroU64::new(1 << 1) { Some(v) => v, None => panic!() });
     /// The memory range is writable.
-    pub const WRITE: Self = Self(NonZeroU64::new(1 << 2).unwrap());
+    pub const WRITE: Self = Self(match NonZeroU64::new(1 << 2) { Some(v) => v, None => panic!() });
     /// The memory range is executable.
-    pub const EXECUTE: Self = Self(NonZeroU64::new(1 << 3).unwrap());
+    pub const EXECUTE: Self = Self(match NonZeroU64::new(1 << 3) { Some(v) => v, None => panic!() });
     /// The memory range has a file path.
-    pub const PATH: Self = Self(NonZeroU64::new(1 << 4).unwrap());
+    pub const PATH: Self = Self(match NonZeroU64::new(1 << 4) { Some(v) => v, None => panic!() });
 }
 
 extern "C" {
@@ -98,16 +101,35 @@ extern "C" {
     pub fn timer_resume_game_time();
 
     /// Attaches to a process based on its name.
-    pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
+    pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<Process>;
+    /// Attaches to a process based on its process id.
+    pub fn process_attach_by_pid(pid: ProcessId) -> Option<Process>;
     /// Detaches from a process.
-    pub fn process_detach(process: ProcessId);
+    pub fn process_detach(process: Process);
+    /// Lists processes based on their name. Returns `false` if listing the
+    /// processes failed. If it was successful, the buffer is now filled
+    /// with the process ids. They are in no specific order. The
+    /// `list_len_ptr` will be updated to the amount of process ids that
+    /// were found. If this is larger than the original value provided, the
+    /// buffer provided was too small and not all process ids could be
+    /// stored. This is still considered successful and can optionally be
+    /// treated as an error condition by the caller by checking if the
+    /// length increased and potentially reallocating a larger buffer. If
+    /// the length decreased after the call, the buffer was larger than
+    /// needed and the remaining entries are untouched.
+    pub fn process_list_by_name(
+        name_ptr: *const u8,
+        name_len: usize,
+        list_ptr: *mut ProcessId,
+        list_len_ptr: *mut usize,
+    ) -> bool;
     /// Checks whether is a process is still open. You should detach from a
     /// process and stop using it if this returns `false`.
-    pub fn process_is_open(process: ProcessId) -> bool;
+    pub fn process_is_open(process: Process) -> bool;
     /// Reads memory from a process at the address given. This will write
     /// the memory to the buffer given. Returns `false` if this fails.
     pub fn process_read(
-        process: ProcessId,
+        process: Process,
         address: Address,
         buf_ptr: *mut u8,
         buf_len: usize,
@@ -115,41 +137,41 @@ extern "C" {
 
     /// Gets the address of a module in a process.
     pub fn process_get_module_address(
-        process: ProcessId,
+        process: Process,
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroAddress>;
     /// Gets the size of a module in a process.
     pub fn process_get_module_size(
-        process: ProcessId,
+        process: Process,
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroU64>;
 
     /// Gets the number of memory ranges in a given process.
-    pub fn process_get_memory_range_count(process: ProcessId) -> Option<NonZeroU64>;
+    pub fn process_get_memory_range_count(process: Process) -> Option<NonZeroU64>;
     /// Gets the start address of a memory range by its index.
     pub fn process_get_memory_range_address(
-        process: ProcessId,
+        process: Process,
         idx: u64,
     ) -> Option<NonZeroAddress>;
     /// Gets the size of a memory range by its index.
-    pub fn process_get_memory_range_size(process: ProcessId, idx: u64) -> Option<NonZeroU64>;
+    pub fn process_get_memory_range_size(process: Process, idx: u64) -> Option<NonZeroU64>;
     /// Gets the flags of a memory range by its index.
     pub fn process_get_memory_range_flags(
-        process: ProcessId,
+        process: Process,
         idx: u64,
     ) -> Option<MemoryRangeFlags>;
 
     /// Stores the file system path of the executable in the buffer given. The
-    /// path is a pa thth that is accessiblerough the WASI file system, so a
+    /// path is a path that is accessible through the WASI file system, so a
     /// Windows path of `C:\foo\bar.exe` would be returned as
     /// `/mnt/c/foo/bar.exe`. Returns `false` if the buffer is too small. After
     /// this call, no matter whether it was successful or not, the
     /// `buf_len_ptr` will be set to the required buffer size. The path is
     /// guaranteed to be valid UTF-8 and is not nul-terminated.
     pub fn process_get_path(
-        process: ProcessId,
+        process: Process,
         buf_ptr: *mut u8,
         buf_len_ptr: *mut usize,
     ) -> bool;

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -99,8 +99,12 @@
 //!
 //!     /// Attaches to a process based on its name.
 //!     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
+//!     /// Attaches to a process based on its pid.
+//!     pub fn process_attach_pid(pid: u32);
 //!     /// Detaches from a process.
 //!     pub fn process_detach(process: ProcessId);
+//!     /// Lists processes (as pids) based on their name.
+//!     pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool
 //!     /// Checks whether is a process is still open. You should detach from a
 //!     /// process and stop using it if this returns `false`.
 //!     pub fn process_is_open(process: ProcessId) -> bool;

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -103,7 +103,10 @@
 //!     pub fn process_attach_pid(pid: u32);
 //!     /// Detaches from a process.
 //!     pub fn process_detach(process: ProcessId);
-//!     /// Lists processes (as pids) based on their name.
+//!     /// Lists processes (as pids) based on their name. Returns `false` 
+//!     /// if the buffer is too small. After this call, no matter whether
+//!     /// it was successful or not, the `buf_len_ptr` will be set to the
+//!     /// required buffer size. 
 //!     pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool
 //!     /// Checks whether is a process is still open. You should detach from a
 //!     /// process and stop using it if this returns `false`.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -34,7 +34,10 @@
 //! pub struct NonZeroAddress(pub NonZeroU64);
 //!
 //! #[repr(transparent)]
-//! pub struct ProcessId(NonZeroU64);
+//! pub struct Process(NonZeroU64);
+//!
+//! #[repr(transparent)]
+//! pub struct ProcessId(u64);
 //!
 //! #[repr(transparent)]
 //! pub struct TimerState(u32);
@@ -56,13 +59,13 @@
 //!
 //! impl MemoryRangeFlags {
 //!     /// The memory range is readable.
-//!     pub const READ: Self = Self(NonZeroU64::new(1 << 1).unwrap());
+//!     pub const READ: Self = Self(match NonZeroU64::new(1 << 1) { Some(v) => v, None => panic!() });
 //!     /// The memory range is writable.
-//!     pub const WRITE: Self = Self(NonZeroU64::new(1 << 2).unwrap());
+//!     pub const WRITE: Self = Self(match NonZeroU64::new(1 << 2) { Some(v) => v, None => panic!() });
 //!     /// The memory range is executable.
-//!     pub const EXECUTE: Self = Self(NonZeroU64::new(1 << 3).unwrap());
+//!     pub const EXECUTE: Self = Self(match NonZeroU64::new(1 << 3) { Some(v) => v, None => panic!() });
 //!     /// The memory range has a file path.
-//!     pub const PATH: Self = Self(NonZeroU64::new(1 << 4).unwrap());
+//!     pub const PATH: Self = Self(match NonZeroU64::new(1 << 4) { Some(v) => v, None => panic!() });
 //! }
 //!
 //! extern "C" {
@@ -98,23 +101,35 @@
 //!     pub fn timer_resume_game_time();
 //!
 //!     /// Attaches to a process based on its name.
-//!     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
-//!     /// Attaches to a process based on its pid.
-//!     pub fn process_attach_pid(pid: u32);
+//!     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<Process>;
+//!     /// Attaches to a process based on its process id.
+//!     pub fn process_attach_by_pid(pid: ProcessId) -> Option<Process>;
 //!     /// Detaches from a process.
-//!     pub fn process_detach(process: ProcessId);
-//!     /// Lists processes (as pids) based on their name. Returns `false` 
-//!     /// if the buffer is too small. After this call, no matter whether
-//!     /// it was successful or not, the `buf_len_ptr` will be set to the
-//!     /// required buffer size. 
-//!     pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool
+//!     pub fn process_detach(process: Process);
+//!     /// Lists processes based on their name. Returns `false` if listing the
+//!     /// processes failed. If it was successful, the buffer is now filled
+//!     /// with the process ids. They are in no specific order. The
+//!     /// `list_len_ptr` will be updated to the amount of process ids that
+//!     /// were found. If this is larger than the original value provided, the
+//!     /// buffer provided was too small and not all process ids could be
+//!     /// stored. This is still considered successful and can optionally be
+//!     /// treated as an error condition by the caller by checking if the
+//!     /// length increased and potentially reallocating a larger buffer. If
+//!     /// the length decreased after the call, the buffer was larger than
+//!     /// needed and the remaining entries are untouched.
+//!     pub fn process_list_by_name(
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!         list_ptr: *mut ProcessId,
+//!         list_len_ptr: *mut usize,
+//!     ) -> bool;
 //!     /// Checks whether is a process is still open. You should detach from a
 //!     /// process and stop using it if this returns `false`.
-//!     pub fn process_is_open(process: ProcessId) -> bool;
+//!     pub fn process_is_open(process: Process) -> bool;
 //!     /// Reads memory from a process at the address given. This will write
 //!     /// the memory to the buffer given. Returns `false` if this fails.
 //!     pub fn process_read(
-//!         process: ProcessId,
+//!         process: Process,
 //!         address: Address,
 //!         buf_ptr: *mut u8,
 //!         buf_len: usize,
@@ -122,29 +137,29 @@
 //!
 //!     /// Gets the address of a module in a process.
 //!     pub fn process_get_module_address(
-//!         process: ProcessId,
+//!         process: Process,
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the size of a module in a process.
 //!     pub fn process_get_module_size(
-//!         process: ProcessId,
+//!         process: Process,
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
 //!
 //!     /// Gets the number of memory ranges in a given process.
-//!     pub fn process_get_memory_range_count(process: ProcessId) -> Option<NonZeroU64>;
+//!     pub fn process_get_memory_range_count(process: Process) -> Option<NonZeroU64>;
 //!     /// Gets the start address of a memory range by its index.
 //!     pub fn process_get_memory_range_address(
-//!         process: ProcessId,
+//!         process: Process,
 //!         idx: u64,
 //!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the size of a memory range by its index.
-//!     pub fn process_get_memory_range_size(process: ProcessId, idx: u64) -> Option<NonZeroU64>;
+//!     pub fn process_get_memory_range_size(process: Process, idx: u64) -> Option<NonZeroU64>;
 //!     /// Gets the flags of a memory range by its index.
 //!     pub fn process_get_memory_range_flags(
-//!         process: ProcessId,
+//!         process: Process,
 //!         idx: u64,
 //!     ) -> Option<MemoryRangeFlags>;
 //!
@@ -156,7 +171,7 @@
 //!     /// `buf_len_ptr` will be set to the required buffer size. The path is
 //!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
 //!     pub fn process_get_path(
-//!         process: ProcessId,
+//!         process: Process,
 //!         buf_ptr: *mut u8,
 //!         buf_len_ptr: *mut usize,
 //!     ) -> bool;

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -85,12 +85,14 @@ impl Process {
 
         let path = build_path(process.exe());
 
-        let handle = pid.try_into().context(InvalidHandle)?;
+        let pid_out = pid as Pid;
+
+        let handle = pid_out.try_into().context(InvalidHandle)?;
 
         let now = Instant::now();
         Ok(Process {
             handle,
-            pid,
+            pid: pid_out,
             memory_ranges: Vec::new(),
             next_memory_range_check: now,
             next_open_check: now + Duration::from_secs(1),

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -720,7 +720,7 @@ fn bind_interface<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), Creat
                     for i in &list {
                         list_bytes.extend_from_slice(&i.to_le_bytes());
                     }
-                    let buf = get_slice_mut(memory, list_ptr, (list.len() * mem::size_of_val(&list_len)) as _)?;
+                    let buf = get_slice_mut(memory, list_ptr, (list.len() * mem::size_of::<u32>()) as _)?;
                     buf.copy_from_slice(list_bytes.as_slice());
                     Ok(1u32)
                 } else {

--- a/crates/livesplit-auto-splitting/src/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime.rs
@@ -14,7 +14,8 @@ use std::{
     env::consts::{ARCH, OS},
     path::{Path, PathBuf},
     str,
-    time::{Duration, Instant}, mem,
+    time::{Duration, Instant}, 
+    mem,
 };
 use sysinfo::{ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt};
 use wasi_common::{

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -34,7 +34,10 @@
 //! pub struct NonZeroAddress(pub NonZeroU64);
 //!
 //! #[repr(transparent)]
-//! pub struct ProcessId(NonZeroU64);
+//! pub struct Process(NonZeroU64);
+//!
+//! #[repr(transparent)]
+//! pub struct ProcessId(u64);
 //!
 //! #[repr(transparent)]
 //! pub struct TimerState(u32);
@@ -49,6 +52,20 @@
 //!     pub const PAUSED: Self = Self(2);
 //!     /// The timer has ended, but didn't get reset yet.
 //!     pub const ENDED: Self = Self(3);
+//! }
+//!
+//! #[repr(transparent)]
+//! pub struct MemoryRangeFlags(NonZeroU64);
+//!
+//! impl MemoryRangeFlags {
+//!     /// The memory range is readable.
+//!     pub const READ: Self = Self(match NonZeroU64::new(1 << 1) { Some(v) => v, None => panic!() });
+//!     /// The memory range is writable.
+//!     pub const WRITE: Self = Self(match NonZeroU64::new(1 << 2) { Some(v) => v, None => panic!() });
+//!     /// The memory range is executable.
+//!     pub const EXECUTE: Self = Self(match NonZeroU64::new(1 << 3) { Some(v) => v, None => panic!() });
+//!     /// The memory range has a file path.
+//!     pub const PATH: Self = Self(match NonZeroU64::new(1 << 4) { Some(v) => v, None => panic!() });
 //! }
 //!
 //! extern "C" {
@@ -84,32 +101,67 @@
 //!     pub fn timer_resume_game_time();
 //!
 //!     /// Attaches to a process based on its name.
-//!     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
+//!     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<Process>;
+//!     /// Attaches to a process based on its process id.
+//!     pub fn process_attach_by_pid(pid: ProcessId) -> Option<Process>;
 //!     /// Detaches from a process.
-//!     pub fn process_detach(process: ProcessId);
+//!     pub fn process_detach(process: Process);
+//!     /// Lists processes based on their name. Returns `false` if listing the
+//!     /// processes failed. If it was successful, the buffer is now filled
+//!     /// with the process ids. They are in no specific order. The
+//!     /// `list_len_ptr` will be updated to the amount of process ids that
+//!     /// were found. If this is larger than the original value provided, the
+//!     /// buffer provided was too small and not all process ids could be
+//!     /// stored. This is still considered successful and can optionally be
+//!     /// treated as an error condition by the caller by checking if the
+//!     /// length increased and potentially reallocating a larger buffer. If
+//!     /// the length decreased after the call, the buffer was larger than
+//!     /// needed and the remaining entries are untouched.
+//!     pub fn process_list_by_name(
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!         list_ptr: *mut ProcessId,
+//!         list_len_ptr: *mut usize,
+//!     ) -> bool;
 //!     /// Checks whether is a process is still open. You should detach from a
 //!     /// process and stop using it if this returns `false`.
-//!     pub fn process_is_open(process: ProcessId) -> bool;
+//!     pub fn process_is_open(process: Process) -> bool;
 //!     /// Reads memory from a process at the address given. This will write
 //!     /// the memory to the buffer given. Returns `false` if this fails.
 //!     pub fn process_read(
-//!         process: ProcessId,
+//!         process: Process,
 //!         address: Address,
 //!         buf_ptr: *mut u8,
 //!         buf_len: usize,
 //!     ) -> bool;
+//!
 //!     /// Gets the address of a module in a process.
 //!     pub fn process_get_module_address(
-//!         process: ProcessId,
+//!         process: Process,
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroAddress>;
 //!     /// Gets the size of a module in a process.
 //!     pub fn process_get_module_size(
-//!         process: ProcessId,
+//!         process: Process,
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
+//!
+//!     /// Gets the number of memory ranges in a given process.
+//!     pub fn process_get_memory_range_count(process: Process) -> Option<NonZeroU64>;
+//!     /// Gets the start address of a memory range by its index.
+//!     pub fn process_get_memory_range_address(
+//!         process: Process,
+//!         idx: u64,
+//!     ) -> Option<NonZeroAddress>;
+//!     /// Gets the size of a memory range by its index.
+//!     pub fn process_get_memory_range_size(process: Process, idx: u64) -> Option<NonZeroU64>;
+//!     /// Gets the flags of a memory range by its index.
+//!     pub fn process_get_memory_range_flags(
+//!         process: Process,
+//!         idx: u64,
+//!     ) -> Option<MemoryRangeFlags>;
 //!
 //!     /// Stores the file system path of the executable in the buffer given. The
 //!     /// path is a path that is accessible through the WASI file system, so a
@@ -119,7 +171,7 @@
 //!     /// `buf_len_ptr` will be set to the required buffer size. The path is
 //!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
 //!     pub fn process_get_path(
-//!         process: ProcessId,
+//!         process: Process,
 //!         buf_ptr: *mut u8,
 //!         buf_len_ptr: *mut usize,
 //!     ) -> bool;


### PR DESCRIPTION
Adds two functions to the API:

`process_attach_pid` attaches to a process by referencing its PID.
`process_list` lists all PIDs associated with processes with the name passed in.

Together, these allow an autosplitter to define its own logic for discovering and attaching to processes.  

Sometimes start time or largest PID don't quite get the right process.  For example, Tony Hawk's Pro Skater 1+2 has a bootstrap and game process, both with the same name.  They start in the same second, so the regular `process_attach` logic often selects the incorrect process.  This pull request allows an author to check each process closer to determine which one is desired.