### PR TITLE
Fix wasi_path test non-windows

### DIFF
--- a/crates/livesplit-auto-splitting/src/wasi_path.rs
+++ b/crates/livesplit-auto-splitting/src/wasi_path.rs
@@ -281,6 +281,9 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn test_wasi_to_non_windows() {
-        assert_eq!(to_native(r"/mnt/foo/bar.exe", false), Some(r"/foo/bar.exe".into()));
+        assert_eq!(
+            to_native(r"/mnt/foo/bar.exe", false),
+            Some(r"/foo/bar.exe".into())
+        );
     }
 }

--- a/crates/livesplit-auto-splitting/src/wasi_path.rs
+++ b/crates/livesplit-auto-splitting/src/wasi_path.rs
@@ -281,6 +281,6 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn test_wasi_to_non_windows() {
-        assert_eq!(to_native(r"/mnt/foo/bar.exe"), Some(r"/foo/bar.exe".into()));
+        assert_eq!(to_native(r"/mnt/foo/bar.exe", false), Some(r"/foo/bar.exe".into()));
     }
 }


### PR DESCRIPTION
Fixes the `wasi_path` test for non-windows to pass the new `supports_device_path` argument to `to_native`.