### PR TITLE
Add FileSelection Widget

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -288,6 +288,19 @@ extern "C" {
         option_description_ptr: *const u8,
         option_description_len: usize,
     ) -> bool;
+    /// Adds a new file selection setting that the user can modify.
+    /// This allows the user to select a file path to be stored at the key.
+    /// The filter can include `*` wildcards, for example `"*.txt"`.
+    /// The pointers need to point to valid UTF-8 encoded text with the
+    /// respective given length.
+    pub fn user_settings_add_file_selection(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        filter_ptr: *const u8,
+        filter_len: usize,
+    );
     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
     /// explaining the purpose of a setting to the user. The pointers need to
     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -290,7 +290,8 @@ extern "C" {
     ) -> bool;
     /// Adds a new file selection setting that the user can modify.
     /// This allows the user to select a file path to be stored at the key.
-    /// The filter can include `*` wildcards, for example `"*.txt"`.
+    /// The filter can include `*` wildcards, for example `"*.txt"`,
+    /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
     /// The pointers need to point to valid UTF-8 encoded text with the
     /// respective given length.
     pub fn user_settings_add_file_selection(

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -288,19 +288,57 @@ extern "C" {
         option_description_ptr: *const u8,
         option_description_len: usize,
     ) -> bool;
-    /// Adds a new file selection setting that the user can modify.
-    /// This allows the user to select a file path to be stored at the key.
-    /// The filter can include `*` wildcards, for example `"*.txt"`,
-    /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
-    /// The pointers need to point to valid UTF-8 encoded text with the
-    /// respective given length.
-    pub fn user_settings_add_file_selection(
+    /// Adds a new file select setting that the user can modify. This allows the
+    /// user to choose a file from the file system. The key is used to store the
+    /// path of the file in the settings map and needs to be unique across all
+    /// types of settings. The description is what's shown to the user. The
+    /// pointers need to point to valid UTF-8 encoded text with the respective
+    /// given length. The path is a path that is accessible through the WASI
+    /// file system, so a Windows path of `C:\foo\bar.exe` would be stored as
+    /// `/mnt/c/foo/bar.exe`.
+    pub fn user_settings_add_file_select(
         key_ptr: *const u8,
         key_len: usize,
         description_ptr: *const u8,
         description_len: usize,
-        filter_ptr: *const u8,
-        filter_len: usize,
+    );
+    /// Adds a filter to a file select setting. The key needs to match the key
+    /// of the file select setting that it's supposed to be added to. The
+    /// description is what's shown to the user for the specific filter. The
+    /// description is optional. You may provide a null pointer if you don't
+    /// want to specify a description. The pattern is a [glob
+    /// pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that is used
+    /// to filter the files. The pattern generally only supports `*` wildcards,
+    /// not `?` or brackets. This may however differ between frontends.
+    /// Additionally `;` can't be used in Windows's native file dialog if it's
+    /// part of the pattern. Multiple patterns may be specified by separating
+    /// them with ASCII space characters. There are operating systems where glob
+    /// patterns are not supported. A best effort lookup of the fitting MIME
+    /// type may be used by a frontend on those operating systems instead. The
+    /// pointers need to point to valid UTF-8 encoded text with the respective
+    /// given length.
+    pub fn user_settings_add_file_select_name_filter(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        pattern_ptr: *const u8,
+        pattern_len: usize,
+    );
+    /// Adds a filter to a file select setting. The key needs to match the key
+    /// of the file select setting that it's supposed to be added to. The MIME
+    /// type is what's used to filter the files. Most operating systems do not
+    /// support MIME types, but the frontends are encouraged to look up the file
+    /// extensions that are associated with the MIME type and use those as a
+    /// filter in those cases. You may also use wildcards as part of the MIME
+    /// types such as `image/*`. The support likely also varies between
+    /// frontends however. The pointers need to point to valid UTF-8 encoded
+    /// text with the respective given length.
+    pub fn user_settings_add_file_select_mime_filter(
+        key_ptr: *const u8,
+        key_len: usize,
+        mime_type_ptr: *const u8,
+        mime_type_len: usize,
     );
     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
     /// explaining the purpose of a setting to the user. The pointers need to

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -288,19 +288,57 @@
 //!         option_description_ptr: *const u8,
 //!         option_description_len: usize,
 //!     ) -> bool;
-//!     /// Adds a new file selection setting that the user can modify.
-//!     /// This allows the user to select a file path to be stored at the key.
-//!     /// The filter can include `*` wildcards, for example `"*.txt"`,
-//!     /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
-//!     /// The pointers need to point to valid UTF-8 encoded text with the
-//!     /// respective given length.
-//!     pub fn user_settings_add_file_selection(
+//!     /// Adds a new file select setting that the user can modify. This allows the
+//!     /// user to choose a file from the file system. The key is used to store the
+//!     /// path of the file in the settings map and needs to be unique across all
+//!     /// types of settings. The description is what's shown to the user. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length. The path is a path that is accessible through the WASI
+//!     /// file system, so a Windows path of `C:\foo\bar.exe` would be stored as
+//!     /// `/mnt/c/foo/bar.exe`.
+//!     pub fn user_settings_add_file_select(
 //!         key_ptr: *const u8,
 //!         key_len: usize,
 //!         description_ptr: *const u8,
 //!         description_len: usize,
-//!         filter_ptr: *const u8,
-//!         filter_len: usize,
+//!     );
+//!     /// Adds a filter to a file select setting. The key needs to match the key
+//!     /// of the file select setting that it's supposed to be added to. The
+//!     /// description is what's shown to the user for the specific filter. The
+//!     /// description is optional. You may provide a null pointer if you don't
+//!     /// want to specify a description. The pattern is a [glob
+//!     /// pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that is used
+//!     /// to filter the files. The pattern generally only supports `*` wildcards,
+//!     /// not `?` or brackets. This may however differ between frontends.
+//!     /// Additionally `;` can't be used in Windows's native file dialog if it's
+//!     /// part of the pattern. Multiple patterns may be specified by separating
+//!     /// them with ASCII space characters. There are operating systems where glob
+//!     /// patterns are not supported. A best effort lookup of the fitting MIME
+//!     /// type may be used by a frontend on those operating systems instead. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length.
+//!     pub fn user_settings_add_file_select_name_filter(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         pattern_ptr: *const u8,
+//!         pattern_len: usize,
+//!     );
+//!     /// Adds a filter to a file select setting. The key needs to match the key
+//!     /// of the file select setting that it's supposed to be added to. The MIME
+//!     /// type is what's used to filter the files. Most operating systems do not
+//!     /// support MIME types, but the frontends are encouraged to look up the file
+//!     /// extensions that are associated with the MIME type and use those as a
+//!     /// filter in those cases. You may also use wildcards as part of the MIME
+//!     /// types such as `image/*`. The support likely also varies between
+//!     /// frontends however. The pointers need to point to valid UTF-8 encoded
+//!     /// text with the respective given length.
+//!     pub fn user_settings_add_file_select_mime_filter(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         mime_type_ptr: *const u8,
+//!         mime_type_len: usize,
 //!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -516,6 +516,7 @@ mod process;
 mod runtime;
 pub mod settings;
 mod timer;
+pub mod wasi_path;
 
 pub use process::Process;
 pub use runtime::{

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -290,7 +290,8 @@
 //!     ) -> bool;
 //!     /// Adds a new file selection setting that the user can modify.
 //!     /// This allows the user to select a file path to be stored at the key.
-//!     /// The filter can include `*` wildcards, for example `"*.txt"`.
+//!     /// The filter can include `*` wildcards, for example `"*.txt"`,
+//!     /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
 //!     /// The pointers need to point to valid UTF-8 encoded text with the
 //!     /// respective given length.
 //!     pub fn user_settings_add_file_selection(

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -288,6 +288,19 @@
 //!         option_description_ptr: *const u8,
 //!         option_description_len: usize,
 //!     ) -> bool;
+//!     /// Adds a new file selection setting that the user can modify.
+//!     /// This allows the user to select a file path to be stored at the key.
+//!     /// The filter can include `*` wildcards, for example `"*.txt"`.
+//!     /// The pointers need to point to valid UTF-8 encoded text with the
+//!     /// respective given length.
+//!     pub fn user_settings_add_file_selection(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         filter_ptr: *const u8,
+//!         filter_len: usize,
+//!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -10,7 +10,7 @@ use read_process_memory::{CopyAddress, ProcessHandle};
 use snafu::{OptionExt, ResultExt, Snafu};
 use sysinfo::{self, PidExt, ProcessExt};
 
-use crate::{runtime::ProcessList, wasi_path::path_to_wasi};
+use crate::{runtime::ProcessList, wasi_path};
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -69,7 +69,7 @@ impl Process {
             .max_by_key(|p| (p.start_time(), p.pid().as_u32()))
             .context(ProcessDoesntExist)?;
 
-        let path = path_to_wasi(process.exe());
+        let path = wasi_path::from_native(process.exe());
 
         let pid = process.pid().as_u32() as Pid;
 
@@ -92,7 +92,7 @@ impl Process {
             .get(sysinfo::Pid::from_u32(pid))
             .context(ProcessDoesntExist)?;
 
-        let path = path_to_wasi(process.exe());
+        let path = wasi_path::from_native(process.exe());
 
         let pid_out = pid as Pid;
 
@@ -154,7 +154,7 @@ impl Process {
             .iter()
             .find(|m| m.filename().is_some_and(|f| f.ends_with(module)))
             .context(ModuleDoesntExist)
-            .map(|m| path_to_wasi(m.filename().unwrap()).unwrap_or_default())
+            .map(|m| wasi_path::from_native(m.filename().unwrap()).unwrap_or_default())
     }
 
     pub(super) fn read_mem(&self, address: Address, buf: &mut [u8]) -> io::Result<()> {

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -124,6 +124,34 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "user_settings_add_choice_option",
         })?
+        .func_wrap("env", "user_settings_add_file_selection", {
+            |mut caller: Caller<'_, Context<T>>,
+             key_ptr: u32,
+             key_len: u32,
+             description_ptr: u32,
+             description_len: u32,
+             filter_ptr: u32,
+             filter_len: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = get_str(memory, key_ptr, key_len)?.into();
+                let description = get_str(memory, description_ptr, description_len)?.into();
+                let filter =
+                    get_str(memory, filter_ptr, filter_len)?.into();
+                Arc::make_mut(&mut context.settings_widgets).push(settings::Widget {
+                    key,
+                    description,
+                    tooltip: None,
+                    kind: settings::WidgetKind::FileSelection {
+                        filter,
+                    },
+                });
+                Ok(())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_add_file_selection",
+        })?
         .func_wrap("env", "user_settings_set_tooltip", {
             |mut caller: Caller<'_, Context<T>>,
              key_ptr: u32,

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -124,30 +124,87 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "user_settings_add_choice_option",
         })?
-        .func_wrap("env", "user_settings_add_file_selection", {
+        .func_wrap("env", "user_settings_add_file_select", {
             |mut caller: Caller<'_, Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
-             description_len: u32,
-             filter_ptr: u32,
-             filter_len: u32| {
+             description_len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
                 let key = get_str(memory, key_ptr, key_len)?.into();
                 let description = get_str(memory, description_ptr, description_len)?.into();
-                let filter = get_str(memory, filter_ptr, filter_len)?.into();
                 Arc::make_mut(&mut context.settings_widgets).push(settings::Widget {
                     key,
                     description,
                     tooltip: None,
-                    kind: settings::WidgetKind::FileSelection { filter },
+                    kind: settings::WidgetKind::FileSelect {
+                        filters: Arc::new(Vec::new()),
+                    },
                 });
                 Ok(())
             }
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
-            name: "user_settings_add_file_selection",
+            name: "user_settings_add_file_select",
+        })?
+        .func_wrap("env", "user_settings_add_file_select_name_filter", {
+            |mut caller: Caller<'_, Context<T>>,
+             key_ptr: u32,
+             key_len: u32,
+             description_ptr: u32,
+             description_len: u32,
+             pattern_ptr: u32,
+             pattern_len: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = get_str(memory, key_ptr, key_len)?.into();
+                let description = if description_ptr != 0 {
+                    Some(get_str(memory, description_ptr, description_len)?.into())
+                } else {
+                    None
+                };
+                let pattern = get_str(memory, pattern_ptr, pattern_len)?.into();
+                let setting = Arc::make_mut(&mut context.settings_widgets)
+                    .iter_mut()
+                    .find(|s| s.key == key)
+                    .context("There is no setting with the provided key.")?;
+                let settings::WidgetKind::FileSelect { filters } = &mut setting.kind else {
+                    bail!("The setting is not a file select.");
+                };
+                Arc::make_mut(filters).push(settings::FileFilter::Name {
+                    description,
+                    pattern,
+                });
+                Ok(())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_add_file_select_name_filter",
+        })?
+        .func_wrap("env", "user_settings_add_file_select_mime_filter", {
+            |mut caller: Caller<'_, Context<T>>,
+             key_ptr: u32,
+             key_len: u32,
+             mime_ptr: u32,
+             mime_len: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = get_str(memory, key_ptr, key_len)?.into();
+                let mime = get_str(memory, mime_ptr, mime_len)?.into();
+                let setting = Arc::make_mut(&mut context.settings_widgets)
+                    .iter_mut()
+                    .find(|s| s.key == key)
+                    .context("There is no setting with the provided key.")?;
+                let settings::WidgetKind::FileSelect { filters } = &mut setting.kind else {
+                    bail!("The setting is not a file select.");
+                };
+                Arc::make_mut(filters).push(settings::FileFilter::MimeType(mime));
+                Ok(())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_add_file_select_mime_filter",
         })?
         .func_wrap("env", "user_settings_set_tooltip", {
             |mut caller: Caller<'_, Context<T>>,

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -135,15 +135,12 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let (memory, context) = memory_and_context(&mut caller);
                 let key = get_str(memory, key_ptr, key_len)?.into();
                 let description = get_str(memory, description_ptr, description_len)?.into();
-                let filter =
-                    get_str(memory, filter_ptr, filter_len)?.into();
+                let filter = get_str(memory, filter_ptr, filter_len)?.into();
                 Arc::make_mut(&mut context.settings_widgets).push(settings::Widget {
                     key,
                     description,
                     tooltip: None,
-                    kind: settings::WidgetKind::FileSelection {
-                        filter,
-                    },
+                    kind: settings::WidgetKind::FileSelection { filter },
                 });
                 Ok(())
             }

--- a/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
@@ -10,13 +10,13 @@ use wasi_common::{
 };
 use wasmtime_wasi::{ambient_authority, WasiCtxBuilder};
 
-use crate::process::build_path;
+use crate::wasi_path::path_to_wasi;
 
 pub fn build(script_path: Option<&Path>) -> WasiCtx {
     let mut wasi = WasiCtxBuilder::new().build();
 
     if let Some(script_path) = script_path {
-        if let Some(path) = build_path(script_path) {
+        if let Some(path) = path_to_wasi(script_path) {
             let _ = wasi.push_env("SCRIPT_PATH", &path);
         }
     }

--- a/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
@@ -10,13 +10,13 @@ use wasi_common::{
 };
 use wasmtime_wasi::{ambient_authority, WasiCtxBuilder};
 
-use crate::wasi_path::path_to_wasi;
+use crate::wasi_path;
 
 pub fn build(script_path: Option<&Path>) -> WasiCtx {
     let mut wasi = WasiCtxBuilder::new().build();
 
     if let Some(script_path) = script_path {
-        if let Some(path) = path_to_wasi(script_path) {
+        if let Some(path) = wasi_path::from_native(script_path) {
             let _ = wasi.push_env("SCRIPT_PATH", &path);
         }
     }

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -44,12 +44,41 @@ pub enum WidgetKind {
         options: Arc<Vec<ChoiceOption>>,
     },
     /// A file selection. This could be a button that opens a File Dialog.
-    FileSelection {
-        /// A filter on which files are selectable.
-        /// Can include `*` wildcards, for example `"*.txt"`,
-        /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
-        filter: Arc<str>,
+    FileSelect {
+        /// The filters that are used to filter the files that can be selected.
+        filters: Arc<Vec<FileFilter>>,
     },
+}
+
+/// A filter for a file selection setting.
+#[derive(Clone)]
+pub enum FileFilter {
+    /// A filter that matches on the name of the file.
+    Name {
+        /// The description is what's shown to the user for the specific filter.
+        description: Option<Arc<str>>,
+        /// The pattern is a [glob
+        /// pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that is
+        /// used to filter the files. The pattern generally only supports `*`
+        /// wildcards, not `?` or brackets. This may however differ between
+        /// frontends. Additionally `;` can't be used in Windows's native file
+        /// dialog if it's part of the pattern. Multiple patterns may be
+        /// specified by separating them with ASCII space characters. There are
+        /// operating systems where glob patterns are not supported. A best
+        /// effort lookup of the fitting MIME type may be used by a frontend on
+        /// those operating systems instead. The
+        /// [`mime_guess`](https://docs.rs/mime_guess) crate offers such a
+        /// lookup.
+        pattern: Arc<str>,
+    },
+    /// A filter that matches on the MIME type of the file. Most operating
+    /// systems do not support MIME types, but the frontends are encouraged to
+    /// look up the file extensions that are associated with the MIME type and
+    /// use those as a filter in those cases. You may also use wildcards as part
+    /// of the MIME types such as `image/*`. The support likely also varies
+    /// between frontends however. The
+    /// [`mime_guess`](https://docs.rs/mime_guess) crate offers such a lookup.
+    MimeType(Arc<str>),
 }
 
 /// An option for a choice setting.

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -48,7 +48,7 @@ pub enum WidgetKind {
         /// A filter on which files are selectable,
         /// for example `"*.txt"` for text files.
         filter: Arc<str>,
-    }
+    },
 }
 
 /// An option for a choice setting.

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -45,8 +45,9 @@ pub enum WidgetKind {
     },
     /// A file selection. This could be a button that opens a File Dialog.
     FileSelection {
-        /// A filter on which files are selectable,
-        /// for example `"*.txt"` for text files.
+        /// A filter on which files are selectable.
+        /// Can include `*` wildcards, for example `"*.txt"`,
+        /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
         filter: Arc<str>,
     },
 }

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -43,6 +43,12 @@ pub enum WidgetKind {
         /// The available options for the setting.
         options: Arc<Vec<ChoiceOption>>,
     },
+    /// A file selection. This could be a button that opens a File Dialog.
+    FileSelection {
+        /// A filter on which files are selectable,
+        /// for example `"*.txt"` for text files.
+        filter: Arc<str>,
+    }
 }
 
 /// An option for a choice setting.

--- a/crates/livesplit-auto-splitting/src/wasi_path.rs
+++ b/crates/livesplit-auto-splitting/src/wasi_path.rs
@@ -44,7 +44,7 @@ pub fn wasi_to_path(wasi_path_str: &str) -> Option<PathBuf> {
             (1, Component::Normal(mnt)) if mnt == "mnt" => (),
             (2, Component::Normal(d)) if d.len() == 1 && d.to_ascii_lowercase() == d => {
                 let disk = d.to_string_lossy().to_ascii_uppercase();
-                path.push(format!("{}{}{}", r"\\?\", disk, r":\"));
+                path.push(format!("{}{}", disk, r":\"));
             }
             (2, Component::Normal(c)) if !path.has_root() => {
                 if let Some(root) = [r"/", r"\"]
@@ -72,6 +72,10 @@ mod tests {
     fn test_windows_to_wasi() {
         assert_eq!(
             path_to_wasi(Path::new(r"C:\foo\bar.exe")),
+            Some(r"/mnt/c/foo/bar.exe".into())
+        );
+        assert_eq!(
+            path_to_wasi(Path::new(r"\\?\C:\foo\bar.exe")),
             Some(r"/mnt/c/foo/bar.exe".into())
         );
     }

--- a/crates/livesplit-auto-splitting/src/wasi_path.rs
+++ b/crates/livesplit-auto-splitting/src/wasi_path.rs
@@ -1,0 +1,90 @@
+//! Translating WASI Paths
+
+use std::path;
+use std::path::{Component, Path, PathBuf};
+
+/// Translates `original_path` into a path that
+/// is accessible through the WASI file system,
+/// so a Windows path of `C:\foo\bar.exe` would
+/// be returned as `/mnt/c/foo/bar.exe`.
+pub fn path_to_wasi(original_path: &Path) -> Option<Box<str>> {
+    let mut path = String::from("/mnt");
+    for component in original_path.components() {
+        if !path.ends_with('/') {
+            path.push('/');
+        }
+        match component {
+            path::Component::Prefix(prefix) => match prefix.kind() {
+                path::Prefix::VerbatimDisk(disk) | path::Prefix::Disk(disk) => {
+                    path.push(disk.to_ascii_lowercase() as char)
+                }
+                _ => return None,
+            },
+            path::Component::Normal(c) => {
+                path.push_str(c.to_str()?);
+            }
+            path::Component::RootDir => {}
+            path::Component::CurDir => path.push('.'),
+            path::Component::ParentDir => path.push_str(".."),
+        }
+    }
+    Some(path.into_boxed_str())
+}
+
+/// Translates from a path accessible through the WASI
+/// file system to a path accessible outside that,
+/// so a WASI path of `/mnt/c/foo/bar.exe` would
+/// be translated on Windows to `C:\foo\bar.exe`.
+pub fn wasi_to_path(wasi_path_str: &str) -> Option<PathBuf> {
+    let wasi_path = PathBuf::from(wasi_path_str);
+    let mut path = PathBuf::new();
+    for (i, wasi_component) in wasi_path.components().enumerate() {
+        match (i, wasi_component) {
+            (0, Component::RootDir) => (),
+            (1, Component::Normal(mnt)) if mnt == "mnt" => (),
+            (2, Component::Normal(d)) if d.len() == 1 && d.to_ascii_lowercase() == d => {
+                let disk = d.to_string_lossy().to_ascii_uppercase();
+                path.push(format!("{}{}{}", r"\\?\", disk, r":\"));
+            },
+            (2, Component::Normal(c)) if !path.has_root() => {
+                if let Some(root) = [r"/", r"\"].into_iter().map(PathBuf::from).find(|p| p.has_root()) {
+                    path.push(root);
+                }
+                path.push(c);
+            },
+            (i, Component::Normal(c)) if 2 <= i => path.push(c),
+            _ => return None,
+        }
+    }
+    Some(path)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_to_wasi() {
+        assert_eq!(path_to_wasi(Path::new(r"C:\foo\bar.exe")), Some(r"/mnt/c/foo/bar.exe".into()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_wasi_to_windows() {
+        assert_eq!(wasi_to_path(r"/mnt/c/foo/bar.exe"), Some(r"C:\foo\bar.exe".into()));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_non_windows_to_wasi() {
+        assert_eq!(path_to_wasi(Path::new(r"/foo/bar.exe")), Some(r"/mnt/foo/bar.exe".into()));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_wasi_to_non_windows() {
+        assert_eq!(wasi_to_path(r"/mnt/foo/bar.exe"), Some(r"/foo/bar.exe".into()));
+    }
+}

--- a/crates/livesplit-auto-splitting/src/wasi_path.rs
+++ b/crates/livesplit-auto-splitting/src/wasi_path.rs
@@ -45,20 +45,23 @@ pub fn wasi_to_path(wasi_path_str: &str) -> Option<PathBuf> {
             (2, Component::Normal(d)) if d.len() == 1 && d.to_ascii_lowercase() == d => {
                 let disk = d.to_string_lossy().to_ascii_uppercase();
                 path.push(format!("{}{}{}", r"\\?\", disk, r":\"));
-            },
+            }
             (2, Component::Normal(c)) if !path.has_root() => {
-                if let Some(root) = [r"/", r"\"].into_iter().map(PathBuf::from).find(|p| p.has_root()) {
+                if let Some(root) = [r"/", r"\"]
+                    .into_iter()
+                    .map(PathBuf::from)
+                    .find(|p| p.has_root())
+                {
                     path.push(root);
                 }
                 path.push(c);
-            },
+            }
             (i, Component::Normal(c)) if 2 <= i => path.push(c),
             _ => return None,
         }
     }
     Some(path)
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -67,24 +70,36 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn test_windows_to_wasi() {
-        assert_eq!(path_to_wasi(Path::new(r"C:\foo\bar.exe")), Some(r"/mnt/c/foo/bar.exe".into()));
+        assert_eq!(
+            path_to_wasi(Path::new(r"C:\foo\bar.exe")),
+            Some(r"/mnt/c/foo/bar.exe".into())
+        );
     }
 
     #[cfg(windows)]
     #[test]
     fn test_wasi_to_windows() {
-        assert_eq!(wasi_to_path(r"/mnt/c/foo/bar.exe"), Some(r"C:\foo\bar.exe".into()));
+        assert_eq!(
+            wasi_to_path(r"/mnt/c/foo/bar.exe"),
+            Some(r"C:\foo\bar.exe".into())
+        );
     }
 
     #[cfg(not(windows))]
     #[test]
     fn test_non_windows_to_wasi() {
-        assert_eq!(path_to_wasi(Path::new(r"/foo/bar.exe")), Some(r"/mnt/foo/bar.exe".into()));
+        assert_eq!(
+            path_to_wasi(Path::new(r"/foo/bar.exe")),
+            Some(r"/mnt/foo/bar.exe".into())
+        );
     }
 
     #[cfg(not(windows))]
     #[test]
     fn test_wasi_to_non_windows() {
-        assert_eq!(wasi_to_path(r"/mnt/foo/bar.exe"), Some(r"/foo/bar.exe".into()));
+        assert_eq!(
+            wasi_to_path(r"/mnt/foo/bar.exe"),
+            Some(r"/foo/bar.exe".into())
+        );
     }
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -288,19 +288,57 @@
 //!         option_description_ptr: *const u8,
 //!         option_description_len: usize,
 //!     ) -> bool;
-//!     /// Adds a new file selection setting that the user can modify.
-//!     /// This allows the user to select a file path to be stored at the key.
-//!     /// The filter can include `*` wildcards, for example `"*.txt"`,
-//!     /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
-//!     /// The pointers need to point to valid UTF-8 encoded text with the
-//!     /// respective given length.
-//!     pub fn user_settings_add_file_selection(
+//!     /// Adds a new file select setting that the user can modify. This allows the
+//!     /// user to choose a file from the file system. The key is used to store the
+//!     /// path of the file in the settings map and needs to be unique across all
+//!     /// types of settings. The description is what's shown to the user. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length. The path is a path that is accessible through the WASI
+//!     /// file system, so a Windows path of `C:\foo\bar.exe` would be stored as
+//!     /// `/mnt/c/foo/bar.exe`.
+//!     pub fn user_settings_add_file_select(
 //!         key_ptr: *const u8,
 //!         key_len: usize,
 //!         description_ptr: *const u8,
 //!         description_len: usize,
-//!         filter_ptr: *const u8,
-//!         filter_len: usize,
+//!     );
+//!     /// Adds a filter to a file select setting. The key needs to match the key
+//!     /// of the file select setting that it's supposed to be added to. The
+//!     /// description is what's shown to the user for the specific filter. The
+//!     /// description is optional. You may provide a null pointer if you don't
+//!     /// want to specify a description. The pattern is a [glob
+//!     /// pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that is used
+//!     /// to filter the files. The pattern generally only supports `*` wildcards,
+//!     /// not `?` or brackets. This may however differ between frontends.
+//!     /// Additionally `;` can't be used in Windows's native file dialog if it's
+//!     /// part of the pattern. Multiple patterns may be specified by separating
+//!     /// them with ASCII space characters. There are operating systems where glob
+//!     /// patterns are not supported. A best effort lookup of the fitting MIME
+//!     /// type may be used by a frontend on those operating systems instead. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length.
+//!     pub fn user_settings_add_file_select_name_filter(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         pattern_ptr: *const u8,
+//!         pattern_len: usize,
+//!     );
+//!     /// Adds a filter to a file select setting. The key needs to match the key
+//!     /// of the file select setting that it's supposed to be added to. The MIME
+//!     /// type is what's used to filter the files. Most operating systems do not
+//!     /// support MIME types, but the frontends are encouraged to look up the file
+//!     /// extensions that are associated with the MIME type and use those as a
+//!     /// filter in those cases. You may also use wildcards as part of the MIME
+//!     /// types such as `image/*`. The support likely also varies between
+//!     /// frontends however. The pointers need to point to valid UTF-8 encoded
+//!     /// text with the respective given length.
+//!     pub fn user_settings_add_file_select_mime_filter(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         mime_type_ptr: *const u8,
+//!         mime_type_len: usize,
 //!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -290,7 +290,8 @@
 //!     ) -> bool;
 //!     /// Adds a new file selection setting that the user can modify.
 //!     /// This allows the user to select a file path to be stored at the key.
-//!     /// The filter can include `*` wildcards, for example `"*.txt"`.
+//!     /// The filter can include `*` wildcards, for example `"*.txt"`,
+//!     /// and multiple patterns separated by `;` semicolons, like `"*.txt;*.md"`.
 //!     /// The pointers need to point to valid UTF-8 encoded text with the
 //!     /// respective given length.
 //!     pub fn user_settings_add_file_selection(

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -288,6 +288,19 @@
 //!         option_description_ptr: *const u8,
 //!         option_description_len: usize,
 //!     ) -> bool;
+//!     /// Adds a new file selection setting that the user can modify.
+//!     /// This allows the user to select a file path to be stored at the key.
+//!     /// The filter can include `*` wildcards, for example `"*.txt"`.
+//!     /// The pointers need to point to valid UTF-8 encoded text with the
+//!     /// respective given length.
+//!     pub fn user_settings_add_file_selection(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         filter_ptr: *const u8,
+//!         filter_len: usize,
+//!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.


### PR DESCRIPTION
This adds a `FileSelection` Widget to the Auto Splitting Runtime.

Companion PRs:
 - https://github.com/LiveSplit/asr-debugger/pull/12
 - https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/6
 - https://github.com/LiveSplit/asr/pull/83

The `asr-debugger` and `LiveSplit.AutoSplittingRuntime` companion branches both implement this as a button in the settings Gui that opens a file dialog when pressed. The user can select a file, and the WASI-compatible path to that file gets stored in the settings map.

The `asr` companion branch adds a `FileSelection` type that implements the `Widget` trait such that an auto-splitter can put it in their settings gui like this:
```rust
#[derive(Gui)]
pub struct SettingsGui {
    /// General Settings
    _general_settings: Title,
    /// Select a text file
    #[filter = "*.txt"]
    text_file: FileSelection,
}
```