### PR TITLE
Allow hotkeys to be consumed

### DIFF
--- a/crates/livesplit-hotkey/src/key_code.rs
+++ b/crates/livesplit-hotkey/src/key_code.rs
@@ -1845,7 +1845,7 @@ impl KeyCode {
     pub fn resolve(self, hook: &Hook) -> Cow<'static, str> {
         let class = self.classify();
         if class == KeyCodeClass::WritingSystem {
-            if let Some(resolved) = hook.try_resolve(self) {
+            if let Some(resolved) = hook.0.try_resolve(self) {
                 let uppercase = if resolved != "ß" {
                     resolved.to_uppercase()
                 } else {

--- a/crates/livesplit-hotkey/src/other/mod.rs
+++ b/crates/livesplit-hotkey/src/other/mod.rs
@@ -1,33 +1,26 @@
-use crate::{Hotkey, KeyCode};
+use crate::{ConsumePreference, Hotkey, KeyCode, Result};
 use alloc::{fmt, string::String};
 
-/// The error type for this crate.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {}
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
 impl fmt::Display for Error {
+    #[inline]
     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
         Ok(())
     }
 }
 
-/// The result type for this crate.
-pub type Result<T> = core::result::Result<T, Error>;
-
-/// A hook allows you to listen to hotkeys.
 pub struct Hook;
 
 impl Hook {
-    /// Creates a new hook.
-    pub fn new() -> Result<Self> {
+    #[inline]
+    pub fn new(_: ConsumePreference) -> Result<Self> {
         Ok(Hook)
     }
 
-    /// Registers a hotkey to listen to.
+    #[inline]
     pub fn register<F>(&self, _: Hotkey, _: F) -> Result<()>
     where
         F: FnMut() + Send + 'static,
@@ -35,12 +28,13 @@ impl Hook {
         Ok(())
     }
 
-    /// Unregisters a previously registered hotkey.
+    #[inline]
     pub fn unregister(&self, _: Hotkey) -> Result<()> {
         Ok(())
     }
 
-    pub(crate) fn try_resolve(&self, _key_code: KeyCode) -> Option<String> {
+    #[inline]
+    pub fn try_resolve(&self, _key_code: KeyCode) -> Option<String> {
         None
     }
 }

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -1,12 +1,12 @@
 use alloc::borrow::Cow;
-use livesplit_hotkey::KeyCode;
+use livesplit_hotkey::{ConsumePreference, KeyCode};
 
 use crate::{
     hotkey::{Hook, Hotkey},
     HotkeyConfig, SharedTimer,
 };
 
-pub use crate::hotkey::{Error, Result};
+pub use crate::hotkey::Result;
 
 // This enum might be better situated in hotkey_config, but the last method should stay in this file
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -105,7 +105,7 @@ impl HotkeySystem {
     pub fn with_config(timer: SharedTimer, config: HotkeyConfig) -> Result<Self> {
         let mut hotkey_system = Self {
             config,
-            hook: Hook::new()?,
+            hook: Hook::with_consume_preference(ConsumePreference::PreferNoConsume)?,
             timer,
             is_active: false,
         };


### PR DESCRIPTION
This adds a new type to `livesplit-hotkey` that allows you to specify what your preference is for the hotkeys. You can now specify that you want the hotkeys to be consumed, which means that the hotkeys will not be forwarded to the application that is in focus. This is currently not implemented for all the platforms, but the basic API for it is here now.