### PR TITLE
Add API for accessing / modify settings maps

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -40,6 +40,12 @@ pub struct Process(NonZeroU64);
 pub struct ProcessId(u64);
 
 #[repr(transparent)]
+pub struct SettingsMap(NonZeroU64);
+
+#[repr(transparent)]
+pub struct SettingValue(NonZeroU64);
+
+#[repr(transparent)]
 pub struct TimerState(u32);
 
 impl TimerState {
@@ -226,6 +232,63 @@ extern "C" {
         tooltip_ptr: *const u8,
         tooltip_len: usize,
     );
+
+    /// Creates a new settings map. You own the settings map and are responsible
+    /// for freeing it.
+    pub fn settings_map_new() -> SettingsMap;
+    /// Frees a settings map.
+    pub fn settings_map_free(map: SettingsMap);
+    /// Loads a copy of the currently set global settings map. Any changes to it
+    /// are only perceived if it's stored back. You own the settings map and are
+    /// responsible for freeing it.
+    pub fn settings_map_load() -> SettingsMap;
+    /// Stores a copy of the settings map as the new global settings map. This
+    /// will overwrite the previous global settings map. You still retain
+    /// ownership of the map, which means you still need to free it. There's a
+    /// chance that the settings map was changed in the meantime, so those
+    /// changes could get lost. Prefer using `settings_map_store_if_unchanged`
+    /// if you want to avoid that.
+    pub fn settings_map_store(map: SettingsMap);
+    /// Stores a copy of the new settings map as the new global settings map if
+    /// the map has not changed in the meantime. This is done by comparing the
+    /// old map. You still retain ownership of both maps, which means you still
+    /// need to free them. Returns `true` if the map was stored successfully.
+    /// Returns `false` if the map was changed in the meantime.
+    pub fn settings_map_store_if_unchanged(old_map: SettingsMap, new_map: SettingsMap) -> bool;
+    /// Copies a settings map. No changes inside the copy affect the original
+    /// settings map. You own the new settings map and are responsible for
+    /// freeing it.
+    pub fn settings_map_copy(map: SettingsMap) -> SettingsMap;
+    /// Inserts a copy of the setting value into the settings map based on the
+    /// key. If the key already exists, it will be overwritten. You still retain
+    /// ownership of the setting value, which means you still need to free it.
+    pub fn settings_map_insert(
+        map: SettingsMap,
+        key_ptr: *const u8,
+        key_len: usize,
+        value: SettingValue,
+    );
+    /// Gets a copy of the setting value from the settings map based on the key.
+    /// Returns `None` if the key does not exist. Any changes to it are only
+    /// perceived if it's stored back. You own the setting value and are
+    /// responsible for freeing it.
+    pub fn settings_map_get(
+        map: SettingsMap,
+        key_ptr: *const u8,
+        key_len: usize,
+    ) -> Option<SettingValue>;
+
+    /// Creates a new boolean setting value. You own the setting value and are
+    /// responsible for freeing it.
+    pub fn setting_value_new_bool(value: bool) -> SettingValue;
+    /// Frees a setting value.
+    pub fn setting_value_free(value: SettingValue);
+    /// Gets the value of a boolean setting value by storing it into the pointer
+    /// provided. Returns `false` if the setting value is not a boolean. No
+    /// value is stored into the pointer in that case. No matter what happens,
+    /// you still retain ownership of the setting value, which means you still
+    /// need to free it.
+    pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
 }
 ```
 

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -40,6 +40,12 @@
 //! pub struct ProcessId(u64);
 //!
 //! #[repr(transparent)]
+//! pub struct SettingsMap(NonZeroU64);
+//!
+//! #[repr(transparent)]
+//! pub struct SettingValue(NonZeroU64);
+//!
+//! #[repr(transparent)]
 //! pub struct TimerState(u32);
 //!
 //! impl TimerState {
@@ -226,6 +232,63 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!
+//!     /// Creates a new settings map. You own the settings map and are responsible
+//!     /// for freeing it.
+//!     pub fn settings_map_new() -> SettingsMap;
+//!     /// Frees a settings map.
+//!     pub fn settings_map_free(map: SettingsMap);
+//!     /// Loads a copy of the currently set global settings map. Any changes to it
+//!     /// are only perceived if it's stored back. You own the settings map and are
+//!     /// responsible for freeing it.
+//!     pub fn settings_map_load() -> SettingsMap;
+//!     /// Stores a copy of the settings map as the new global settings map. This
+//!     /// will overwrite the previous global settings map. You still retain
+//!     /// ownership of the map, which means you still need to free it. There's a
+//!     /// chance that the settings map was changed in the meantime, so those
+//!     /// changes could get lost. Prefer using `settings_map_store_if_unchanged`
+//!     /// if you want to avoid that.
+//!     pub fn settings_map_store(map: SettingsMap);
+//!     /// Stores a copy of the new settings map as the new global settings map if
+//!     /// the map has not changed in the meantime. This is done by comparing the
+//!     /// old map. You still retain ownership of both maps, which means you still
+//!     /// need to free them. Returns `true` if the map was stored successfully.
+//!     /// Returns `false` if the map was changed in the meantime.
+//!     pub fn settings_map_store_if_unchanged(old_map: SettingsMap, new_map: SettingsMap) -> bool;
+//!     /// Copies a settings map. No changes inside the copy affect the original
+//!     /// settings map. You own the new settings map and are responsible for
+//!     /// freeing it.
+//!     pub fn settings_map_copy(map: SettingsMap) -> SettingsMap;
+//!     /// Inserts a copy of the setting value into the settings map based on the
+//!     /// key. If the key already exists, it will be overwritten. You still retain
+//!     /// ownership of the setting value, which means you still need to free it.
+//!     pub fn settings_map_insert(
+//!         map: SettingsMap,
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         value: SettingValue,
+//!     );
+//!     /// Gets a copy of the setting value from the settings map based on the key.
+//!     /// Returns `None` if the key does not exist. Any changes to it are only
+//!     /// perceived if it's stored back. You own the setting value and are
+//!     /// responsible for freeing it.
+//!     pub fn settings_map_get(
+//!         map: SettingsMap,
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!     ) -> Option<SettingValue>;
+//!
+//!     /// Creates a new boolean setting value. You own the setting value and are
+//!     /// responsible for freeing it.
+//!     pub fn setting_value_new_bool(value: bool) -> SettingValue;
+//!     /// Frees a setting value.
+//!     pub fn setting_value_free(value: SettingValue);
+//!     /// Gets the value of a boolean setting value by storing it into the pointer
+//!     /// provided. Returns `false` if the setting value is not a boolean. No
+//!     /// value is stored into the pointer in that case. No matter what happens,
+//!     /// you still retain ownership of the setting value, which means you still
+//!     /// need to free it.
+//!     pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
 //! }
 //! ```
 //!
