### PR TITLE
Don't use Floats to parse "extended" Time Spans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           # "ld: cannot find -lexecinfo"
           # - NetBSD x86_64
           - Solaris sparcv9
-          - Solaris x86_64
+          # - Solaris x86_64
 
           # Testing other channels
           - Windows Beta
@@ -482,9 +482,10 @@ jobs:
             target: sparcv9-sun-solaris
             tests: skip
 
-          - label: Solaris x86_64
-            target: x86_64-sun-solaris
-            tests: skip
+          # FIXME: The target got renamed and cross doesn't support it yet.
+          # - label: Solaris x86_64
+          #   target: x86_64-pc-solaris
+          #   tests: skip
 
           # Testing other channels
           - label: Windows Beta

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -29,11 +29,6 @@ impl TimeSpan {
         Self(Duration::seconds_f64(0.001 * milliseconds))
     }
 
-    /// Creates a new `TimeSpan` from a given amount of days.
-    pub fn from_days(days: f64) -> Self {
-        Self(Duration::seconds_f64(days * (24.0 * 60.0 * 60.0)))
-    }
-
     /// Converts the `TimeSpan` to a `Duration` from the `time` crate.
     pub const fn to_duration(&self) -> Duration {
         self.0
@@ -167,14 +162,14 @@ impl From<TimeSpan> for Duration {
 impl Add for TimeSpan {
     type Output = TimeSpan;
     fn add(self, rhs: TimeSpan) -> TimeSpan {
-        TimeSpan(self.0 + rhs.0)
+        TimeSpan(self.0.saturating_add(rhs.0))
     }
 }
 
 impl Sub for TimeSpan {
     type Output = TimeSpan;
     fn sub(self, rhs: TimeSpan) -> TimeSpan {
-        TimeSpan(self.0 - rhs.0)
+        TimeSpan(self.0.saturating_sub(rhs.0))
     }
 }
 


### PR DESCRIPTION
When parsing the splits files we still accidentally used floats to parse the extended notation that contains the number of days. It really only was used for the amount of days and as far as I can tell never allowed for any fractional values anyways. However, it almost certainly allowed values such as `NaN` or `Inf`, which probably would've caused a panic.