### PR TITLE
Replace `img_hash` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,10 @@ windows-sys = { version = "0.48.0", features = [
 libc = { version = "0.2.101", optional = true }
 
 [dev-dependencies]
-img_hash = "3.1.0"
+seahash = "4.1.0"
+
+[target.'cfg(windows)'.dev-dependencies]
+sysinfo = { version = "0.29.10", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5.0"

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -24,7 +24,9 @@ wasmtime = { version = "13.0.0", default-features = false, features = [
   "cranelift",
   "parallel-compilation",
 ] }
-wasmtime-wasi = "13.0.0"
+wasmtime-wasi = { version = "13.0.0", default-features = false, features = [
+  "sync",
+] }
 wasi-common = "13.0.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -581,12 +581,8 @@ async fn run(
                     Request::ReloadScript(ret) => {
                         let mut config = Config::default();
                         config.settings_store = Some(runtime.settings_store().clone());
-                        
-                        match ScriptRuntime::new(
-                            &script_path,
-                            Timer(timer.clone()),
-                            config,
-                        ) {
+
+                        match ScriptRuntime::new(&script_path, Timer(timer.clone()), config) {
                             Ok(r) => {
                                 ret.send(Ok(())).ok();
                                 runtime = r;


### PR DESCRIPTION
While a visual hash is a good idea, the underlying `tiny-skia` is meant to pixel perfectly match `Skia`. This means that our hash doesn't actually need to be visual and can be a simple checksum. The `img_hash` crate is very unmaintained, so we are forced to compile ever more so outdated dependencies. So replacing it by a simple checksum via the `seahash` crate makes a lot of sense. The `seahash` crate claims to be very fast and also claims that the hashes are suitable for checksums. So it sounds like a good crate to use for this. However this means that on platforms that don't correctly implement IEEE-754, we can't run the rendering tests anymore.