### PR TITLE
Allow the Windows hotkey callback to recurse

### DIFF
--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -267,7 +267,7 @@ const fn parse_scan_code(value: u32) -> Option<KeyCode> {
 }
 
 unsafe extern "system" fn callback_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    STATE.with(|state| {
+    let hook = STATE.with(|state| {
         let mut state = state.borrow_mut();
         let state = state.as_mut().expect("State should be initialized by now");
 
@@ -377,8 +377,10 @@ unsafe extern "system" fn callback_proc(code: i32, wparam: WPARAM, lparam: LPARA
             }
         }
 
-        CallNextHookEx(state.hook, code, wparam, lparam)
-    })
+        state.hook
+    });
+
+    CallNextHookEx(hook, code, wparam, lparam)
 }
 
 #[inline]


### PR DESCRIPTION
This allows the hotkey callback on Windows to recurse. Each callback hook is responsible for calling the next hook. Usually this is some other hook, but it seems like it's also possible that this is our hook. In that case the RefCell previously panicked due to being locked twice. We instead now release the lock before calling the next hook. Having our callback called twice is possibly still an indication of a bug (alternatively we could ignore that second call), but for now this at least ensures that the program doesn't crash.