### PR TITLE
Improve Auto Splitting runtime in `livesplit-core`

### DIFF
--- a/capi/src/auto_splitting_runtime.rs
+++ b/capi/src/auto_splitting_runtime.rs
@@ -18,15 +18,15 @@ pub struct AutoSplittingRuntime;
 #[allow(missing_docs)]
 #[cfg(not(feature = "auto-splitting"))]
 impl AutoSplittingRuntime {
-    pub fn new(_: SharedTimer) -> Self {
+    pub fn new() -> Self {
         Self
     }
 
-    pub fn unload_script_blocking(&self) -> Result<(), ()> {
+    pub fn unload(&self) -> Result<(), ()> {
         Err(())
     }
 
-    pub fn load_script_blocking(&self, _: PathBuf) -> Result<(), ()> {
+    pub fn load(&self, _: PathBuf, _: SharedTimer) -> Result<(), ()> {
         Err(())
     }
 }
@@ -36,32 +36,26 @@ pub type OwnedAutoSplittingRuntime = Box<AutoSplittingRuntime>;
 /// type
 pub type NullableOwnedAutoSplittingRuntime = Option<OwnedAutoSplittingRuntime>;
 
-/// Creates a new Auto Splitting Runtime for a Timer.
+/// Creates a new Auto Splitting Runtime.
 #[no_mangle]
-pub extern "C" fn AutoSplittingRuntime_new(
-    shared_timer: OwnedSharedTimer,
-) -> OwnedAutoSplittingRuntime {
-    Box::new(AutoSplittingRuntime::new(*shared_timer))
+pub extern "C" fn AutoSplittingRuntime_new() -> OwnedAutoSplittingRuntime {
+    Box::new(AutoSplittingRuntime::new())
 }
 
 /// Attempts to load an auto splitter. Returns true if successful.
 #[no_mangle]
-pub unsafe extern "C" fn AutoSplittingRuntime_load_script(
+pub unsafe extern "C" fn AutoSplittingRuntime_load(
     this: &AutoSplittingRuntime,
     path: *const c_char,
+    shared_timer: OwnedSharedTimer,
 ) -> bool {
-    let path = str(path);
-    if !path.is_empty() {
-        this.load_script_blocking(PathBuf::from(path)).is_ok()
-    } else {
-        false
-    }
+    this.load(PathBuf::from(str(path)), *shared_timer).is_ok()
 }
 
 /// Attempts to unload the auto splitter. Returns true if successful.
 #[no_mangle]
-pub extern "C" fn AutoSplittingRuntime_unload_script(this: &AutoSplittingRuntime) -> bool {
-    this.unload_script_blocking().is_ok()
+pub extern "C" fn AutoSplittingRuntime_unload(this: &AutoSplittingRuntime) -> bool {
+    this.unload().is_ok()
 }
 
 /// drop

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }
+arc-swap = "1.6.0"
 async-trait = "0.1.73"
 bytemuck = { version = "1.14.0", features = ["min_const_generics"] }
 indexmap = "2.0.2"

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -505,6 +505,20 @@ pub mod settings;
 mod timer;
 
 pub use process::Process;
-pub use runtime::{Config, CreationError, InterruptHandle, Runtime, RuntimeGuard};
+pub use runtime::{
+    AutoSplitter, CompiledAutoSplitter, Config, CreationError, ExecutionGuard, InterruptHandle,
+    Runtime,
+};
 pub use time;
 pub use timer::{Timer, TimerState};
+
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Config>();
+    assert_send_sync::<Process>();
+    assert_send_sync::<Runtime>();
+    assert_send_sync::<CompiledAutoSplitter>();
+    const fn with_timer<T: Send + Sync + Timer>() {
+        assert_send_sync::<AutoSplitter<T>>();
+    }
+};

--- a/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
@@ -1,6 +1,6 @@
 use std::{
     env::consts::{ARCH, OS},
-    time::Duration,
+    sync::atomic,
 };
 
 use anyhow::{ensure, Result};
@@ -28,8 +28,11 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 const MAX_DURATION: f64 = u64::MAX as f64;
                 ensure!(duration < MAX_DURATION, "The tick rate is too small.");
 
-                *caller.data_mut().shared_data.tick_rate.lock().unwrap() =
-                    Duration::from_secs_f64(duration);
+                caller
+                    .data_mut()
+                    .shared_data
+                    .tick_rate
+                    .store(duration.to_bits(), atomic::Ordering::Relaxed);
 
                 Ok(())
             }

--- a/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
@@ -41,7 +41,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .func_wrap("env", "settings_map_load", {
             |mut caller: Caller<'_, Context<T>>| {
                 let ctx = caller.data_mut();
-                let settings_map = ctx.shared_data.settings_map.lock().unwrap().clone();
+                let settings_map = ctx.shared_data.get_settings_map();
                 ctx.settings_maps.insert(settings_map).data().as_ffi()
             }
         })

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -20,8 +20,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let key = Arc::<str>::from(get_str(memory, key_ptr, key_len)?);
                 let description = get_str(memory, description_ptr, description_len)?.into();
                 let default_value = default_value != 0;
-                let value_in_map = match context.shared_data.settings_map.lock().unwrap().get(&key)
-                {
+                let value_in_map = match context.shared_data.get_settings_map().get(&key) {
                     Some(settings::Value::Bool(v)) => *v,
                     _ => default_value,
                 };

--- a/crates/livesplit-auto-splitting/src/settings/map.rs
+++ b/crates/livesplit-auto-splitting/src/settings/map.rs
@@ -9,8 +9,9 @@ use super::Value;
 /// user settings, but because the user didn't modify them, they are not stored
 /// here yet.
 #[derive(Clone, Default, PartialEq)]
+#[repr(transparent)]
 pub struct Map {
-    values: Arc<IndexMap<Arc<str>, Value>>,
+    pub(crate) values: Arc<IndexMap<Arc<str>, Value>>,
 }
 
 impl fmt::Debug for Map {
@@ -73,20 +74,6 @@ impl Map {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
-    }
-
-    /// Returns [`true`] if the identity of the map is the same as the identity
-    /// of the other map. Maps use the copy-on-write principle. This means that
-    /// cloning a map is cheap because it references all the same data as the
-    /// original until one of the variables is changed. With this function you
-    /// can check if two variables internally share the same data and are
-    /// therefore identical. This is useful to determine if the map has changed
-    /// since the last time it was checked. You may use this as part of a
-    /// compare-and-swap loop.
-    #[must_use]
-    #[inline]
-    pub fn is_unchanged(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.values, &other.values)
     }
 }
 
@@ -164,23 +151,5 @@ mod tests {
         assert!(!map.is_empty());
         map.insert("c".into(), Value::Bool(true));
         assert!(!map.is_empty());
-    }
-
-    #[test]
-    fn test_is_unchanged() {
-        let mut map = Map::new();
-        let mut map2 = map.clone();
-        assert!(map.is_unchanged(&map2));
-        map.insert("a".into(), Value::Bool(true));
-        assert!(!map.is_unchanged(&map2));
-        map2.insert("a".into(), Value::Bool(true));
-        assert!(!map.is_unchanged(&map2));
-        map.insert("b".into(), Value::Bool(false));
-        assert!(!map.is_unchanged(&map2));
-        map2.insert("b".into(), Value::Bool(false));
-        assert!(!map.is_unchanged(&map2));
-        map2 = map.clone();
-        assert!(map.is_unchanged(&map2));
-        assert!(map2.is_unchanged(&map));
     }
 }

--- a/crates/livesplit-auto-splitting/src/settings/value.rs
+++ b/crates/livesplit-auto-splitting/src/settings/value.rs
@@ -20,6 +20,89 @@ pub enum Value {
     String(Arc<str>),
 }
 
+impl Value {
+    /// Accesses the value as boolean, if it is one.
+    pub const fn to_bool(&self) -> Option<bool> {
+        if let Self::Bool(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    /// Accesses the value as 64-bit signed integer, if it is one.
+    pub const fn to_i64(&self) -> Option<i64> {
+        if let Self::I64(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    /// Accesses the value as 64-bit floating point, if it is one.
+    pub const fn to_f64(&self) -> Option<f64> {
+        if let Self::F64(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
+    /// Accesses the value as a map, if it is one.
+    pub const fn as_map(&self) -> Option<&Map> {
+        if let Self::Map(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Accesses the value as a list, if it is one.
+    pub const fn as_list(&self) -> Option<&List> {
+        if let Self::List(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Accesses the value as a string, if it is one.
+    pub const fn as_string(&self) -> Option<&Arc<str>> {
+        if let Self::String(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Converts the value into a map, if it is one.
+    pub fn into_map(self) -> Option<Map> {
+        if let Self::Map(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Converts the value into a list, if it is one.
+    pub fn into_list(self) -> Option<List> {
+        if let Self::List(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Converts the value into a string, if it is one.
+    pub fn into_string(self) -> Option<Arc<str>> {
+        if let Self::String(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
The auto splitting  runtime that lives directly in `livesplit-core` used to have a channel that communicates with the background thread where the auto splitter is getting executed. This channel was also used for accessing and modifying the settings. However the design for the settings has improved a lot to the point where multiple threads can interact with them entirely lock free. This change removes the channel entirely and instead provides the lock free way of interacting with the settings.

Additionally there's a separate change where the auto splitter can now be precompiled and instantiated separately. This allows you to restart an auto splitter without also having to recompile it.