### PR TITLE
Add settings object query functions

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -30,5 +30,7 @@ wasmtime-wasi = { version = "13.0.0", default-features = false, features = [
 ] }
 wasi-common = "13.0.0"
 
+xmltree = { version = "0.10.3" }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem"] }

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -226,6 +226,33 @@ extern "C" {
         tooltip_ptr: *const u8,
         tooltip_len: usize,
     );
+    /// Gets the AutoSplitterSettings as a settings object
+    /// and puts it in the obj_ptr.
+    /// This can be queried by functions such as
+    /// settings_object_as_bool, settings_object_list_get,
+    /// and settings_object_dict_get.
+    pub fn get_auto_splitter_settings(obj_ptr: *mut u64) -> bool;
+    /// Query a settings object as a bool:
+    ///   1 for Some(true)
+    ///   0 for Some(false)
+    ///   -1 for None
+    pub fn settings_object_as_bool(obj: u64) -> i32;
+    /// Query a settings object as a list, get the length:
+    ///   non-negative values for Some(len)
+    ///   -1 for None
+    pub fn settings_object_list_len(obj: u64) -> i32;
+    /// Query a settings object as a list, get an element by index,
+    /// putting the element at elem_ptr.
+    pub fn settings_object_list_get(obj: u64, index: u32, elem_ptr: *mut u64) -> bool;
+    /// Query a settings object as a dict, get a value by key,
+    /// putting the value at value_ptr.
+    pub fn settings_object_dict_get(obj: u64, key_ptr: *const u8, key_len: usize, value_ptr: *mut u64) -> bool;
+    /// Query a settings object as a string, storing the
+    /// contents in the buffer given.
+    /// Returns `false` if the buffer is too small.
+    /// After this call, whether it was successful or not,
+    /// the `buf_len_ptr` will be set to the required buffer size.
+    pub fn settings_object_as_str(obj: u64, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 }
 ```
 

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -226,6 +226,33 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Gets the AutoSplitterSettings as a settings object
+//!     /// and puts it in the obj_ptr.
+//!     /// This can be queried by functions such as
+//!     /// settings_object_as_bool, settings_object_list_get,
+//!     /// and settings_object_dict_get.
+//!     pub fn get_auto_splitter_settings(obj_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a bool:
+//!     ///   1 for Some(true)
+//!     ///   0 for Some(false)
+//!     ///   -1 for None
+//!     pub fn settings_object_as_bool(obj: u64) -> i32;
+//!     /// Query a settings object as a list, get the length:
+//!     ///   non-negative values for Some(len)
+//!     ///   -1 for None
+//!     pub fn settings_object_list_len(obj: u64) -> i32;
+//!     /// Query a settings object as a list, get an element by index,
+//!     /// putting the element at elem_ptr.
+//!     pub fn settings_object_list_get(obj: u64, index: u32, elem_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a dict, get a value by key,
+//!     /// putting the value at value_ptr.
+//!     pub fn settings_object_dict_get(obj: u64, key_ptr: *const u8, key_len: usize, value_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a string, storing the
+//!     /// contents in the buffer given.
+//!     /// Returns `false` if the buffer is too small.
+//!     /// After this call, whether it was successful or not,
+//!     /// the `buf_len_ptr` will be set to the required buffer size.
+//!     pub fn settings_object_as_str(obj: u64, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //! }
 //! ```
 //!

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::{HashMap, hash_map::DefaultHasher}, hash::{Hasher, Hash}};
+
+use xmltree::{Element, XMLNode};
 
 /// A setting that is meant to be shown to and modified by the user.
 #[non_exhaustive]
