### PR TITLE
Run parser: deserialize the AutoSplitterSettings

### DIFF
--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 /// A setting widget that is meant to be shown to and modified by the user.
 #[non_exhaustive]
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Widget {
     /// A unique identifier for this setting. This is not meant to be shown to
     /// the user and is only used to keep track of the setting. This key is used
@@ -19,7 +19,7 @@ pub struct Widget {
 }
 
 /// The type of a [`Widget`] and additional information about it.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum WidgetKind {
     /// A title that is shown to the user. It doesn't by itself store a value
     /// and is instead used to group settings together.
@@ -51,7 +51,7 @@ pub enum WidgetKind {
 }
 
 /// A filter for a file selection setting.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FileFilter {
     /// A filter that matches on the name of the file.
     Name {
@@ -82,7 +82,7 @@ pub enum FileFilter {
 }
 
 /// An option for a choice setting.
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ChoiceOption {
     /// The unique identifier of the option. This is not meant to be shown to
     /// the user and is only used to keep track of the option. This key is used

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -570,7 +570,8 @@ use crate::{
 };
 use arc_swap::ArcSwapOption;
 use livesplit_auto_splitting::{
-    AutoSplitter, Config, CreationError, LogLevel, Timer as AutoSplitTimer, TimerState,
+    AutoSplitter, CompiledAutoSplitter, Config, CreationError, LogLevel, Timer as AutoSplitTimer,
+    TimerState,
 };
 pub use livesplit_auto_splitting::{settings, wasi_path};
 use snafu::Snafu;
@@ -578,7 +579,7 @@ use std::{
     fmt, fs, io,
     path::PathBuf,
     sync::{
-        Condvar, Mutex,
+        Condvar, Mutex, RwLock,
         mpsc::{self, Receiver, RecvTimeoutError, Sender},
     },
     thread,
@@ -614,6 +615,7 @@ pub struct Runtime<T: event::CommandSink + TimerQuery + Send + 'static> {
     shared_state: Arc<SharedState<T>>,
     changed_sender: Sender<()>,
     runtime: livesplit_auto_splitting::Runtime,
+    compiled_auto_splitter: RwLock<Option<CompiledAutoSplitter>>,
 }
 
 struct SharedState<T: 'static> {
@@ -688,6 +690,7 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
             changed_sender,
             // TODO: unwrap?
             runtime: livesplit_auto_splitting::Runtime::new(Config::default()).unwrap(),
+            compiled_auto_splitter: RwLock::new(None),
         }
     }
 
@@ -695,11 +698,24 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
     pub fn load(&self, path: PathBuf, timer: T) -> Result<(), Error> {
         let data = fs::read(path).map_err(|e| Error::ReadFileFailed { source: e })?;
 
-        let auto_splitter = self
+        let compiled_auto_splitter = self
             .runtime
             .compile(&data)
-            .map_err(|e| Error::LoadFailed { source: e })?
-            .instantiate(Timer(timer), None, None)
+            .map_err(|e| Error::LoadFailed { source: e })?;
+        self.instantiate(&compiled_auto_splitter, timer)?;
+        *self.compiled_auto_splitter.write().unwrap() = Some(compiled_auto_splitter);
+        Ok(())
+    }
+
+    /// Instantiates the compiled auto splitter.
+    fn instantiate(
+        &self,
+        compiled_auto_splitter: &CompiledAutoSplitter,
+        timer: T,
+    ) -> Result<(), Error> {
+        let settings_map = timer.get_timer().run().auto_splitter_settings_map_load();
+        let auto_splitter = compiled_auto_splitter
+            .instantiate(Timer(timer), settings_map, None)
             .map_err(|e| Error::LoadFailed { source: e })?;
 
         self.shared_state
@@ -720,6 +736,15 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
         self.changed_sender
             .send(())
             .map_err(|_| Error::ThreadStopped)
+    }
+
+    /// Reloads the auto splitter without re-compiling.
+    pub fn reload(&self, timer: T) -> Result<(), Error> {
+        self.unload()?;
+        if let Some(compiled_auto_splitter) = self.compiled_auto_splitter.read().unwrap().as_ref() {
+            self.instantiate(compiled_auto_splitter, timer)?;
+        }
+        Ok(())
     }
 
     /// Accesses a copy of the currently stored settings. The auto splitter can

--- a/src/run/auto_splitter_settings.rs
+++ b/src/run/auto_splitter_settings.rs
@@ -1,0 +1,13 @@
+use core::fmt::Debug;
+use livesplit_auto_splitting::settings;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct AutoSplitterSettings {
+    pub custom_settings: settings::Map,
+}
+
+impl AutoSplitterSettings {
+    pub fn set_custom_settings(&mut self, custom_settings: settings::Map) {
+        self.custom_settings = custom_settings;
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -15,6 +15,9 @@
 //! ```
 
 mod attempt;
+
+#[cfg(feature = "auto-splitting")]
+mod auto_splitter_settings;
 mod comparisons;
 pub mod editor;
 mod linked_layout;
@@ -40,6 +43,8 @@ pub use segment_groups::{
 };
 pub use segment_history::SegmentHistory;
 
+#[cfg(feature = "auto-splitting")]
+use crate::run::auto_splitter_settings::AutoSplitterSettings;
 use crate::{
     AtomicDateTime, Time, TimeSpan, TimingMethod,
     comparison::{ComparisonGenerator, RACE_COMPARISON_PREFIX, default_generators, personal_best},
@@ -81,6 +86,8 @@ pub struct Run {
     custom_comparisons: Vec<String>,
     comparison_generators: ComparisonGenerators,
     auto_splitter_settings: String,
+    #[cfg(feature = "auto-splitting")]
+    parsed_auto_splitter_settings: Option<AutoSplitterSettings>,
     linked_layout: Option<LinkedLayout>,
 }
 
@@ -135,6 +142,8 @@ impl Run {
             custom_comparisons: vec![personal_best::NAME.to_string()],
             comparison_generators: ComparisonGenerators(default_generators()),
             auto_splitter_settings: String::new(),
+            #[cfg(feature = "auto-splitting")]
+            parsed_auto_splitter_settings: None,
             linked_layout: None,
         }
     }
@@ -393,6 +402,40 @@ impl Run {
     #[inline]
     pub const fn auto_splitter_settings_mut(&mut self) -> &mut String {
         &mut self.auto_splitter_settings
+    }
+
+    /// Loads a copy of the Auto Splitter Settings as a settings map.
+    #[inline]
+    #[cfg(feature = "auto-splitting")]
+    pub fn auto_splitter_settings_map_load(
+        &self,
+    ) -> Option<livesplit_auto_splitting::settings::Map> {
+        if let Some(p) = &self.parsed_auto_splitter_settings {
+            return Some(p.custom_settings.clone());
+        }
+        None
+    }
+
+    /// Stores a settings map into the parsed auto splitter settings.
+    #[cfg(feature = "auto-splitting")]
+    pub fn auto_splitter_settings_map_store(
+        &mut self,
+        settings_map: livesplit_auto_splitting::settings::Map,
+    ) {
+        let p = &mut self.parsed_auto_splitter_settings;
+        match p {
+            None => {
+                if settings_map.is_empty() {
+                    return;
+                }
+                let mut a = AutoSplitterSettings::default();
+                a.set_custom_settings(settings_map);
+                *p = Some(a);
+            }
+            Some(a) => {
+                a.set_custom_settings(settings_map);
+            }
+        }
     }
 
     /// Accesses the [`LinkedLayout`] of this `Run`. If a

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -20,6 +20,11 @@ use crate::{
 use alloc::borrow::Cow;
 use core::{mem::MaybeUninit, str};
 use time::{Date, Duration, PrimitiveDateTime};
+#[cfg(feature = "auto-splitting")]
+use {
+    crate::run::auto_splitter_settings::AutoSplitterSettings, crate::util::xml::Attributes,
+    livesplit_auto_splitting::settings,
+};
 
 /// The Error type for splits files that couldn't be parsed by the LiveSplit
 /// Parser.
@@ -415,6 +420,135 @@ fn parse_attempt_history(version: Version, reader: &mut Reader, run: &mut Run) -
     }
 }
 
+fn parse_auto_splitter_settings(
+    _version: Version,
+    reader: &mut Reader<'_>,
+    run: &mut Run,
+) -> Result<()> {
+    reencode_children(reader, run.auto_splitter_settings_mut()).map_err(Into::<Error>::into)?;
+
+    #[cfg(feature = "auto-splitting")]
+    let mut reader = Reader::new(run.auto_splitter_settings());
+
+    #[cfg(feature = "auto-splitting")]
+    let mut any_parsed = false;
+    #[cfg(feature = "auto-splitting")]
+    let mut settings = AutoSplitterSettings::default();
+
+    #[cfg(feature = "auto-splitting")]
+    // The compiler seems to throw a warning that 'attributes' isn't used by default, it actually is though
+    #[allow(unused_variables)]
+    parse_children(&mut reader, |reader, tag, attributes| -> Result<()> {
+        match tag.name() {
+            "CustomSettings" => {
+                any_parsed = true;
+                settings.set_custom_settings(parse_settings_map(reader));
+                Ok(())
+            }
+            _ => end_tag(reader),
+        }
+    })
+    .ok();
+
+    #[cfg(feature = "auto-splitting")]
+    if any_parsed {
+        run.parsed_auto_splitter_settings = Some(settings);
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "auto-splitting")]
+fn parse_settings_map(reader: &mut Reader<'_>) -> settings::Map {
+    let mut settings_map = settings::Map::new();
+
+    parse_children(reader, |reader, _tag, attributes| {
+        if let (Some(id), Some(value)) = parse_settings_entry(reader, attributes) {
+            settings_map.insert(id.into(), value);
+        }
+        Ok::<(), Error>(())
+    })
+    .ok();
+
+    settings_map
+}
+
+#[cfg(feature = "auto-splitting")]
+fn parse_settings_list(reader: &mut Reader<'_>) -> settings::List {
+    let mut settings_list = settings::List::new();
+
+    parse_children(reader, |reader, _tag, attributes| {
+        if let (_, Some(value)) = parse_settings_entry(reader, attributes) {
+            settings_list.push(value);
+        }
+        Ok::<(), Error>(())
+    })
+    .ok();
+
+    settings_list
+}
+
+#[cfg(feature = "auto-splitting")]
+fn parse_settings_entry(
+    reader: &mut Reader<'_>,
+    attributes: Attributes<'_>,
+) -> (Option<String>, Option<settings::Value>) {
+    let mut id = None;
+    let mut setting_type = None;
+    let mut string_value = None;
+    type_hint(parse_attributes(attributes, |k, v| {
+        match k {
+            "id" => id = Some(v.unescape_str()),
+            "type" => setting_type = Some(v.unescape_str()),
+            "value" => string_value = Some(v.unescape_str()),
+            _ => {}
+        }
+        Ok(true)
+    }))
+    .ok();
+    let Some(setting_type) = setting_type else {
+        return (id, None);
+    };
+    let value = match setting_type.as_str() {
+        "bool" => {
+            let mut b = bool::default();
+            type_hint(text(reader, |t| {
+                b = parse_bool(t.as_ref()).unwrap_or_default();
+            }))
+            .ok();
+            Some(settings::Value::Bool(b))
+        }
+        "i64" => {
+            let mut i = i64::default();
+            type_hint(text(reader, |t| {
+                i = t.as_ref().parse().unwrap_or_default();
+            }))
+            .ok();
+            Some(settings::Value::I64(i))
+        }
+        "f64" => {
+            let mut f = f64::default();
+            type_hint(text(reader, |t| {
+                f = t.as_ref().parse().unwrap_or_default();
+            }))
+            .ok();
+            Some(settings::Value::F64(f))
+        }
+        "string" => {
+            let mut s = String::default();
+            type_hint(text(reader, |t| {
+                s = t.to_string();
+            }))
+            .ok();
+            Some(settings::Value::String(string_value.unwrap_or(s).into()))
+        }
+        "map" => Some(settings::Value::Map(parse_settings_map(reader))),
+        "list" => Some(settings::Value::List(parse_settings_list(reader))),
+        _ => None,
+    };
+    (id, value)
+}
+
 /// Attempts to parse a LiveSplit splits file.
 pub fn parse(source: &str) -> Result<Run> {
     let mut reader = Reader::new(source);
@@ -515,10 +649,7 @@ pub fn parse(source: &str) -> Result<Run> {
                 *run.segment_groups_mut() = SegmentGroups::from_vec_lossy(groups, run.len());
                 Ok(())
             }
-            "AutoSplitterSettings" => {
-                let settings = run.auto_splitter_settings_mut();
-                reencode_children(reader, settings).map_err(Into::into)
-            }
+            "AutoSplitterSettings" => parse_auto_splitter_settings(version, reader, &mut run),
             "LayoutPath" => text(reader, |t| {
                 run.set_linked_layout(if t == "?default" {
                     Some(LinkedLayout::Default)
@@ -590,6 +721,8 @@ fn import_legacy_subsplits(run: &mut Run) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "auto-splitting")]
+    use livesplit_auto_splitting::settings;
 
     #[test]
     fn time_span_parsing() {
@@ -610,5 +743,161 @@ mod tests {
         parse_time_span("-123.45.23:34:56.789").unwrap_err();
         parse_time_span("NaN.23:34:56.789").unwrap_err();
         parse_time_span("Inf.23:34:56.789").unwrap_err();
+    }
+
+    #[cfg(feature = "auto-splitting")]
+    #[test]
+    fn test_parse_settings() {
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"
+                <Setting id="start" type="bool">True</Setting>
+                <Setting id="split" type="bool">True</Setting>
+                <Setting id="remove_loads" type="bool">True</Setting>
+            "#
+            )),
+            {
+                let mut m = settings::Map::new();
+                m.insert("start".into(), settings::Value::Bool(true));
+                m.insert("split".into(), settings::Value::Bool(true));
+                m.insert("remove_loads".into(), settings::Value::Bool(true));
+                m
+            },
+        );
+
+        assert_eq!(
+            parse_settings_list(&mut Reader::new(
+                r#"<Setting type="string" value="KingsPass" />"#
+            )),
+            {
+                let mut l = settings::List::new();
+                l.push(settings::Value::String("KingsPass".into()));
+                l
+            },
+        );
+
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"<Setting id="splits_0_item" type="string" value="KingsPass" />"#
+            )),
+            {
+                let mut m = settings::Map::new();
+                m.insert(
+                    "splits_0_item".into(),
+                    settings::Value::String("KingsPass".into()),
+                );
+                m
+            },
+        );
+
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"
+                <Setting id="inner_map" type="map">
+                    <Setting id="first" type="bool">True</Setting>
+                    <Setting id="second" type="string" value="bar" />
+                </Setting>
+            "#
+            )),
+            {
+                let mut map = settings::Map::new();
+
+                let mut inner_map = settings::Map::new();
+                inner_map.insert("first".into(), settings::Value::Bool(true));
+                inner_map.insert("second".into(), settings::Value::String("bar".into()));
+
+                map.insert("inner_map".into(), settings::Value::Map(inner_map));
+                map
+            },
+        );
+
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"
+                <Setting id="lolol" type="map">
+                    <Setting id="first" type="bool">True</Setting>
+                    <Setting id="second" type="string" value="bar"></Setting>
+                    <Setting id="recursive" type="map">
+                        <Setting id="first" type="bool">True</Setting>
+                        <Setting id="second" type="string" value="bar"></Setting>
+                    </Setting>
+                </Setting>
+            "#
+            )),
+            {
+                let mut map = settings::Map::new();
+
+                let mut inner_map = settings::Map::new();
+                inner_map.insert("first".into(), settings::Value::Bool(true));
+                inner_map.insert("second".into(), settings::Value::String("bar".into()));
+                inner_map.insert("recursive".into(), settings::Value::Map(inner_map.clone()));
+
+                map.insert("lolol".into(), settings::Value::Map(inner_map));
+                map
+            },
+        );
+
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"
+                <Setting id="lolol" type="map">
+                    <Setting id="first" type="bool">True</Setting>
+                    <Setting id="second" type="string" value="bar" />
+                    <Setting id="recursive" type="map">
+                        <Setting id="first" type="bool">True</Setting>
+                        <Setting id="second" type="string" value="bar" />
+                    </Setting>
+                </Setting>
+            "#
+            )),
+            {
+                let mut map = settings::Map::new();
+
+                let mut inner_map = settings::Map::new();
+                inner_map.insert("first".into(), settings::Value::Bool(true));
+                inner_map.insert("second".into(), settings::Value::String("bar".into()));
+                inner_map.insert("recursive".into(), settings::Value::Map(inner_map.clone()));
+
+                map.insert("lolol".into(), settings::Value::Map(inner_map));
+                map
+            },
+        );
+
+        assert_eq!(
+            parse_settings_map(&mut Reader::new(
+                r#"
+                <Setting id="level32_bool" type="bool">True</Setting>
+                <Setting id="other_setting" type="bool">True</Setting>
+                <Setting id="level12_bool" type="bool">True</Setting>
+                <Setting id="lolol" type="map">
+                    <Setting id="first" type="bool">True</Setting>
+                    <Setting id="second" type="string" value="bar" />
+                    <Setting id="recursive" type="map">
+                        <Setting id="first" type="bool">True</Setting>
+                        <Setting id="second" type="string" value="bar" />
+                    </Setting>
+                </Setting>
+                <Setting id="okok" type="string" value="hello, you seem to like true!" />
+            "#
+            )),
+            {
+                let mut map = settings::Map::new();
+                map.insert("level32_bool".into(), settings::Value::Bool(true));
+                map.insert("other_setting".into(), settings::Value::Bool(true));
+                map.insert("level12_bool".into(), settings::Value::Bool(true));
+
+                let mut inner_map = settings::Map::new();
+                inner_map.insert("first".into(), settings::Value::Bool(true));
+                inner_map.insert("second".into(), settings::Value::String("bar".into()));
+                inner_map.insert("recursive".into(), settings::Value::Map(inner_map.clone()));
+
+                map.insert("lolol".into(), settings::Value::Map(inner_map));
+                map.insert(
+                    "okok".into(),
+                    settings::Value::String("hello, you seem to like true!".into()),
+                );
+                map
+            },
+        );
     }
 }

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -24,6 +24,8 @@
 //! livesplit::save_run(&run, IoWrite(writer)).expect("Couldn't save the splits file");
 //! ```
 
