### PR TITLE
pub use livesplit_auto_splitting::wasi_path

### DIFF
--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -544,8 +544,7 @@ use crate::{
     platform::Arc,
     timing::{SharedTimer, TimerPhase},
 };
-pub use livesplit_auto_splitting::settings;
-pub use livesplit_auto_splitting::wasi_path;
+pub use livesplit_auto_splitting::{settings, wasi_path};
 use livesplit_auto_splitting::{
     AutoSplitter, Config, CreationError, InterruptHandle, Timer as AutoSplitTimer, TimerState,
 };

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -545,6 +545,7 @@ use crate::{
     timing::{SharedTimer, TimerPhase},
 };
 pub use livesplit_auto_splitting::settings;
+pub use livesplit_auto_splitting::wasi_path;
 use livesplit_auto_splitting::{
     AutoSplitter, Config, CreationError, InterruptHandle, Timer as AutoSplitTimer, TimerState,
 };


### PR DESCRIPTION
Re-exports `wasi_path` from `livesplit_core::auto_splitting` so that https://github.com/LiveSplit/obs-livesplit-one/pull/47 can use it without adding an additional dependency.