### PR TITLE
Add `SettingsList` for storing lists of settings

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -43,6 +43,9 @@ pub struct ProcessId(u64);
 pub struct SettingsMap(NonZeroU64);
 
 #[repr(transparent)]
+pub struct SettingsList(NonZeroU64);
+
+#[repr(transparent)]
 pub struct SettingValue(NonZeroU64);
 
 #[repr(transparent)]
@@ -295,6 +298,51 @@ extern "C" {
         key_ptr: *const u8,
         key_len: usize,
     ) -> Option<SettingValue>;
+    /// Gets the length of a settings map.
+    pub fn settings_map_len(map: SettingsMap) -> u64;
+    /// Gets the key of a setting value from the settings map based on the index
+    /// by storing it into the buffer provided. Returns `false` if the buffer is
+    /// too small. After this call, no matter whether it was successful or not,
+    /// the `buf_len_ptr` will be set to the required buffer size. If `false` is
+    /// returned and the `buf_len_ptr` got set to 0, the index is out of bounds.
+    /// The key is guaranteed to be valid UTF-8 and is not nul-terminated.
+    pub fn settings_map_get_key_by_index(
+        map: SettingsMap,
+        idx: u64,
+        buf_ptr: *mut u8,
+        buf_len_ptr: *mut usize,
+    ) -> bool;
+    /// Gets a copy of the setting value from the settings map based on the
+    /// index. Returns `None` if the index is out of bounds. Any changes to it
+    /// are only perceived if it's stored back. You own the setting value and
+    /// are responsible for freeing it.
+    pub fn settings_map_get_value_by_index(map: SettingsMap, idx: u64) -> Option<SettingValue>;
+
+    /// Creates a new settings list. You own the settings list and are
+    /// responsible for freeing it.
+    pub fn settings_list_new() -> SettingsList;
+    /// Frees a settings list.
+    pub fn settings_list_free(list: SettingsList);
+    /// Copies a settings list. No changes inside the copy affect the original
+    /// settings list. You own the new settings list and are responsible for
+    /// freeing it.
+    pub fn settings_list_copy(list: SettingsList) -> SettingsList;
+    /// Gets the length of a settings list.
+    pub fn settings_list_len(list: SettingsList) -> u64;
+    /// Gets a copy of the setting value from the settings list based on the
+    /// index. Returns `None` if the index is out of bounds. Any changes to it
+    /// are only perceived if it's stored back. You own the setting value and
+    /// are responsible for freeing it.
+    pub fn settings_list_get(list: SettingsList, idx: u64) -> Option<SettingValue>;
+    /// Pushes a copy of the setting value to the end of the settings list. You
+    /// still retain ownership of the setting value, which means you still need
+    /// to free it.
+    pub fn settings_list_push(list: SettingsList, value: SettingValue);
+    /// Inserts a copy of the setting value into the settings list at the index
+    /// given. If the index is out of bounds, the setting value is pushed to the
+    /// end of the settings list. You still retain ownership of the setting
+    /// value, which means you still need to free it.
+    pub fn settings_list_insert(list: SettingsList, idx: u64, value: SettingValue);
 
     /// Creates a new setting value from a settings map. The value is a copy of
     /// the settings map. Any changes to the original settings map afterwards
