### PR TITLE
Add Choice Settings to the Auto Splitting Runtime

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -120,10 +120,9 @@ fn with_vec<F, R>(f: F) -> R
 where
     F: FnOnce(&mut Vec<u8>) -> R,
 {
-    OUTPUT_VEC.with(|output| {
-        let mut output = output.borrow_mut();
+    OUTPUT_VEC.with_borrow_mut(|output| {
         output.clear();
-        f(&mut output)
+        f(output)
     })
 }
 
@@ -131,10 +130,9 @@ fn output_vec<F>(f: F) -> *const c_char
 where
     F: FnOnce(&mut Vec<u8>),
 {
-    OUTPUT_VEC.with(|output| {
-        let mut output = output.borrow_mut();
+    OUTPUT_VEC.with_borrow_mut(|output| {
         output.clear();
-        f(&mut output);
+        f(output);
         output.push(0);
         output.as_ptr() as *const c_char
     })
@@ -207,5 +205,5 @@ pub extern "C" fn dealloc(ptr: *mut u8, cap: usize) {
 /// current thread. The length excludes the nul-terminator.
 #[no_mangle]
 pub extern "C" fn get_buf_len() -> usize {
-    OUTPUT_VEC.with(|v| v.borrow().len() - 1)
+    OUTPUT_VEC.with_borrow(|v| v.len() - 1)
 }

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -260,6 +260,34 @@ extern "C" {
         description_len: usize,
         heading_level: u32,
     );
+    /// Adds a new choice setting that the user can modify. This allows the user
+    /// to choose between various options. The key is used to store the setting
+    /// in the settings map and needs to be unique across all types of settings.
+    /// The description is what's shown to the user. The key of the default
+    /// option to show needs to be specified. The pointers need to point to
+    /// valid UTF-8 encoded text with the respective given length.
+    pub fn user_settings_add_choice(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        default_option_key_ptr: *const u8,
+        default_option_key_len: usize,
+    );
+    /// Adds a new option to a choice setting. The key needs to match the key of
+    /// the choice setting that it's supposed to be added to. The option key is
+    /// used as the value to store when the user chooses this option. The
+    /// description is what's shown to the user. The pointers need to point to
+    /// valid UTF-8 encoded text with the respective given length. Returns
+    /// `true` if the option is at this point in time chosen by the user.
+    pub fn user_settings_add_choice_option(
+        key_ptr: *const u8,
+        key_len: usize,
+        option_key_ptr: *const u8,
+        option_key_len: usize,
+        option_description_ptr: *const u8,
+        option_description_len: usize,
+    ) -> bool;
     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
     /// explaining the purpose of a setting to the user. The pointers need to
     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -260,6 +260,34 @@
 //!         description_len: usize,
 //!         heading_level: u32,
 //!     );
+//!     /// Adds a new choice setting that the user can modify. This allows the user
+//!     /// to choose between various options. The key is used to store the setting
+//!     /// in the settings map and needs to be unique across all types of settings.
+//!     /// The description is what's shown to the user. The key of the default
+//!     /// option to show needs to be specified. The pointers need to point to
+//!     /// valid UTF-8 encoded text with the respective given length.
+//!     pub fn user_settings_add_choice(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         default_option_key_ptr: *const u8,
+//!         default_option_key_len: usize,
+//!     );
+//!     /// Adds a new option to a choice setting. The key needs to match the key of
+//!     /// the choice setting that it's supposed to be added to. The option key is
+//!     /// used as the value to store when the user chooses this option. The
+//!     /// description is what's shown to the user. The pointers need to point to
+//!     /// valid UTF-8 encoded text with the respective given length. Returns
+//!     /// `true` if the option is at this point in time chosen by the user.
+//!     pub fn user_settings_add_choice_option(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         option_key_ptr: *const u8,
+//!         option_key_len: usize,
+//!         option_description_ptr: *const u8,
+//!         option_description_len: usize,
+//!     ) -> bool;
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -35,4 +35,24 @@ pub enum WidgetKind {
         /// settings [`Map`](super::Map) yet.
         default_value: bool,
     },
+    /// A choice setting. This could be shown as a dropdown or radio buttons.
+    Choice {
+        /// The default value of the setting, if it's not available in the
+        /// settings [`Map`](super::Map) yet.
+        default_option_key: Arc<str>,
+        /// The available options for the setting.
+        options: Arc<Vec<ChoiceOption>>,
+    },
+}
+
+/// An option for a choice setting.
+#[derive(Clone)]
+pub struct ChoiceOption {
+    /// The unique identifier of the option. This is not meant to be shown to
+    /// the user and is only used to keep track of the option. This key is used
+    /// to store and retrieve the value of the option from the main settings
+    /// [`Map`](super::Map).
+    pub key: Arc<str>,
+    /// The name of the option that is shown to the user.
+    pub description: Arc<str>,
 }

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -267,8 +267,7 @@ const fn parse_scan_code(value: u32) -> Option<KeyCode> {
 }
 
 unsafe extern "system" fn callback_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    let hook = STATE.with(|state| {
-        let mut state = state.borrow_mut();
+    let hook = STATE.with_borrow_mut(|state| {
         let state = state.as_mut().expect("State should be initialized by now");
 
         if code >= 0 {

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -260,6 +260,34 @@
 //!         description_len: usize,
 //!         heading_level: u32,
 //!     );
+//!     /// Adds a new choice setting that the user can modify. This allows the user
+//!     /// to choose between various options. The key is used to store the setting
+//!     /// in the settings map and needs to be unique across all types of settings.
+//!     /// The description is what's shown to the user. The key of the default
+//!     /// option to show needs to be specified. The pointers need to point to
+//!     /// valid UTF-8 encoded text with the respective given length.
+//!     pub fn user_settings_add_choice(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         default_option_key_ptr: *const u8,
+//!         default_option_key_len: usize,
+//!     );
+//!     /// Adds a new option to a choice setting. The key needs to match the key of
+//!     /// the choice setting that it's supposed to be added to. The option key is
+//!     /// used as the value to store when the user chooses this option. The
+//!     /// description is what's shown to the user. The pointers need to point to
+//!     /// valid UTF-8 encoded text with the respective given length. Returns
+//!     /// `true` if the option is at this point in time chosen by the user.
+//!     pub fn user_settings_add_choice_option(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         option_key_ptr: *const u8,
+//!         option_key_len: usize,
+//!         option_description_ptr: *const u8,
+//!         option_description_len: usize,
+//!     ) -> bool;
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.
@@ -882,11 +910,16 @@ async fn run(
                         } else {
                             let widget_value =
                                 match runtime.settings_widgets().iter().find(|x| *x.key == key) {
-                                    Some(widget) => match widget.kind {
+                                    Some(widget) => match &widget.kind {
                                         settings::WidgetKind::Bool { default_value } => {
-                                            Some(settings::Value::Bool(default_value))
+                                            Some(settings::Value::Bool(*default_value))
                                         }
-                                        settings::WidgetKind::Title { heading_level: _ } => None,
+                                        settings::WidgetKind::Title { .. } => None,
+                                        settings::WidgetKind::Choice {
+                                            default_option_key, ..
+                                        } => Some(settings::Value::String(
+                                            default_option_key.clone(),
+                                        )),
                                     },
                                     None => None,
                                 };

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -106,7 +106,7 @@ fn font_fallback() {
     let build_number: u64 = system.kernel_version().unwrap().parse().unwrap();
     let expected_hash = if build_number >= 22000 {
         // Windows 11
-        "d16b447322881767"
+        "04fd5c64e5ca85f5"
     } else {
         // Windows 10
         "f4bffc6bc6fab953"


### PR DESCRIPTION
This allows auto splitters to define settings widgets where the user can choose between a set of options. These settings widgets could then be visualized as for example dropdowns or radio buttons. Each option has a string based key that is stored in the settings map as the value of the setting when it is chosen.