### PR TITLE
Add support for setting values of type i64 and f64

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -305,6 +305,12 @@ extern "C" {
     /// Creates a new boolean setting value. You own the setting value and are
     /// responsible for freeing it.
     pub fn setting_value_new_bool(value: bool) -> SettingValue;
+    /// Creates a new 64-bit signed integer setting value. You own the setting
+    /// value and are responsible for freeing it.
+    pub fn setting_value_new_i64(value: i64) -> SettingValue;
+    /// Creates a new 64-bit floating point setting value. You own the setting
+    /// value and are responsible for freeing it.
+    pub fn setting_value_new_f64(value: f64) -> SettingValue;
     /// Creates a new string setting value. The pointer needs to point to valid
     /// UTF-8 encoded text with the given length. You own the setting value and
     /// are responsible for freeing it.
@@ -324,6 +330,18 @@ extern "C" {
     /// you still retain ownership of the setting value, which means you still
     /// need to free it.
     pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
+    /// Gets the value of a 64-bit signed integer setting value by storing it
+    /// into the pointer provided. Returns `false` if the setting value is not a
+    /// 64-bit signed integer. No value is stored into the pointer in that case.
+    /// No matter what happens, you still retain ownership of the setting value,
+    /// which means you still need to free it.
+    pub fn setting_value_get_i64(value: SettingValue, value_ptr: *mut i64) -> bool;
+    /// Gets the value of a 64-bit floating point setting value by storing it
+    /// into the pointer provided. Returns `false` if the setting value is not a
+    /// 64-bit floating point number. No value is stored into the pointer in
+    /// that case. No matter what happens, you still retain ownership of the
+    /// setting value, which means you still need to free it.
+    pub fn setting_value_get_f64(value: SettingValue, value_ptr: *mut f64) -> bool;
     /// Gets the value of a string setting value by storing it into the buffer
     /// provided. Returns `false` if the buffer is too small or if the setting
     /// value is not a string. After this call, no matter whether it was

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -305,6 +305,12 @@
 //!     /// Creates a new boolean setting value. You own the setting value and are
 //!     /// responsible for freeing it.
 //!     pub fn setting_value_new_bool(value: bool) -> SettingValue;
+//!     /// Creates a new 64-bit signed integer setting value. You own the setting
+//!     /// value and are responsible for freeing it.
+//!     pub fn setting_value_new_i64(value: i64) -> SettingValue;
+//!     /// Creates a new 64-bit floating point setting value. You own the setting
+//!     /// value and are responsible for freeing it.
+//!     pub fn setting_value_new_f64(value: f64) -> SettingValue;
 //!     /// Creates a new string setting value. The pointer needs to point to valid
 //!     /// UTF-8 encoded text with the given length. You own the setting value and
 //!     /// are responsible for freeing it.
@@ -324,6 +330,18 @@
 //!     /// you still retain ownership of the setting value, which means you still
 //!     /// need to free it.
 //!     pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
+//!     /// Gets the value of a 64-bit signed integer setting value by storing it
+//!     /// into the pointer provided. Returns `false` if the setting value is not a
+//!     /// 64-bit signed integer. No value is stored into the pointer in that case.
+//!     /// No matter what happens, you still retain ownership of the setting value,
+//!     /// which means you still need to free it.
+//!     pub fn setting_value_get_i64(value: SettingValue, value_ptr: *mut i64) -> bool;
+//!     /// Gets the value of a 64-bit floating point setting value by storing it
+//!     /// into the pointer provided. Returns `false` if the setting value is not a
+//!     /// 64-bit floating point number. No value is stored into the pointer in
+//!     /// that case. No matter what happens, you still retain ownership of the
+//!     /// setting value, which means you still need to free it.
+//!     pub fn setting_value_get_f64(value: SettingValue, value_ptr: *mut f64) -> bool;
 //!     /// Gets the value of a string setting value by storing it into the buffer
 //!     /// provided. Returns `false` if the buffer is too small or if the setting
 //!     /// value is not a string. After this call, no matter whether it was
@@ -362,6 +380,7 @@
     clippy::perf,
     clippy::style,
     clippy::missing_const_for_fn,
+    clippy::undocumented_unsafe_blocks,
     missing_docs,
     rust_2018_idioms
 )]

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -31,7 +31,7 @@ pub enum UserSettingKind {
         /// The top level titles use a heading level of 0.
         heading_level: u32,
     },
