### PR TITLE
Add timer_current_split_index

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -99,6 +99,13 @@ impl MemoryRangeFlags {
 unsafe extern "C" {
     /// Gets the state that the timer currently is in.
     pub safe fn timer_get_state() -> TimerState;
+    /// Accesses the index of the split the attempt is currently on.
+    /// If there's no attempt in progress, `-1` is returned instead.
+    /// This returns an index that is equal to the amount of segments
+    /// when the attempt is finished, but has not been reset.
+    /// So you need to be careful when using this value for indexing.
+    /// Same index does not imply same split on undo and then split.
+    pub safe fn timer_current_split_index() -> i32;
 
     /// Starts the timer.
     pub safe fn timer_start();

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -99,6 +99,13 @@
 //! unsafe extern "C" {
 //!     /// Gets the state that the timer currently is in.
 //!     pub safe fn timer_get_state() -> TimerState;
+//!     /// Accesses the index of the split the attempt is currently on.
+//!     /// If there's no attempt in progress, `-1` is returned instead.
+//!     /// This returns an index that is equal to the amount of segments
+//!     /// when the attempt is finished, but has not been reset.
+//!     /// So you need to be careful when using this value for indexing.
+//!     /// Same index does not imply same split on undo and then split.
+//!     pub safe fn timer_current_split_index() -> i32;
 //!
 //!     /// Starts the timer.
 //!     pub safe fn timer_start();

--- a/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
@@ -14,6 +14,19 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "timer_get_state",
         })?
+        .func_wrap("env", "timer_current_split_index", {
+            |caller: Caller<'_, Context<T>>| {
+                caller
+                    .data()
+                    .timer
+                    .current_split_index()
+                    .map_or(-1, |i| i as i32)
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "timer_current_split_index",
+        })?
         .func_wrap(
             "env",
             "timer_start",

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -35,6 +35,13 @@ pub enum LogLevel {
 pub trait Timer: Send {
     /// Returns the current state of the timer.
     fn state(&self) -> TimerState;
+    /// Accesses the index of the split the attempt is currently on.
+    /// If there's no attempt in progress, `None` is returned instead.
+    /// This returns an index that is equal to the amount of segments
+    /// when the attempt is finished, but has not been reset.
+    /// So you need to be careful when using this value for indexing.
+    /// Same index does not imply same split on undo and then split.
+    fn current_split_index(&self) -> Option<usize>;
     /// Starts the timer.
     fn start(&mut self);
     /// Splits the current segment.

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -14,6 +14,9 @@ impl Timer for DummyTimer {
     fn state(&self) -> TimerState {
         TimerState::NotRunning
     }
+    fn current_split_index(&self) -> Option<usize> {
+        None
+    }
     fn start(&mut self) {}
     fn split(&mut self) {}
     fn skip_split(&mut self) {}

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -99,6 +99,13 @@
 //! unsafe extern "C" {
 //!     /// Gets the state that the timer currently is in.
 //!     pub safe fn timer_get_state() -> TimerState;
+//!     /// Accesses the index of the split the attempt is currently on.
+//!     /// If there's no attempt in progress, `-1` is returned instead.
+//!     /// This returns an index that is equal to the amount of segments
+//!     /// when the attempt is finished, but has not been reset.
+//!     /// So you need to be careful when using this value for indexing.
+//!     /// Same index does not imply same split on undo and then split.
+//!     pub safe fn timer_current_split_index() -> i32;
 //!
 //!     /// Starts the timer.
 //!     pub safe fn timer_start();
@@ -785,6 +792,10 @@ impl<E: event::CommandSink + TimerQuery + Send> AutoSplitTimer for Timer<E> {
             TimerPhase::Paused => TimerState::Paused,
             TimerPhase::Ended => TimerState::Ended,
         }
+    }
+
+    fn current_split_index(&self) -> Option<usize> {
+        self.0.get_timer().current_split_index()
     }
 
     fn start(&mut self) {


### PR DESCRIPTION
This would be the quickest way to allow auto-splitters to have something similar to settings per split https://github.com/LiveSplit/livesplit-core/issues/795: where a List Widget can allow the user to choose list values in the same order as their splits, and the split index allows the auto-splitter to know which index to use from that List.

See also:
- `asr` companion branch: https://github.com/AlexKnauth/asr/tree/split-index
- `LiveSplit.AutoSplittingRuntime` companion branch: https://github.com/AlexKnauth/LiveSplit.AutoSplittingRuntime/tree/split-index