### PR TITLE
WIP: Add get_auto_splitter_settings for AutoSplitterSettings XML contents

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -226,6 +226,15 @@ extern "C" {
         tooltip_ptr: *const u8,
         tooltip_len: usize,
     );
+    /// Stores the AutoSplitterSettings XML contents in the
+    /// buffer given.
+    /// Returns `false` if the buffer is too small.
+    /// After this call, whether it was successful or not,
+    /// the `buf_len_ptr` will be set to the required buffer size.
+    pub fn get_auto_splitter_settings(
+        buf_ptr: *mut u8,
+        buf_len_ptr: *mut usize,
+    ) -> bool;
 }
 ```
 

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -226,6 +226,15 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Stores the AutoSplitterSettings XML contents in the
+//!     /// buffer given.
+//!     /// Returns `false` if the buffer is too small.
+//!     /// After this call, whether it was successful or not,
+//!     /// the `buf_len_ptr` will be set to the required buffer size.
+//!     pub fn get_auto_splitter_settings(
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
 //! }
 //! ```
 //!

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -52,12 +52,21 @@ pub enum SettingValue {
 #[derive(Clone, Default)]
 pub struct SettingsStore {
     values: HashMap<Box<str>, SettingValue>,
+    auto_splitter_settings: String,
 }
 
 impl SettingsStore {
     /// Creates a new empty settings store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a new settings store from the AutoSplitterSettings XML contents.
+    pub fn new_auto_splitter_settings(auto_splitter_settings: String) -> Self {
+        Self {
+            values: Default::default(),
+            auto_splitter_settings
+        }
     }
 
     /// Sets a setting to the new value. If the key of the setting doesn't exist
@@ -78,5 +87,10 @@ impl SettingsStore {
     /// store.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &SettingValue)> {
         self.values.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+
+    /// Gets the AutoSplitterSettings XML contents.
+    pub fn get_auto_splitter_settings(&self) -> &str {
+        &self.auto_splitter_settings
     }
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -226,6 +226,15 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Stores the AutoSplitterSettings XML contents in the
+//!     /// buffer given.
+//!     /// Returns `false` if the buffer is too small.
+//!     /// After this call, whether it was successful or not,
+//!     /// the `buf_len_ptr` will be set to the required buffer size.
+//!     pub fn get_auto_splitter_settings(
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
 //! }
 //! ```
 //!


### PR DESCRIPTION
This adds `get_auto_splitter_settings` to the Auto Splitting Runtime, to get the `AutoSplitterSettings` XML contents.

There may be better ways to accomplish this, and I may run into problems when trying to use it in an ASR-based autosplitter, so this is a draft until I know an autosplitter can make good use of it.