### PR TITLE
Fix Hotkey Modifiers on X11

### DIFF
--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -65,7 +65,7 @@ pub struct Function {
 
 impl Function {
     fn is_static(&self) -> bool {
-        if let Some((name, _)) = self.inputs.get(0) {
+        if let Some((name, _)) = self.inputs.first() {
             name != "this"
         } else {
             true
@@ -277,7 +277,7 @@ fn fns_to_classes(functions: Vec<Function>) -> BTreeMap<String, Class> {
 
         class.comments = function.class_comments.clone();
 
-        match function.inputs.get(0) {
+        match function.inputs.first() {
             Some((name, ty)) if name == "this" => match ty.kind {
                 TypeKind::Value => class.own_fns.push(function),
                 TypeKind::Ref => class.shared_fns.push(function),


### PR DESCRIPTION
Turns out that X11 is very strict about the hotkey modifiers. They need to match exactly, otherwise the hotkey is not recognized. The problem is that there's various "lock" modifiers, such as the caps lock, num lock, and scroll lock, that are always considered for this, but are not really keys that you explicitly press and instead are active or inactive until you toggle them. And they need to match exactly as well. Whoever thought that's a good design should stop doing so immediately.