### PR TITLE
Build on AArch64 based macOS runners in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,16 +408,13 @@ jobs:
           # macOS
           - label: macOS aarch64
             target: aarch64-apple-darwin
-            os: macOS-latest
+            os: macos-14
             cross: skip
-            tests: skip
             install_target: true
-            # FIXME: Switch OS to ARM macOS once GitHub Actions provides that,
-            # use the toolchain instead of the target and run the tests.
 
           - label: macOS x86_64
             target: x86_64-apple-darwin
-            os: macOS-latest
+            os: macos-13
             cross: skip
 
           # iOS


### PR DESCRIPTION
This allows us to run the tests for those targets as well now.