### PR TITLE
Add process_get_module_path

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -157,6 +157,23 @@ extern "C" {
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroU64>;
+    /// Stores the file system path of a module in a process in the buffer
+    /// given. The pointer to the module name needs to point to valid UTF-8
+    /// encoded text with the given length. The path is a path that is
+    /// accessible through the WASI file system, so a Windows path of
+    /// `C:\foo\bar.exe` would be returned as `/mnt/c/foo/bar.exe`. Returns
+    /// `false` if the buffer is too small. After this call, no matter whether
+    /// it was successful or not, the `buf_len_ptr` will be set to the required
+    /// buffer size. If `false` is returned and the `buf_len_ptr` got set to 0,
+    /// the path or the module does not exist or it failed to get read. The path
+    /// is guaranteed to be valid UTF-8 and is not nul-terminated.
+    pub fn process_get_module_path(
+        process: Process,
+        name_ptr: *const u8,
+        name_len: usize,
+        buf_ptr: *mut u8,
+        buf_len_ptr: *mut usize,
+    ) -> bool;
     /// Stores the file system path of the executable in the buffer given. The
     /// path is a path that is accessible through the WASI file system, so a
     /// Windows path of `C:\foo\bar.exe` would be returned as

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -157,6 +157,23 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
+//!     /// Stores the file system path of a module in a process in the buffer
+//!     /// given. The pointer to the module name needs to point to valid UTF-8
+//!     /// encoded text with the given length. The path is a path that is
+//!     /// accessible through the WASI file system, so a Windows path of
+//!     /// `C:\foo\bar.exe` would be returned as `/mnt/c/foo/bar.exe`. Returns
+//!     /// `false` if the buffer is too small. After this call, no matter whether
+//!     /// it was successful or not, the `buf_len_ptr` will be set to the required
+//!     /// buffer size. If `false` is returned and the `buf_len_ptr` got set to 0,
+//!     /// the path or the module does not exist or it failed to get read. The path
+//!     /// is guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     pub fn process_get_module_path(
+//!         process: Process,
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
 //!     /// Stores the file system path of the executable in the buffer given. The
 //!     /// path is a path that is accessible through the WASI file system, so a
 //!     /// Windows path of `C:\foo\bar.exe` would be returned as

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -141,6 +141,15 @@ impl Process {
             .sum())
     }
 
+    pub(super) fn module_path(&mut self, module: &str) -> Result<Box<str>, ModuleError> {
+        self.refresh_memory_ranges()?;
+        self.memory_ranges
+            .iter()
+            .find(|m| m.filename().is_some_and(|f| f.ends_with(module)))
+            .context(ModuleDoesntExist)
+            .map(|m| build_path(m.filename().unwrap()).unwrap_or_default())
+    }
+
     pub(super) fn read_mem(&self, address: Address, buf: &mut [u8]) -> io::Result<()> {
         self.handle.copy_address(address as usize, buf)
     }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -157,6 +157,23 @@
 //!         name_ptr: *const u8,
 //!         name_len: usize,
 //!     ) -> Option<NonZeroU64>;
+//!     /// Stores the file system path of a module in a process in the buffer
+//!     /// given. The pointer to the module name needs to point to valid UTF-8
+//!     /// encoded text with the given length. The path is a path that is
+//!     /// accessible through the WASI file system, so a Windows path of
+//!     /// `C:\foo\bar.exe` would be returned as `/mnt/c/foo/bar.exe`. Returns
+//!     /// `false` if the buffer is too small. After this call, no matter whether
+//!     /// it was successful or not, the `buf_len_ptr` will be set to the required
+//!     /// buffer size. If `false` is returned and the `buf_len_ptr` got set to 0,
+//!     /// the path or the module does not exist or it failed to get read. The path
+//!     /// is guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     pub fn process_get_module_path(
+//!         process: Process,
+//!         name_ptr: *const u8,
+//!         name_len: usize,
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
 //!     /// Stores the file system path of the executable in the buffer given. The
 //!     /// path is a path that is accessible through the WASI file system, so a
 //!     /// Windows path of `C:\foo\bar.exe` would be returned as


### PR DESCRIPTION
This adds `process_get_module_path` to the Auto Splitting Runtime, which gets the path on the file system to the module.

This is useful in situations where the Section Header Table is there in the file, but is not loaded into memory, even when the rest of the module is.