@@ -52,7 +54,8 @@ pub enum SettingValue {
 #[derive(Clone, Default)]
 pub struct SettingsStore {
     values: HashMap<Box<str>, SettingValue>,
-    auto_splitter_settings: String,
+    objects: HashMap<u64, ObjectValue>,
+    auto_splitter_settings: u64, // u64 to be looked up in SettingsStore objects
 }
 
 impl SettingsStore {
@@ -62,10 +65,13 @@ impl SettingsStore {
     }
 
     /// Creates a new settings store from the AutoSplitterSettings XML contents.
-    pub fn new_auto_splitter_settings(auto_splitter_settings: String) -> Self {
+    pub fn new_auto_splitter_settings(xml: String) -> Self {
+        let mut objects = HashMap::new();
+        let auto_splitter_settings = ObjectValue::from_xml_string(xml, &mut objects).insert(&mut objects);
         Self {
             values: Default::default(),
-            auto_splitter_settings
+            objects,
+            auto_splitter_settings,
         }
     }
 
@@ -89,8 +95,103 @@ impl SettingsStore {
         self.values.iter().map(|(k, v)| (k.as_ref(), v))
     }
 
-    /// Gets the AutoSplitterSettings XML contents.
-    pub fn get_auto_splitter_settings(&self) -> &str {
-        &self.auto_splitter_settings
+    /// Gets the AutoSplitterSettings object.
+    pub fn get_auto_splitter_settings(&self) -> u64 {
+        self.auto_splitter_settings
+    }
+
+    /// Query a settings object as a string.
+    pub fn object_as_str(&self, o: u64) -> Option<&str> {
+        match self.objects.get(&o)? {
+            ObjectValue::Text(s) => Some(s),
+            ObjectValue::List(l) => {
+                match l[..] {
+                    [] => Some(""),
+                    [e] => self.object_as_str(e),
+                    _ => None,
+                }
+            },
+            _ => None,
+        }
+    }
+    /// Query a settings objects as a bool.
+    pub fn object_as_bool(&self, o: u64) -> Option<bool> {
+        match self.object_as_str(o)?.trim() {
+            "True" => Some(true),
+            "False" => Some(false),
+            _ => None,
+        }
+    }
+    /// Query a settings object as a list.
+    pub fn object_as_list(&self, o: u64) -> Option<&[u64]> {
+        match self.objects.get(&o)? {
+            ObjectValue::List(l) => Some(l),
+            _ => None,
+        }
+    }
+    /// Query a settings object as a list, get the length.
+    pub fn object_list_len(&self, o: u64) -> Option<usize> {
+        Some(self.object_as_list(o)?.len())
+    }
+    /// Query a settings object as a list, get an element by index.
+    pub fn object_list_get(&self, o: u64, index: usize) -> Option<u64> {
+        self.object_as_list(o)?.get(index).copied()
+    }
+    /// Query a settings object as a dictionary, get a value by key.
+    pub fn object_dict_get(&self, o: u64, key: &str) -> Option<u64> {
+        if let Some(v) = self.object_entry_get(o, key) {
+            return Some(v);
+        }
+        for e in self.object_as_list(o)? {
+            if let Some(v) = self.object_entry_get(*e, key) {
+                return Some(v);
+            }
+        }
+        None
+    }
+    fn object_entry_get(&self, o: u64, key: &str) -> Option<u64> {
+        match self.objects.get(&o) {
+            Some(ObjectValue::Entry(k, v)) if k == key => {
+                Some(*v)
+            },
+            _ => None
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum ObjectValue {
+    Text(String),
+    Entry(String, u64), // u64 to be looked up in SettingsStore objects
+    List(Vec<u64>), // u64 to be looked up in SettingsStore objects
+}
+
+impl ObjectValue {
+    fn insert(self, objects: &mut HashMap<u64, ObjectValue>) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        objects.len().hash(&mut hasher);
+        let h = hasher.finish();
+        objects.insert(h, self);
+        h
+    }
+    fn from_xml_string(xml: String, objects: &mut HashMap<u64, ObjectValue>) -> ObjectValue {
+        ObjectValue::from_xml_nodes(Element::parse_all(xml.as_bytes()).unwrap_or_default(), objects)
+    }
+    fn from_xml_nodes(xml: Vec<XMLNode>, objects: &mut HashMap<u64, ObjectValue>) -> ObjectValue {
+        let hs = xml.into_iter().filter_map(|e| {
+            ObjectValue::from_xml_node(e, objects).map(|o| o.insert(objects))
+        }).collect();
+        ObjectValue::List(hs)
+    }
+    fn from_xml_node(xml: XMLNode, objects: &mut HashMap<u64, ObjectValue>) -> Option<ObjectValue> {
+        match xml {
+            XMLNode::Text(s) => Some(ObjectValue::Text(s)),
+            XMLNode::Element(Element { name, children, .. }) => {
+                let h = ObjectValue::from_xml_nodes(children, objects).insert(objects);
+                Some(ObjectValue::Entry(name, h))
+            },
+            _ => None
+        }
     }
 }

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -52,12 +52,21 @@ pub enum SettingValue {
 #[derive(Clone, Default)]
 pub struct SettingsStore {
     values: HashMap<Box<str>, SettingValue>,
+    auto_splitter_settings: String,
 }
 
 impl SettingsStore {
     /// Creates a new empty settings store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a new settings store from the AutoSplitterSettings XML contents.
+    pub fn new_auto_splitter_settings(auto_splitter_settings: String) -> Self {
+        Self {
+            values: Default::default(),
+            auto_splitter_settings
+        }
     }
 
     /// Sets a setting to the new value. If the key of the setting doesn't exist
@@ -78,5 +87,10 @@ impl SettingsStore {
     /// store.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &SettingValue)> {
         self.values.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+
+    /// Gets the AutoSplitterSettings XML contents.
+    pub fn get_auto_splitter_settings(&self) -> &str {
+        &self.auto_splitter_settings
     }
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -226,6 +226,33 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Gets the AutoSplitterSettings as a settings object
+//!     /// and puts it in the obj_ptr.
+//!     /// This can be queried by functions such as
+//!     /// settings_object_as_bool, settings_object_list_get,
+//!     /// and settings_object_dict_get.
+//!     pub fn get_auto_splitter_settings(obj_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a bool:
+//!     ///   1 for Some(true)
+//!     ///   0 for Some(false)
+//!     ///   -1 for None
+//!     pub fn settings_object_as_bool(obj: u64) -> i32;
+//!     /// Query a settings object as a list, get the length:
+//!     ///   non-negative values for Some(len)
+//!     ///   -1 for None
+//!     pub fn settings_object_list_len(obj: u64) -> i32;
+//!     /// Query a settings object as a list, get an element by index,
+//!     /// putting the element at elem_ptr.
+//!     pub fn settings_object_list_get(obj: u64, index: u32, elem_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a dict, get a value by key,
+//!     /// putting the value at value_ptr.
+//!     pub fn settings_object_dict_get(obj: u64, key_ptr: *const u8, key_len: usize, value_ptr: *mut u64) -> bool;
+//!     /// Query a settings object as a string, storing the
+//!     /// contents in the buffer given.
+//!     /// Returns `false` if the buffer is too small.
+//!     /// After this call, whether it was successful or not,
+//!     /// the `buf_len_ptr` will be set to the required buffer size.
+//!     pub fn settings_object_as_str(obj: u64, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //! }
 //! ```
 //!


### PR DESCRIPTION
This adds 6 functions to the Auto Splitting Runtime:
 - `get_auto_splitter_settings` to get the `AutoSplitterSettings` as a settings object,
 - `settings_object_as_bool` to query a settings object as a boolean,
 - `settings_object_list_len` and
 - `settings_object_list_get` to query it as a list,
 - `settings_object_dict_get` to query it as a dictionary,
 - `settings_object_as_str` to query it as a string.

A settings object as a list or dict can contain other settings objects inside it, which can also be lists or dicts, allowing settings with more nested structure.

This allows an auto splitter to get settings from the `AutoSplitterSettings` XML contents from existing splits files, without the auto splitter needing to know whether it's XML, JSON, or any other representation behind the settings object.

This PR is a replacement of https://github.com/LiveSplit/livesplit-core/pull/726 after feedback.

A git diff of the corresponding changes to the Rust `asr` crate to use these functions and turn them into methods of a `SettingsObject` type can be seen here:
https://github.com/AlexKnauth/asr/compare/unity-2-mono-4...AlexKnauth:asr:auto_splitter_settings_query