@@ -261,6 +324,6 @@ mod timer;
 
 pub use process::Process;
 pub use runtime::{Config, CreationError, InterruptHandle, Runtime, RuntimeGuard};
-pub use settings::{SettingValue, SettingsStore, UserSetting, UserSettingKind};
+pub use settings::{SettingValue, SettingsMap, UserSetting, UserSettingKind};
 pub use time;
 pub use timer::{Timer, TimerState};

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -6,8 +6,8 @@ use std::{collections::HashMap, sync::Arc};
 pub struct UserSetting {
     /// A unique identifier for this setting. This is not meant to be shown to
     /// the user and is only used to keep track of the setting. This key is used
-    /// to store and retrieve the value of the setting from the
-    /// [`SettingsStore`].
+    /// to store and retrieve the value of the setting from the main
+    /// [`SettingsMap`].
     pub key: Arc<str>,
     /// The name of the setting that is shown to the user.
     pub description: Arc<str>,
@@ -32,7 +32,7 @@ pub enum UserSettingKind {
     /// A boolean setting. This could be visualized as a checkbox or a slider.
     Bool {
         /// The default value of the setting, if it's not available in the
-        /// settings store yet.
+        /// settings map yet.
         default_value: bool,
     },
 }
@@ -45,17 +45,17 @@ pub enum SettingValue {
     Bool(bool),
 }
 
-/// Stores all the settings of an auto splitter. Currently this only stores
+/// A key-value map that stores the settings of an auto splitter. It only stores
 /// values that are modified. So there may be settings that are registered as
 /// user settings, but because the user didn't modify them, they are not stored
 /// here yet.
 #[derive(Clone, Default)]
-pub struct SettingsStore {
+pub struct SettingsMap {
     values: Arc<HashMap<Arc<str>, SettingValue>>,
 }
 
-impl SettingsStore {
-    /// Creates a new empty settings store.
+impl SettingsMap {
+    /// Creates a new empty settings map.
     pub fn new() -> Self {
         Self::default()
     }
@@ -63,19 +63,18 @@ impl SettingsStore {
     /// Sets a setting to the new value. If the key of the setting doesn't exist
     /// yet it will be stored as a new value. Otherwise the value will be
     /// updated.
-    pub fn set(&mut self, key: Arc<str>, value: SettingValue) {
+    pub fn insert(&mut self, key: Arc<str>, value: SettingValue) {
         Arc::make_mut(&mut self.values).insert(key, value);
     }
 
     /// Accesses the value of a setting by its key. While the setting may exist
     /// as part of the user settings, it may not have been stored into the
-    /// settings store yet, so it may not exist, despite being registered.
+    /// settings map yet, so it may not exist, despite being registered.
     pub fn get(&self, key: &str) -> Option<&SettingValue> {
         self.values.get(key)
     }
 
-    /// Iterates over all the setting keys and their values in the settings
-    /// store.
+    /// Iterates over all the setting keys and their values in the map.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &SettingValue)> {
         self.values.iter().map(|(k, v)| (k.as_ref(), v))
     }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -40,6 +40,12 @@
 //! pub struct ProcessId(u64);
 //!
 //! #[repr(transparent)]
+//! pub struct SettingsMap(NonZeroU64);
+//!
+//! #[repr(transparent)]
+//! pub struct SettingValue(NonZeroU64);
+//!
+//! #[repr(transparent)]
 //! pub struct TimerState(u32);
 //!
 //! impl TimerState {
@@ -226,6 +232,63 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!
+//!     /// Creates a new settings map. You own the settings map and are responsible
+//!     /// for freeing it.
+//!     pub fn settings_map_new() -> SettingsMap;
+//!     /// Frees a settings map.
+//!     pub fn settings_map_free(map: SettingsMap);
+//!     /// Loads a copy of the currently set global settings map. Any changes to it
+//!     /// are only perceived if it's stored back. You own the settings map and are
+//!     /// responsible for freeing it.
+//!     pub fn settings_map_load() -> SettingsMap;
+//!     /// Stores a copy of the settings map as the new global settings map. This
+//!     /// will overwrite the previous global settings map. You still retain
+//!     /// ownership of the map, which means you still need to free it. There's a
+//!     /// chance that the settings map was changed in the meantime, so those
+//!     /// changes could get lost. Prefer using `settings_map_store_if_unchanged`
+//!     /// if you want to avoid that.
+//!     pub fn settings_map_store(map: SettingsMap);
+//!     /// Stores a copy of the new settings map as the new global settings map if
+//!     /// the map has not changed in the meantime. This is done by comparing the
+//!     /// old map. You still retain ownership of both maps, which means you still
+//!     /// need to free them. Returns `true` if the map was stored successfully.
+//!     /// Returns `false` if the map was changed in the meantime.
+//!     pub fn settings_map_store_if_unchanged(old_map: SettingsMap, new_map: SettingsMap) -> bool;
+//!     /// Copies a settings map. No changes inside the copy affect the original
+//!     /// settings map. You own the new settings map and are responsible for
+//!     /// freeing it.
+//!     pub fn settings_map_copy(map: SettingsMap) -> SettingsMap;
+//!     /// Inserts a copy of the setting value into the settings map based on the
+//!     /// key. If the key already exists, it will be overwritten. You still retain
+//!     /// ownership of the setting value, which means you still need to free it.
+//!     pub fn settings_map_insert(
+//!         map: SettingsMap,
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         value: SettingValue,
+//!     );
+//!     /// Gets a copy of the setting value from the settings map based on the key.
+//!     /// Returns `None` if the key does not exist. Any changes to it are only
+//!     /// perceived if it's stored back. You own the setting value and are
+//!     /// responsible for freeing it.
+//!     pub fn settings_map_get(
+//!         map: SettingsMap,
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!     ) -> Option<SettingValue>;
+//!
+//!     /// Creates a new boolean setting value. You own the setting value and are
+//!     /// responsible for freeing it.
+//!     pub fn setting_value_new_bool(value: bool) -> SettingValue;
+//!     /// Frees a setting value.
+//!     pub fn setting_value_free(value: SettingValue);
+//!     /// Gets the value of a boolean setting value by storing it into the pointer
+//!     /// provided. Returns `false` if the setting value is not a boolean. No
+//!     /// value is stored into the pointer in that case. No matter what happens,
+//!     /// you still retain ownership of the setting value, which means you still
+//!     /// need to free it.
+//!     pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
 //! }
 //! ```
 //!
@@ -252,7 +315,7 @@ use livesplit_auto_splitting::{
     Config, CreationError, InterruptHandle, Runtime as ScriptRuntime, Timer as AutoSplitTimer,
     TimerState,
 };
-pub use livesplit_auto_splitting::{SettingValue, SettingsStore, UserSetting, UserSettingKind};
+pub use livesplit_auto_splitting::{SettingValue, SettingsMap, UserSetting, UserSettingKind};
 use snafu::Snafu;
 use std::{fmt, fs, io, path::PathBuf, thread, time::Duration};
 use tokio::{
@@ -635,7 +698,7 @@ async fn run(
                     }
                     Request::ReloadScript(ret) => {
                         let mut config = Config::default();
-                        config.settings_store = Some(runtime.settings_store().clone());
+                        config.settings_map = Some(runtime.settings_map().clone());
 
                         match ScriptRuntime::new(&script_path, Timer(timer.clone()), config) {
                             Ok(r) => {
@@ -654,8 +717,8 @@ async fn run(
                         log::info!(target: "Auto Splitter", "Getting the settings");
                     }
                     Request::GetSettingValue(key, ret) => {
-                        let store = &runtime.settings_store();
-                        let setting_value = store.get(key.as_str());
+                        let settings_map = runtime.settings_map();
+                        let setting_value = settings_map.get(key.as_str());
 
                         let user_setting_value =
                             match runtime.user_settings().iter().find(|x| *x.key == key) {
@@ -678,10 +741,10 @@ async fn run(
                     }
                     Request::SetSettingValue(key, value, ret) => {
                         loop {
-                            let old = runtime.settings_store();
+                            let old = runtime.settings_map();
                             let mut new = old.clone();
-                            new.set(key.clone(), value.clone());
-                            if runtime.set_settings_store_if_unchanged(old, new) {
+                            new.insert(key.clone(), value.clone());
+                            if runtime.set_settings_map_if_unchanged(&old, new) {
                                 break;
                             }
                         }


### PR DESCRIPTION
This adds a new API that allows auto splitters to access the current settings map and to modify it. For now only booleans settings are supported, but this can very easily be extended to other types. The API is designed so no large scale locking is necessary, so malicious or buggy auto splitters can't lock up the application. However, in order for the API to not cause race conditions all the values are based on the copy-on-write principle. The values are cheaply cloned, allowing the auto splitter to work on a seemingly owned copy of the settings map and the values inside. A CAS algorithm can be used to then resolve any races where two parts of the code make modifications to the settings map in parallel.