### PR TITLE
Fix debug support for wasmtime 16

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -34,3 +34,8 @@ wasi-common = "16.0.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52.0", features = ["Win32_Storage_FileSystem"] }
+
+[features]
+default = ["enhanced-backtrace"]
+debugger-support = ["wasmtime/debug-builtins"]
+enhanced-backtrace = ["wasmtime/addr2line", "wasmtime/demangle"]

--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -171,24 +171,25 @@ fn single_process() -> ProcessRefreshKind {
 #[non_exhaustive]
 pub struct Config {
     /// This enables debug information for the WebAssembly module. This is
-    /// useful for debugging purposes. This is disabled by default.
+    /// useful for debugging purposes. By default this `true` if the feature
+    /// `debugger-support` is enabled.
     pub debug_info: bool,
     /// This enables optimizations for the WebAssembly module. This is enabled
     /// by default. You may want to disable this when debugging the auto
     /// splitter.
     pub optimize: bool,
     /// This enables backtrace details for the WebAssembly module. If a trap
-    /// occurs more details are printed in the backtrace. This is enabled by
-    /// default.
+    /// occurs more details are printed in the backtrace. By default this `true`
+    /// if the feature `enhanced-backtrace` is enabled.
     pub backtrace_details: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            debug_info: false,
+            debug_info: cfg!(feature = "debugger-support"),
             optimize: true,
-            backtrace_details: true,
+            backtrace_details: cfg!(feature = "enhanced-backtrace"),
         }
     }
 }


### PR DESCRIPTION
Apparently additional features need to be enabled now. We probably don't always want to enable them, so we expose them as features of our own crate.