### PR TITLE
Disable broken targets in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,9 @@ jobs:
           - FreeBSD i686
           - FreeBSD x86_64
           - illumos x86_64
-          - NetBSD x86_64
+          # FIXME: The target currently fails to link due to
+          # "ld: cannot find -lexecinfo"
+          # - NetBSD x86_64
           - Solaris sparcv9
           - Solaris x86_64
 
@@ -388,6 +390,9 @@ jobs:
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
+            # FIXME: The mips targets currently miscompile:
+            # https://github.com/rust-lang/rust/issues/116177
+            tests: skip
 
           - label: Linux mips64 musl
             target: mips64-unknown-linux-muslabi64
@@ -396,6 +401,9 @@ jobs:
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
+            # FIXME: The mips targets currently miscompile:
+            # https://github.com/rust-lang/rust/issues/116177
+            tests: skip
 
           - label: Linux mipsel musl
             target: mipsel-unknown-linux-musl
@@ -404,6 +412,9 @@ jobs:
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
+            # FIXME: The mips targets currently miscompile:
+            # https://github.com/rust-lang/rust/issues/116177
+            tests: skip
 
           - label: Linux mips64el musl
             target: mips64el-unknown-linux-muslabi64
@@ -412,6 +423,9 @@ jobs:
             # FIXME: Networking Tests fail due to missing OpenSSL
             # https://github.com/LiveSplit/livesplit-core/issues/308
             dylib: skip
+            # FIXME: The mips targets currently miscompile:
+            # https://github.com/rust-lang/rust/issues/116177
+            tests: skip
 
           - label: Linux powerpc
             target: powerpc-unknown-linux-gnu
@@ -545,9 +559,11 @@ jobs:
             target: x86_64-unknown-illumos
             tests: skip
 
-          - label: NetBSD x86_64
-            target: x86_64-unknown-netbsd
-            tests: skip
+          # FIXME: The target currently fails to link due to
+          # "ld: cannot find -lexecinfo"
+          # - label: NetBSD x86_64
+          #   target: x86_64-unknown-netbsd
+          #   tests: skip
 
           - label: Solaris sparcv9
             target: sparcv9-sun-solaris

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,4 +1,4 @@
-use livesplit_auto_splitting::{Config, Runtime, SettingsStore, Timer, TimerState};
+use livesplit_auto_splitting::{Config, Runtime, Timer, TimerState};
 use std::{
     ffi::OsStr,
     fmt, fs,


### PR DESCRIPTION
This disables the tests on MIPS because the MIPS targets are currently very broken. Additionally, it disables the NetBSD target because it currently fails to link.