### PR TITLE
Update resource paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/LiveSplit/Resources/Icon.png" alt="LiveSplit" height="42" width="45" align="top"/> livesplit-core
+# <img src="https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/res/Icon.png" alt="LiveSplit" height="42" width="45" align="top"/> livesplit-core
 
 [![Build Status](https://github.com/LiveSplit/livesplit-core/workflows/Build/badge.svg)](https://github.com/LiveSplit/livesplit-core/actions)
 [![crates.io](https://img.shields.io/crates/v/livesplit-core.svg)](https://crates.io/crates/livesplit-core)

--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -1,4 +1,4 @@
-# <img src="https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/LiveSplit/Resources/Icon.png" alt="LiveSplit" height="42" width="45" align="top"/> livesplit-auto-splitting
+# <img src="https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/res/Icon.png" alt="LiveSplit" height="42" width="45" align="top"/> livesplit-auto-splitting
 
 livesplit-auto-splitting is a library that provides a runtime for running
 auto splitters that can control a speedrun timer. These auto splitters are


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2446

### Description

Some resources were moved on the main `LiveSplit/LiveSplit` repo which affects some README files here.