-    /// A boolean setting. This could be visualized as a checkbox or a slider.
+    /// A boolean setting. This could be visualized as a checkbox or a toggle.
     Bool {
         /// The default value of the setting, if it's not available in the
         /// settings map yet.
@@ -47,6 +47,10 @@ pub enum SettingValue {
     Map(SettingsMap),
     /// A boolean value.
     Bool(bool),
+    /// A 64-bit signed integer value.
+    I64(i64),
+    /// A 64-bit floating point value.
+    F64(f64),
     /// A string value.
     String(Arc<str>),
 }
@@ -56,6 +60,8 @@ impl fmt::Debug for SettingValue {
         match self {
             Self::Map(v) => fmt::Debug::fmt(v, f),
             Self::Bool(v) => fmt::Debug::fmt(v, f),
+            Self::I64(v) => fmt::Debug::fmt(v, f),
+            Self::F64(v) => fmt::Debug::fmt(v, f),
             Self::String(v) => fmt::Debug::fmt(v, f),
         }
     }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -305,6 +305,12 @@
 //!     /// Creates a new boolean setting value. You own the setting value and are
 //!     /// responsible for freeing it.
 //!     pub fn setting_value_new_bool(value: bool) -> SettingValue;
+//!     /// Creates a new 64-bit signed integer setting value. You own the setting
+//!     /// value and are responsible for freeing it.
+//!     pub fn setting_value_new_i64(value: i64) -> SettingValue;
+//!     /// Creates a new 64-bit floating point setting value. You own the setting
+//!     /// value and are responsible for freeing it.
+//!     pub fn setting_value_new_f64(value: f64) -> SettingValue;
 //!     /// Creates a new string setting value. The pointer needs to point to valid
 //!     /// UTF-8 encoded text with the given length. You own the setting value and
 //!     /// are responsible for freeing it.
@@ -324,6 +330,18 @@
 //!     /// you still retain ownership of the setting value, which means you still
 //!     /// need to free it.
 //!     pub fn setting_value_get_bool(value: SettingValue, value_ptr: *mut bool) -> bool;
+//!     /// Gets the value of a 64-bit signed integer setting value by storing it
+//!     /// into the pointer provided. Returns `false` if the setting value is not a
+//!     /// 64-bit signed integer. No value is stored into the pointer in that case.
+//!     /// No matter what happens, you still retain ownership of the setting value,
+//!     /// which means you still need to free it.
+//!     pub fn setting_value_get_i64(value: SettingValue, value_ptr: *mut i64) -> bool;
+//!     /// Gets the value of a 64-bit floating point setting value by storing it
+//!     /// into the pointer provided. Returns `false` if the setting value is not a
+//!     /// 64-bit floating point number. No value is stored into the pointer in
+//!     /// that case. No matter what happens, you still retain ownership of the
+//!     /// setting value, which means you still need to free it.
+//!     pub fn setting_value_get_f64(value: SettingValue, value_ptr: *mut f64) -> bool;
 //!     /// Gets the value of a string setting value by storing it into the buffer
 //!     /// provided. Returns `false` if the buffer is too small or if the setting
 //!     /// value is not a string. After this call, no matter whether it was


### PR DESCRIPTION
This adds support for setting values of type i64 and f64. It's unclear if we want to support unsigned integers or different sizes. [OBS's Data Settings API](https://docs.obsproject.com/reference-settings#set-functions), which logically is used for the same purpose as our settings maps and values, also only suports these two types. So it's probably fine for now to only support those.