### PR TITLE
Update `Instant` implementations & Add Safety Docs

### DIFF
--- a/src/platform/no_std/time.rs
+++ b/src/platform/no_std/time.rs
@@ -73,6 +73,7 @@ pub fn utc_now() -> DateTime {
     if clock.is_null() {
         panic!("No clock registered");
     }
+    // SAFETY: If it's not null, we know it's valid.
     let clock = unsafe { &*clock };
     clock.date_now()
 }

--- a/src/platform/wasm/unknown/time.rs
+++ b/src/platform/wasm/unknown/time.rs
@@ -13,6 +13,7 @@ extern "C" {
 }
 
 pub fn utc_now() -> DateTime {
+    // SAFETY: We pass a pointer to a valid `FFIDateTime` to `Date_now`.
     unsafe {
         let mut date_time = MaybeUninit::uninit();
         Date_now(date_time.as_mut_ptr());
@@ -31,6 +32,7 @@ pub struct Instant(Duration);
 
 impl Instant {
     pub fn now() -> Self {
+        // SAFETY: This is always safe to cal.
         let secs = unsafe { Instant_now() };
         let nanos = (secs.fract() * 1_000_000_000.0) as _;
         let secs = secs as _;


### PR DESCRIPTION
This updates the implementations that we use for `Instant`:

1. On Apple platforms we now use the recommended APIs directly. All platforms that are supported by Rust supported that API now.
2. On Linux we always use `CLOCK_BOOTTIME`, because Rust does not support any kernels anymore that don't support it.
3. All the unsafe blocks now have safety documentation.