### PR TITLE
Implement neutral delta times

### DIFF
--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -319,7 +319,7 @@ pub fn split_color(
 ) -> SemanticColor {
     if show_best_segments && check_best_segment(timer, segment_index, method) {
         SemanticColor::BestSegment
-    } else if let Some(time_difference) = time_difference {
+    } else if let Some(time_difference) = time_difference.filter(|t| t != &TimeSpan::zero()) {
         let last_delta = segment_index
             .checked_sub(1)
             .and_then(|n| last_delta(timer.run(), n, comparison, method));

--- a/src/analysis/tests/mod.rs
+++ b/src/analysis/tests/mod.rs
@@ -1,1 +1,2 @@
 mod empty_run;
+mod semantic_colors;

--- a/src/analysis/tests/semantic_colors.rs
+++ b/src/analysis/tests/semantic_colors.rs
@@ -1,0 +1,46 @@
+use crate::{
+    analysis::split_color,
+    comparison,
+    settings::SemanticColor,
+    util::tests_helper::{
+        create_timer, make_progress_run_with_splits_opt, run_with_splits, span, start_run,
+    },
+    Timer, TimingMethod,
+};
+
+#[test]
+fn segment_colors_are_correct() {
+    let mut timer = create_timer(&["A", "B"]);
+
+    run_with_splits(&mut timer, &[10.0, 20.0]);
+
+    start_run(&mut timer);
+    make_progress_run_with_splits_opt(&mut timer, &[Some(7.0)]);
+
+    assert_eq!(color(&timer, -2.5), SemanticColor::AheadLosingTime);
+    assert_eq!(color(&timer, -5.0), SemanticColor::AheadGainingTime);
+
+    assert_eq!(color(&timer, 0.0), SemanticColor::Default);
+
+    timer.reset(false);
+
+    start_run(&mut timer);
+    make_progress_run_with_splits_opt(&mut timer, &[Some(15.0)]);
+
+    assert_eq!(color(&timer, 2.5), SemanticColor::BehindGainingTime);
+    assert_eq!(color(&timer, 8.0), SemanticColor::BehindLosingTime);
+
+    assert_eq!(color(&timer, 0.0), SemanticColor::Default);
+}
+
+fn color(timer: &Timer, delta: f64) -> SemanticColor {
+    split_color(
+        timer,
+        Some(span(delta)),
+        1,
+        true,
+        false,
+        comparison::personal_best::NAME,
+        TimingMethod::GameTime,
+    )
+}


### PR DESCRIPTION
If the delta time is exactly 0, then it shouldn't have a sign at all and be considered neither semantically ahead or behind, like a skipped delta, and thus it gets assigned a neutral color (i.e. the text color).