+#[cfg(feature = "auto-splitting")]
+use crate::run::AutoSplitterSettings;
 use crate::{
     DateTime, Run, Time, Timer, TimerPhase,
     localization::Lang,
@@ -35,6 +37,8 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::{fmt, mem::MaybeUninit};
+#[cfg(feature = "auto-splitting")]
+use livesplit_auto_splitting::settings;
 use time::UtcOffset;
 
 const LSS_IMAGE_HEADER: &[u8; 156] = include_bytes!("lss_image_header.bin");
@@ -329,10 +333,208 @@ pub fn save_run<W: fmt::Write>(run: &Run, writer: W) -> fmt::Result {
             },
         )?;
 
-        writer.tag_with_text_content(
-            "AutoSplitterSettings",
-            NO_ATTRIBUTES,
-            Text::new_escaped(run.auto_splitter_settings()),
-        )
+        write_run_auto_splitter_settings(writer, run)
     })
+}
+
+fn write_run_auto_splitter_settings<W: fmt::Write>(
+    writer: &mut Writer<W>,
+    run: &Run,
+) -> fmt::Result {
+    #[cfg(feature = "auto-splitting")]
+    if let Some(AutoSplitterSettings { custom_settings }) = &run.parsed_auto_splitter_settings {
+        return writer.tag_with_content("AutoSplitterSettings", NO_ATTRIBUTES, |writer| {
+            writer.tag_with_text_content("Version", NO_ATTRIBUTES, DisplayAlreadyEscaped("1.0"))?;
+
+            write_settings_map(writer, "CustomSettings", vec![], custom_settings)?;
+
+            Ok(())
+        });
+    }
+
+    writer.tag_with_text_content(
+        "AutoSplitterSettings",
+        NO_ATTRIBUTES,
+        Text::new_escaped(run.auto_splitter_settings()),
+    )
+}
+
+#[cfg(feature = "auto-splitting")]
+fn write_settings_map<W: fmt::Write>(
+    writer: &mut Writer<W>,
+    tag: &str,
+    attrs: Vec<(&str, &str)>,
+    map: &settings::Map,
+) -> fmt::Result {
+    writer.tag_with_content(tag, attrs, |writer| {
+        for (id, value) in map.iter() {
+            write_settings_entry(writer, vec![("id", id)], value).ok();
+        }
+        Ok(())
+    })
+}
+
+#[cfg(feature = "auto-splitting")]
+fn write_settings_list<W: fmt::Write>(
+    writer: &mut Writer<W>,
+    tag: &str,
+    attrs: Vec<(&str, &str)>,
+    map: &settings::List,
+) -> fmt::Result {
+    writer.tag_with_content(tag, attrs, |writer| {
+        for value in map.iter() {
+            write_settings_entry(writer, vec![], value).ok();
+        }
+        Ok(())
+    })
+}
+
+#[cfg(feature = "auto-splitting")]
+fn write_settings_entry<'a, W>(
+    writer: &mut Writer<W>,
+    mut attrs: Vec<(&str, &'a str)>,
+    value: &'a settings::Value,
+) -> fmt::Result
+where
+    W: fmt::Write,
+{
+    match value {
+        settings::Value::Map(m) => {
+            attrs.push(("type", "map"));
+            write_settings_map(writer, "Setting", attrs, m)
+        }
+        settings::Value::List(l) => {
+            attrs.push(("type", "list"));
+            write_settings_list(writer, "Setting", attrs, l)
+        }
+        settings::Value::Bool(b) => {
+            attrs.push(("type", "bool"));
+            writer.tag_with_text_content("Setting", attrs, bool(*b))
+        }
+        settings::Value::I64(i) => {
+            attrs.push(("type", "i64"));
+            writer.tag_with_text_content("Setting", attrs, Text::new_escaped(&i.to_string()))
+        }
+        settings::Value::F64(f) => {
+            attrs.push(("type", "f64"));
+            writer.tag_with_text_content("Setting", attrs, Text::new_escaped(&f.to_string()))
+        }
+        settings::Value::String(s) => {
+            attrs.push(("type", "string"));
+            attrs.push(("value", s));
+            writer.empty_tag("Setting", attrs)
+        }
+        _ => writer.empty_tag("Setting", attrs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "auto-splitting")]
+    use super::*;
+    #[cfg(feature = "auto-splitting")]
+    use livesplit_auto_splitting::settings;
+
+    #[cfg(feature = "auto-splitting")]
+    #[test]
+    fn test_write_settings() {
+        assert_eq!(
+            {
+                let mut s = String::new();
+                let mut writer = Writer::new_skip_header(&mut s);
+                write_settings_entry(&mut writer, vec![], &settings::Value::Bool(true)).ok();
+                s
+            },
+            r#"<Setting type="bool">True</Setting>"#
+        );
+
+        assert_eq!(
+            {
+                let mut s = String::new();
+                let mut writer = Writer::new_skip_header(&mut s);
+                write_settings_entry(
+                    &mut writer,
+                    vec![("id", "start")],
+                    &settings::Value::Bool(true),
+                )
+                .ok();
+                s
+            },
+            r#"<Setting id="start" type="bool">True</Setting>"#
+        );
+
+        assert_eq!(
+            {
+                let mut s = String::new();
+                let mut writer = Writer::new_skip_header(&mut s);
+                let mut m = settings::Map::new();
+                m.insert("start".into(), settings::Value::Bool(true));
+                m.insert("split".into(), settings::Value::Bool(true));
+                m.insert("remove_loads".into(), settings::Value::Bool(true));
+                write_settings_map(&mut writer, "CustomSettings", vec![], &m).ok();
+                s
+            },
+            format!(
+                "{}{}{}{}{}",
+                r#"<CustomSettings>"#,
+                r#"<Setting id="start" type="bool">True</Setting>"#,
+                r#"<Setting id="split" type="bool">True</Setting>"#,
+                r#"<Setting id="remove_loads" type="bool">True</Setting>"#,
+                r#"</CustomSettings>"#,
+            )
+        );
+
+        assert_eq!(
+            {
+                let mut s = String::new();
+                let mut writer = Writer::new_skip_header(&mut s);
+                let mut m = settings::Map::new();
+                m.insert("first".into(), settings::Value::Bool(true));
+                m.insert("second".into(), settings::Value::String("bar".into()));
+                write_settings_entry(
+                    &mut writer,
+                    vec![("id", "inner_map")],
+                    &settings::Value::Map(m),
+                )
+                .ok();
+                s
+            },
+            format!(
+                "{}{}{}{}",
+                r#"<Setting id="inner_map" type="map">"#,
+                r#"<Setting id="first" type="bool">True</Setting>"#,
+                r#"<Setting id="second" type="string" value="bar"/>"#,
+                r#"</Setting>"#,
+            )
+        );
+
+        assert_eq!(
+            {
+                let mut s = String::new();
+                let mut writer = Writer::new_skip_header(&mut s);
+                let mut m = settings::Map::new();
+                m.insert("first".into(), settings::Value::Bool(true));
+                m.insert("second".into(), settings::Value::String("bar".into()));
+                m.insert("recursive".into(), settings::Value::Map(m.clone()));
+                write_settings_entry(
+                    &mut writer,
+                    vec![("id", "inner_map")],
+                    &settings::Value::Map(m),
+                )
+                .ok();
+                s
+            },
+            format!(
+                "{}{}{}{}{}{}{}{}",
+                r#"<Setting id="inner_map" type="map">"#,
+                r#"<Setting id="first" type="bool">True</Setting>"#,
+                r#"<Setting id="second" type="string" value="bar"/>"#,
+                r#"<Setting id="recursive" type="map">"#,
+                r#"<Setting id="first" type="bool">True</Setting>"#,
+                r#"<Setting id="second" type="string" value="bar"/>"#,
+                r#"</Setting>"#,
+                r#"</Setting>"#,
+            )
+        );
+    }
 }

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -168,6 +168,15 @@ impl Timer {
         &self.run
     }
 
+    /// Stores a settings map into the parsed auto splitter settings.
+    #[cfg(feature = "auto-splitting")]
+    pub fn run_auto_splitter_settings_map_store(
+        &mut self,
+        settings_map: livesplit_auto_splitting::settings::Map,
+    ) {
+        self.run.auto_splitter_settings_map_store(settings_map);
+    }
+
     /// Marks the Run as unmodified, so that it is known that all the changes
     /// have been saved.
     #[inline]


### PR DESCRIPTION
Based on the work of @Refragg, I updated it to use the new settings map and settings value types.

- [x] Make sure the auto-splitter gets the settings from a freshly opened splits file.
- [x] Make sure a saved splits file gets the settings from the autosplitter, when the autosplitter has edited them.
- [x] Make sure a saved splits file gets to keep its Legacy XML, when the autosplitter has no settings of its own to replace it with.