### PR TITLE
Remove the MIPS targets from the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,6 @@ jobs:
           - Linux thumbv7neon
           - Linux aarch64
           - Linux aarch64 musl
-          - Linux mips musl
-          - Linux mips64 musl
-          - Linux mipsel musl
-          - Linux mips64el musl
           - Linux powerpc
           - Linux powerpc64
           - Linux powerpc64le
@@ -380,38 +376,6 @@ jobs:
           - label: Linux aarch64 musl
             target: aarch64-unknown-linux-musl
             dylib: skip
-
-          - label: Linux mips musl
-            target: mips-unknown-linux-musl
-            auto_splitting: skip
-            dylib: skip
-            # FIXME: The mips targets currently miscompile:
-            # https://github.com/rust-lang/rust/issues/116177
-            tests: skip
-
-          - label: Linux mips64 musl
-            target: mips64-unknown-linux-muslabi64
-            auto_splitting: skip
-            dylib: skip
-            # FIXME: The mips targets currently miscompile:
-            # https://github.com/rust-lang/rust/issues/116177
-            tests: skip
-
-          - label: Linux mipsel musl
-            target: mipsel-unknown-linux-musl
-            auto_splitting: skip
-            dylib: skip
-            # FIXME: The mips targets currently miscompile:
-            # https://github.com/rust-lang/rust/issues/116177
-            tests: skip
-
-          - label: Linux mips64el musl
-            target: mips64el-unknown-linux-muslabi64
-            auto_splitting: skip
-            dylib: skip
-            # FIXME: The mips targets currently miscompile:
-            # https://github.com/rust-lang/rust/issues/116177
-            tests: skip
 
           - label: Linux powerpc
             target: powerpc-unknown-linux-gnu


### PR DESCRIPTION
They are now entirely gone.