### PR TITLE
Allow nonblocking access to Auto Splitting Runtime

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -260,7 +260,7 @@ mod settings;
 mod timer;
 
 pub use process::Process;
-pub use runtime::{Config, CreationError, InterruptHandle, Runtime};
+pub use runtime::{Config, CreationError, InterruptHandle, Runtime, RuntimeGuard};
 pub use settings::{SettingValue, SettingsStore, UserSetting, UserSettingKind};
 pub use time;
 pub use timer::{Timer, TimerState};

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -69,8 +69,8 @@ fn compile(crate_name: &str) -> anyhow::Result<Runtime<DummyTimer>> {
 }
 
 fn run(crate_name: &str) -> anyhow::Result<()> {
-    let mut runtime = compile(crate_name)?;
-    runtime.update()?;
+    let runtime = compile(crate_name)?;
+    runtime.lock().update()?;
     Ok(())
 }
 
@@ -139,7 +139,7 @@ fn random() {
 
 #[test]
 fn infinite_loop() {
-    let mut runtime = compile("infinite-loop").unwrap();
+    let runtime = compile("infinite-loop").unwrap();
 
     let interrupt = runtime.interrupt_handle();
 
@@ -148,7 +148,7 @@ fn infinite_loop() {
         interrupt.interrupt();
     });
 
-    assert!(runtime.update().is_err());
+    assert!(runtime.lock().update().is_err());
 }
 
 // FIXME: Test Network


### PR DESCRIPTION
In order to implement the settings more cleanly and allow the auto splitters to read and modify them, we need to reduce any potential locks that could lock up the auto splitter, or worse, the entire application. This now introduces a "git like" model where the user settings and settings store can be atomically stored and loaded. This allows the entire `asr-debugger` to function without being locked up by a malicious auto splitter now.