@@ -302,6 +350,12 @@ extern "C" {
     /// value and are responsible for freeing it. You also retain ownership of
     /// the settings map, which means you still need to free it.
     pub fn setting_value_new_map(value: SettingsMap) -> SettingValue;
+    /// Creates a new setting value from a settings list. The value is a copy of
+    /// the settings list. Any changes to the original settings list afterwards
+    /// are not going to be perceived by the setting value. You own the setting
+    /// value and are responsible for freeing it. You also retain ownership of
+    /// the settings list, which means you still need to free it.
+    pub fn setting_value_new_list(value: SettingsList) -> SettingValue;
     /// Creates a new boolean setting value. You own the setting value and are
     /// responsible for freeing it.
     pub fn setting_value_new_bool(value: bool) -> SettingValue;
@@ -317,6 +371,10 @@ extern "C" {
     pub fn setting_value_new_string(value_ptr: *const u8, value_len: usize) -> SettingValue;
     /// Frees a setting value.
     pub fn setting_value_free(value: SettingValue);
+    /// Copies a setting value. No changes inside the copy affect the original
+    /// setting value. You own the new setting value and are responsible for
+    /// freeing it.
+    pub fn setting_value_copy(value: SettingValue) -> SettingValue;
     /// Gets the value of a setting value as a settings map by storing it into
     /// the pointer provided. Returns `false` if the setting value is not a
     /// settings map. No value is stored into the pointer in that case. No
@@ -324,6 +382,13 @@ extern "C" {
     /// which means you still need to free it. You own the settings map and are
     /// responsible for freeing it.
     pub fn setting_value_get_map(value: SettingValue, value_ptr: *mut SettingsMap) -> bool;
+    /// Gets the value of a setting value as a settings list by storing it into
+    /// the pointer provided. Returns `false` if the setting value is not a
+    /// settings list. No value is stored into the pointer in that case. No
+    /// matter what happens, you still retain ownership of the setting value,
+    /// which means you still need to free it. You own the settings list and are
+    /// responsible for freeing it.
+    pub fn setting_value_get_list(value: SettingValue, value_ptr: *mut SettingsList) -> bool;
     /// Gets the value of a boolean setting value by storing it into the pointer
     /// provided. Returns `false` if the setting value is not a boolean. No
     /// value is stored into the pointer in that case. No matter what happens,

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -43,6 +43,9 @@
 //! pub struct SettingsMap(NonZeroU64);
 //!
 //! #[repr(transparent)]
+//! pub struct SettingsList(NonZeroU64);
+//!
+//! #[repr(transparent)]
 //! pub struct SettingValue(NonZeroU64);
 //!
 //! #[repr(transparent)]
@@ -295,6 +298,51 @@
 //!         key_ptr: *const u8,
 //!         key_len: usize,
 //!     ) -> Option<SettingValue>;
+//!     /// Gets the length of a settings map.
+//!     pub fn settings_map_len(map: SettingsMap) -> u64;
+//!     /// Gets the key of a setting value from the settings map based on the index
+//!     /// by storing it into the buffer provided. Returns `false` if the buffer is
+//!     /// too small. After this call, no matter whether it was successful or not,
+//!     /// the `buf_len_ptr` will be set to the required buffer size. If `false` is
+//!     /// returned and the `buf_len_ptr` got set to 0, the index is out of bounds.
+//!     /// The key is guaranteed to be valid UTF-8 and is not nul-terminated.
+//!     pub fn settings_map_get_key_by_index(
+//!         map: SettingsMap,
+//!         idx: u64,
+//!         buf_ptr: *mut u8,
+//!         buf_len_ptr: *mut usize,
+//!     ) -> bool;
+//!     /// Gets a copy of the setting value from the settings map based on the
+//!     /// index. Returns `None` if the index is out of bounds. Any changes to it
+//!     /// are only perceived if it's stored back. You own the setting value and
+//!     /// are responsible for freeing it.
+//!     pub fn settings_map_get_value_by_index(map: SettingsMap, idx: u64) -> Option<SettingValue>;
+//!
+//!     /// Creates a new settings list. You own the settings list and are
+//!     /// responsible for freeing it.
+//!     pub fn settings_list_new() -> SettingsList;
+//!     /// Frees a settings list.
+//!     pub fn settings_list_free(list: SettingsList);
+//!     /// Copies a settings list. No changes inside the copy affect the original
+//!     /// settings list. You own the new settings list and are responsible for
+//!     /// freeing it.
+//!     pub fn settings_list_copy(list: SettingsList) -> SettingsList;
+//!     /// Gets the length of a settings list.
+//!     pub fn settings_list_len(list: SettingsList) -> u64;
+//!     /// Gets a copy of the setting value from the settings list based on the
+//!     /// index. Returns `None` if the index is out of bounds. Any changes to it
+//!     /// are only perceived if it's stored back. You own the setting value and
+//!     /// are responsible for freeing it.
+//!     pub fn settings_list_get(list: SettingsList, idx: u64) -> Option<SettingValue>;
+//!     /// Pushes a copy of the setting value to the end of the settings list. You
+//!     /// still retain ownership of the setting value, which means you still need
+//!     /// to free it.
+//!     pub fn settings_list_push(list: SettingsList, value: SettingValue);
+//!     /// Inserts a copy of the setting value into the settings list at the index
+//!     /// given. If the index is out of bounds, the setting value is pushed to the
+//!     /// end of the settings list. You still retain ownership of the setting
+//!     /// value, which means you still need to free it.
+//!     pub fn settings_list_insert(list: SettingsList, idx: u64, value: SettingValue);
 //!
 //!     /// Creates a new setting value from a settings map. The value is a copy of
 //!     /// the settings map. Any changes to the original settings map afterwards
@@ -302,6 +350,12 @@
 //!     /// value and are responsible for freeing it. You also retain ownership of
 //!     /// the settings map, which means you still need to free it.
 //!     pub fn setting_value_new_map(value: SettingsMap) -> SettingValue;
+//!     /// Creates a new setting value from a settings list. The value is a copy of
+//!     /// the settings list. Any changes to the original settings list afterwards
+//!     /// are not going to be perceived by the setting value. You own the setting
+//!     /// value and are responsible for freeing it. You also retain ownership of
+//!     /// the settings list, which means you still need to free it.
+//!     pub fn setting_value_new_list(value: SettingsList) -> SettingValue;
 //!     /// Creates a new boolean setting value. You own the setting value and are
 //!     /// responsible for freeing it.
 //!     pub fn setting_value_new_bool(value: bool) -> SettingValue;
@@ -317,6 +371,10 @@
 //!     pub fn setting_value_new_string(value_ptr: *const u8, value_len: usize) -> SettingValue;
 //!     /// Frees a setting value.
 //!     pub fn setting_value_free(value: SettingValue);
+//!     /// Copies a setting value. No changes inside the copy affect the original
+//!     /// setting value. You own the new setting value and are responsible for
+//!     /// freeing it.
+//!     pub fn setting_value_copy(value: SettingValue) -> SettingValue;
 //!     /// Gets the value of a setting value as a settings map by storing it into
 //!     /// the pointer provided. Returns `false` if the setting value is not a
 //!     /// settings map. No value is stored into the pointer in that case. No
@@ -324,6 +382,13 @@
 //!     /// which means you still need to free it. You own the settings map and are
 //!     /// responsible for freeing it.
 //!     pub fn setting_value_get_map(value: SettingValue, value_ptr: *mut SettingsMap) -> bool;
+//!     /// Gets the value of a setting value as a settings list by storing it into
+//!     /// the pointer provided. Returns `false` if the setting value is not a
+//!     /// settings list. No value is stored into the pointer in that case. No
+//!     /// matter what happens, you still retain ownership of the setting value,
+//!     /// which means you still need to free it. You own the settings list and are
+//!     /// responsible for freeing it.
+//!     pub fn setting_value_get_list(value: SettingValue, value_ptr: *mut SettingsList) -> bool;
 //!     /// Gets the value of a boolean setting value by storing it into the pointer
 //!     /// provided. Returns `false` if the setting value is not a boolean. No
 //!     /// value is stored into the pointer in that case. No matter what happens,
@@ -392,6 +457,6 @@ mod timer;
 
 pub use process::Process;
 pub use runtime::{Config, CreationError, InterruptHandle, Runtime, RuntimeGuard};
-pub use settings::{SettingValue, SettingsMap, UserSetting, UserSettingKind};
+pub use settings::{SettingValue, SettingsList, SettingsMap, UserSetting, UserSettingKind};
 pub use time;
 pub use timer::{Timer, TimerState};

--- a/crates/livesplit-auto-splitting/src/settings.rs
+++ b/crates/livesplit-auto-splitting/src/settings.rs
@@ -43,8 +43,10 @@ pub enum UserSettingKind {
 #[non_exhaustive]
 #[derive(Clone)]
 pub enum SettingValue {
-    /// A map of settings that are stored in the [`SettingsMap`].
+    /// A map of settings that are stored in a [`SettingsMap`].
     Map(SettingsMap),
+    /// A list of settings that are stored in a [`SettingsList`].
+    List(SettingsList),
     /// A boolean value.
     Bool(bool),
     /// A 64-bit signed integer value.
@@ -59,6 +61,7 @@ impl fmt::Debug for SettingValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Map(v) => fmt::Debug::fmt(v, f),
+            Self::List(v) => fmt::Debug::fmt(v, f),
             Self::Bool(v) => fmt::Debug::fmt(v, f),
             Self::I64(v) => fmt::Debug::fmt(v, f),
             Self::F64(v) => fmt::Debug::fmt(v, f),
@@ -77,6 +80,7 @@ pub struct SettingsMap {
 }
 
 impl fmt::Debug for SettingsMap {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.values, f)
     }
@@ -84,6 +88,8 @@ impl fmt::Debug for SettingsMap {
 
 impl SettingsMap {
     /// Creates a new empty settings map.
+    #[must_use]
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
@@ -91,6 +97,7 @@ impl SettingsMap {
     /// Sets a setting to the new value. If the key of the setting doesn't exist
     /// yet it will be stored as a new value. Otherwise the value will be
     /// updated.
+    #[inline]
     pub fn insert(&mut self, key: Arc<str>, value: SettingValue) {
         Arc::make_mut(&mut self.values).insert(key, value);
     }
@@ -98,17 +105,145 @@ impl SettingsMap {
     /// Accesses the value of a setting by its key. While the setting may exist
     /// as part of the user settings, it may not have been stored into the
     /// settings map yet, so it may not exist, despite being registered.
+    #[must_use]
+    #[inline]
     pub fn get(&self, key: &str) -> Option<&SettingValue> {
         self.values.get(key)
     }
 
+    /// Accesses the value of a setting by its index. The index is the position
+    /// of the setting in the list of all settings. This may be useful for
+    /// iterating over all settings. Prefer using [`iter`](Self::iter) in most
+    /// situations though.
+    #[must_use]
+    #[inline]
+    pub fn get_by_index(&self, index: usize) -> Option<(&str, &SettingValue)> {
+        self.values.get_index(index).map(|(k, v)| (k.as_ref(), v))
+    }
+
     /// Iterates over all the setting keys and their values in the map.
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = (&str, &SettingValue)> {
         self.values.iter().map(|(k, v)| (k.as_ref(), v))
     }
 
+    /// Returns the number of settings that are stored in the map.
+    #[must_use]
     #[inline]
-    pub(super) fn is_unchanged(&self, other: &Self) -> bool {
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns [`true`] if the map doesn't contain any settings.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Returns [`true`] if the identity of the map is the same as the identity
+    /// of the other map. Maps use the copy-on-write principle. This means that
+    /// cloning a map is cheap because it references all the same data as the
+    /// original until one of the variables is changed. With this function you
+    /// can check if two variables internally share the same data and are
+    /// therefore identical. This is useful to determine if the map has changed
+    /// since the last time it was checked. You may use this as part of a
+    /// compare-and-swap loop.
+    #[must_use]
+    #[inline]
+    pub fn is_unchanged(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.values, &other.values)
+    }
+}
+
+/// A list of settings that may be used as a [`SettingValue`] as part of a
+/// [`SettingsMap`]. It logically resembles a [`Vec`] of [`SettingValue`] and
+/// therefore provides similar functionality.
+#[derive(Clone, Default)]
+pub struct SettingsList {
+    list: Arc<Vec<SettingValue>>,
+}
+
+impl fmt::Debug for SettingsList {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.list, f)
+    }
+}
+
+impl SettingsList {
+    /// Creates a new empty settings list.
+    #[must_use]
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of settings that are stored in the list.
+    #[must_use]
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    /// Returns [`true`] if the list doesn't contain any settings.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    /// Accesses the value of a setting by its index. The index is the position
+    /// of the setting in the list of all settings. This may be useful for
+    /// iterating over all settings. Prefer using [`iter`](Self::iter) in most
+    /// situations though.
+    #[must_use]
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&SettingValue> {
+        self.list.get(index)
+    }
+
+    /// Pushes a setting value to the end of the list.
+    #[inline]
+    pub fn push(&mut self, value: SettingValue) {
+        Arc::make_mut(&mut self.list).push(value);
+    }
+
+    /// Inserts a setting value at the given index. If the index is larger than
+    /// the length of the list, the value will be appended to the end of the
+    /// list.
+    #[inline]
+    pub fn insert(&mut self, index: usize, value: SettingValue) {
+        let list = Arc::make_mut(&mut self.list);
+        list.insert(index.min(list.len()), value);
+    }
+
+    /// Removes the setting value at the given index and returns it. If the
+    /// index is larger than the length of the list, [`None`] will be returned.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Option<SettingValue> {
+        let list = Arc::make_mut(&mut self.list);
+        if index >= list.len() {
+            return None;
+        }
+        Some(list.remove(index))
+    }
+
+    /// Iterates over all the setting values in the list.
+    #[inline]
+    pub fn iter(&self) -> std::slice::Iter<'_, SettingValue> {
+        self.list.iter()
+    }
+
+    /// Returns [`true`] if the identity of the list is the same as the identity
+    /// of the other list. Lists use the copy-on-write principle. This means
+    /// that cloning a list is cheap because it references all the same data as
+    /// the original until one of the variables is changed. With this function
+    /// you can check if two variables internally share the same data and are
+    /// therefore identical. This is useful to determine if the list has changed
+    /// since the last time it was checked. You may use this as part of a
+    /// compare-and-swap loop.
+    pub fn is_unchanged(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.list, &other.list)
     }
 }


### PR DESCRIPTION
This is a new type that is used to store lists of settings in addition to `SettingsMap`. The difference is that for lists you don't use keys to look up the values, but instead you use indices, or more likely, iteration.