### PR TITLE
Add tooltips to all settings

### DIFF
--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -632,6 +632,8 @@ export interface SettingsDescriptionJson {
 export interface SettingsDescriptionFieldJson {
     /** The name of the setting. */
     text: string,
+    /** The tooltip to show for the setting. */
+    tooltip: string,
     /** The current value of the setting. */
     value: SettingsDescriptionValueJson,
 }

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -100,8 +100,16 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
-            Field::new("Size".into(), u64::from(self.settings.size).into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
+            Field::new(
+                "Size".into(),
+                "The size of the component.".into(),
+                u64::from(self.settings.size).into(),
+            ),
         ])
     }
 

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -102,13 +102,26 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the comparison in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the comparison's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.value_color.into(),
+            ),
         ])
     }
 

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -178,7 +178,7 @@ impl Component {
             ),
             Field::new(
                 "Comparison".into(),
-                "The comparison to predict the final time from. If not set, the current comparison is taken from the timer.".into(),
+                "The comparison to predict the final time from. If not specified, the current comparison is used.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -171,18 +171,36 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Comparison".into(),
+                "The comparison to predict the final time from. If not set, the current comparison is taken from the timer.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the predicted time in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the predicted time. If not specified, the color is taken from the layout.".into(),
+                self.settings.value_color.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the predicted time shown.".into(),
+                self.settings.accuracy.into(),
+            ),
         ])
     }
 

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -174,7 +174,7 @@ impl Component {
             ),
             Field::new(
                 "Comparison".into(),
-                "The comparison to use for calculating how far ahead or behind the current attempt is. If not set, the current comparison is taken from the timer.".into(),
+                "The comparison to use for calculating how far ahead or behind the current attempt is. If not specified, the current comparison is used.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
@@ -189,7 +189,7 @@ impl Component {
             ),
             Field::new(
                 "Drop Decimals".into(),
-                "Specifies if the decimals should not be shown anymore when the visualized delta is above one minute.".into(),
+                "Specifies if the decimals should not be shown anymore when the visualized delta is over a minute.".into(),
                 self.settings.drop_decimals.into(),
             ),
             Field::new(

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -167,18 +167,36 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Comparison".into(),
+                "The comparison to use for calculating how far ahead or behind the current attempt is. If not set, the current comparison is taken from the timer.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the comparison and the delta in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Drop Decimals".into(), self.settings.drop_decimals.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the comparison name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into()
+            ),
+            Field::new(
+                "Drop Decimals".into(),
+                "Specifies if the decimals should not be shown anymore when the visualized delta is above one minute.".into(),
+                self.settings.drop_decimals.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the delta shown.".into(),
+                self.settings.accuracy.into()
+            ),
         ])
     }
 

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -354,46 +354,64 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Timing Method".into(),
+                "Specifies the timing method to use. If not specified, the current timing method of the timer is used for showing the time.".into(),
                 self.settings.timer.timing_method.into(),
             ),
             Field::new(
                 "Comparison 1".into(),
+                "The first comparison to show the segment time of. If it's not specified, the current comparison is used.".into(),
                 self.settings.comparison1.clone().into(),
             ),
             Field::new(
                 "Comparison 2".into(),
+                "The second comparison to show the segment time of. If it's not specified, the current comparison is used, unless the first comparison is also None. This is not shown if the second comparison is hidden.".into(),
                 self.settings.comparison2.clone().into(),
             ),
             Field::new(
                 "Hide Second Comparison".into(),
+                "Specifies whether to only show a single comparison.".into(),
                 self.settings.hide_second_comparison.into(),
             ),
             Field::new(
                 "Timer Height".into(),
+                "The height of the run timer.".into(),
                 u64::from(self.settings.timer.height).into(),
             ),
             Field::new(
                 "Segment Timer Height".into(),
+                "The height of the segment timer.".into(),
                 u64::from(self.settings.segment_timer.height).into(),
             ),
             Field::new(
                 "Timer Color".into(),
+                "Instead of automatically determining the color for the main timer, based on a how well the current attempt is doing, a specific color to always be used can be provided instead.".into(),
                 self.settings.timer.color_override.into(),
             ),
             Field::new(
                 "Show Timer Gradient".into(),
+                "The main timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise the actual color is used instead of a gradient.".into(),
                 self.settings.timer.show_gradient.into(),
             ),
             Field::new(
                 "Timer Digits Format".into(),
+                "Determines how many digits are to always be shown for the main timer. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
                 self.settings.timer.digits_format.into(),
             ),
-            Field::new("Timer Accuracy".into(), self.settings.timer.accuracy.into()),
+            Field::new(
+                "Timer Accuracy".into(),
+                "The accuracy of the time shown for the main timer.".into(),
+                self.settings.timer.accuracy.into(),
+            ),
             Field::new(
                 "Segment Timer Color".into(),
+                "Changes the color of the segment timer to a color different from the default color.".into(),
                 self.settings
                     .segment_timer
                     .color_override
@@ -402,37 +420,49 @@ impl Component {
             ),
             Field::new(
                 "Show Segment Timer Gradient".into(),
+                "The segment timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise the actual color is used instead of a gradient.".into(),
                 self.settings.segment_timer.show_gradient.into(),
             ),
             Field::new(
                 "Segment Timer Digits Format".into(),
+                "Determines how many digits are to always be shown for the segment timer. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
                 self.settings.segment_timer.digits_format.into(),
             ),
             Field::new(
                 "Segment Timer Accuracy".into(),
+                "The accuracy of the time shown for the segment timer.".into(),
                 self.settings.segment_timer.accuracy.into(),
             ),
             Field::new(
                 "Comparison Names Color".into(),
+                "The color of the comparison names if they are shown. If no color is specified, the color is taken from the layout.".into(),
                 self.settings.comparison_names_color.into(),
             ),
             Field::new(
                 "Comparison Times Color".into(),
+                "The color of the comparison times if they are shown. If no color is specified, the color is taken from the layout.".into(),
                 self.settings.comparison_times_color.into(),
             ),
             Field::new(
                 "Comparison Times Accuracy".into(),
+                "The accuracy of the comparison times.".into(),
                 self.settings.comparison_times_accuracy.into(),
             ),
             Field::new(
                 "Show Segment Name".into(),
+                "Specifies whether the segment name should be shown.".into(),
                 self.settings.show_segment_name.into(),
             ),
             Field::new(
                 "Segment Name Color".into(),
+                "The color of the segment name if it's shown. If no color is specified, the color is taken from the layout.".into(),
                 self.settings.segment_name_color.into(),
             ),
-            Field::new("Display Icon".into(), self.settings.display_icon.into()),
+            Field::new(
+                "Display Icon".into(),
+                "Specifies whether the segment icon should be shown.".into(),
+                self.settings.display_icon.into(),
+            ),
         ])
     }
 

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -361,17 +361,17 @@ impl Component {
             ),
             Field::new(
                 "Timing Method".into(),
-                "Specifies the timing method to use. If not specified, the current timing method of the timer is used for showing the time.".into(),
+                "Specifies the timing method to use. If not specified, the current timing method is used.".into(),
                 self.settings.timer.timing_method.into(),
             ),
             Field::new(
                 "Comparison 1".into(),
-                "The first comparison to show the segment time of. If it's not specified, the current comparison is used.".into(),
+                "The first comparison to show the segment time of. If not specified, the current comparison is used.".into(),
                 self.settings.comparison1.clone().into(),
             ),
             Field::new(
                 "Comparison 2".into(),
-                "The second comparison to show the segment time of. If it's not specified, the current comparison is used, unless the first comparison is also None. This is not shown if the second comparison is hidden.".into(),
+                "The second comparison to show the segment time of. If not specified, the current comparison is used, unless the first comparison is also None. This is not shown if the second comparison is hidden.".into(),
                 self.settings.comparison2.clone().into(),
             ),
             Field::new(
@@ -391,17 +391,17 @@ impl Component {
             ),
             Field::new(
                 "Timer Color".into(),
-                "Instead of automatically determining the color for the main timer, based on a how well the current attempt is doing, a specific color to always be used can be provided instead.".into(),
+                "Instead of automatically determining the color for the main timer based on a how well the current attempt is doing, a specific color to always be used can be provided instead.".into(),
                 self.settings.timer.color_override.into(),
             ),
             Field::new(
                 "Show Timer Gradient".into(),
-                "The main timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise the actual color is used instead of a gradient.".into(),
+                "The main timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise, the actual color is used instead of a gradient.".into(),
                 self.settings.timer.show_gradient.into(),
             ),
             Field::new(
                 "Timer Digits Format".into(),
-                "Determines how many digits are to always be shown for the main timer. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
+                "Specifies how many digits to show for the main timer. If the duration is lower than the digits to be shown, zeros are shown instead.".into(),
                 self.settings.timer.digits_format.into(),
             ),
             Field::new(
@@ -420,12 +420,12 @@ impl Component {
             ),
             Field::new(
                 "Show Segment Timer Gradient".into(),
-                "The segment timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise the actual color is used instead of a gradient.".into(),
+                "The segment timer automatically turns its color into a vertical gradient if this setting is activated. Otherwise, the actual color is used instead of a gradient.".into(),
                 self.settings.segment_timer.show_gradient.into(),
             ),
             Field::new(
                 "Segment Timer Digits Format".into(),
-                "Determines how many digits are to always be shown for the segment timer. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
+                "Specifies how many digits to show for the segment timer. If the duration is lower than the digits to be shown, zeros are shown instead.".into(),
                 self.settings.segment_timer.digits_format.into(),
             ),
             Field::new(

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -279,37 +279,57 @@ impl Component {
         SettingsDescription::with_fields(vec![
             Field::new(
                 "Comparison".into(),
+                "The comparison to use for the graph. If not set, the current comparison is taken from the timer.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
-            Field::new("Height".into(), u64::from(self.settings.height).into()),
+            Field::new(
+                "Height".into(),
+                "The height of the chart.".into(),
+                u64::from(self.settings.height).into(),
+            ),
             Field::new(
                 "Show Best Segments".into(),
+                "Specifies whether to color the best segments with the layout's best segment color.".into(),
                 self.settings.show_best_segments.into(),
             ),
-            Field::new("Live Graph".into(), self.settings.live_graph.into()),
-            Field::new("Flip Graph".into(), self.settings.flip_graph.into()),
+            Field::new(
+                "Live Graph".into(),
+                "Specifies whether the graph should automatically refresh all the time. If this is deactivated, changes to the graph only happen whenever the current segment changes.".into(),
+                self.settings.live_graph.into(),
+            ),
+            Field::new(
+                "Flip Graph".into(),
+                "Specifies whether the chart should be flipped vertically. If not set, split times which are ahead of the comparison are displayed below the x-axis and times which are behind are above it. Enabling this settings flips it.".into(),
+                self.settings.flip_graph.into(),
+            ),
             Field::new(
                 "Behind Background Color".into(),
+                "The background color for the chart region containing the times that are behind the comparison.".into(),
                 self.settings.behind_background_color.into(),
             ),
             Field::new(
                 "Ahead Background Color".into(),
+                "The background color for the chart region containing the times that are ahead of the comparison.".into(),
                 self.settings.ahead_background_color.into(),
             ),
             Field::new(
                 "Grid Lines Color".into(),
+                "The color of the chart's grid lines.".into(),
                 self.settings.grid_lines_color.into(),
             ),
             Field::new(
                 "Graph Lines Color".into(),
+                "The color of the lines connecting the graph's points.".into(),
                 self.settings.graph_lines_color.into(),
             ),
             Field::new(
                 "Partial Fill Color".into(),
+                "The color of the region enclosed by the x-axis and the graph. The partial fill color is only used for live changes. More specifically, this color is used in the interval from the last split time to the current time.".into(),
                 self.settings.partial_fill_color.into(),
             ),
             Field::new(
                 "Complete Fill Color".into(),
+                "The color of the region enclosed by the x-axis and the graph, excluding the graph segment with live changes.".into(),
                 self.settings.complete_fill_color.into(),
             ),
         ])

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -279,7 +279,7 @@ impl Component {
         SettingsDescription::with_fields(vec![
             Field::new(
                 "Comparison".into(),
-                "The comparison to use for the graph. If not set, the current comparison is taken from the timer.".into(),
+                "The comparison to use for the graph. If not specified, the current comparison is used.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
@@ -299,7 +299,7 @@ impl Component {
             ),
             Field::new(
                 "Flip Graph".into(),
-                "Specifies whether the chart should be flipped vertically. If not set, split times which are ahead of the comparison are displayed below the x-axis and times which are behind are above it. Enabling this settings flips it.".into(),
+                "Specifies whether the chart should be flipped vertically. If not enabled, split times which are ahead of the comparison are displayed below the x-axis and times which are behind are above it. Enabling this settings flips it.".into(),
                 self.settings.flip_graph.into(),
             ),
             Field::new(

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -108,13 +108,29 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the PB chance in two separate rows."
+                    .into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout."
+                    .into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the PB chance. If not specified, the color is taken from the layout."
+                    .into(),
+                self.settings.value_color.into(),
+            ),
         ])
     }
 

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -171,22 +171,41 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Comparison".into(),
+                "The comparison to calculate the possible time save for. If not specified, the current comparison is used.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the possible time save in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
             Field::new(
                 "Show Total Possible Time Save".into(),
+                "Specifies whether to show the total possible time save for the remainder of the current attempt, instead of the possible time save for the current segment.".into(),
                 self.settings.total_possible_time_save.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the possible time save. If not specified, the color is taken from the layout.".into(),
+                self.settings.value_color.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the possible time save shown.".into(),
+                self.settings.accuracy.into(),
+            ),
         ])
     }
 

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -265,7 +265,7 @@ impl Component {
             ),
             Field::new(
                 "Comparison".into(),
-                "The comparison to calculate how much time was saved or lost is based on. If not set, the current comparison is taken from the timer.".into(),
+                "The comparison used for calculating how much time was saved or lost. If not specified, the current comparison is used.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
@@ -280,7 +280,7 @@ impl Component {
             ),
             Field::new(
                 "Drop Decimals".into(),
-                "Specifies whether to drop the decimals from the time when the visualized time is over a minute.".into(),
+                "Specifies whether to drop the decimals from the time when the time shown is over a minute.".into(),
                 self.settings.drop_decimals.into(),
             ),
             Field::new(

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -258,20 +258,39 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Comparison".into(),
+                "The comparison to calculate how much time was saved or lost is based on. If not set, the current comparison is taken from the timer.".into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and how much time was saved or lost in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Drop Decimals".into(), self.settings.drop_decimals.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Drop Decimals".into(),
+                "Specifies whether to drop the decimals from the time when the visualized time is over a minute.".into(),
+                self.settings.drop_decimals.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the time shown.".into(),
+                self.settings.accuracy.into(),
+            ),
             Field::new(
                 "Show Possible Time Save".into(),
+                "Specifies whether to show how much time could've been saved for the previous segment in addition to the time saved or lost.".into(),
                 self.settings.show_possible_time_save.into(),
             ),
         ])

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -182,18 +182,38 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Comparison".into(),
+                "The comparison chosen. If not specified, uses the timer's current comparison."
+                    .into(),
                 self.settings.comparison_override.clone().into(),
             ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the segment time in two separate rows."
+                    .into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout."
+                    .into(),
+                self.settings.label_color.into()),
+            Field::new(
+                "Value Color".into(),
+                "The color of the segment time. If not specified, the color is taken from the layout."
+                    .into(),
+                self.settings.value_color.into()),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the segment time shown.".into(),
+                self.settings.accuracy.into(),
+            ),
         ])
     }
 

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -189,7 +189,7 @@ impl Component {
             ),
             Field::new(
                 "Comparison".into(),
-                "The comparison chosen. If not specified, uses the timer's current comparison."
+                "The comparison for the segment time. If not specified, the current comparison is used."
                     .into(),
                 self.settings.comparison_override.clone().into(),
             ),

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -76,8 +76,8 @@ pub struct Settings {
     pub always_show_last_split: bool,
     /// If there's not enough segments to fill the list of splits, this option
     /// allows filling the remaining splits with blank space in order to
-    /// maintain the visual split count specified. Otherwise the visual split
-    /// count is reduced to the actual amount of segments.
+    /// maintain the visual split count specified. Otherwise the visual
+    /// split count is reduced to the actual amount of segments.
     pub fill_with_blank_space: bool,
     /// Specifies whether to display each split as two rows, with the segment
     /// name being in one row and the times being in the other.
@@ -425,61 +425,79 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         let mut settings = SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
             Field::new(
-                "Total Splits".into(),
+                "Background".into(),
+                "The background shown behind the component. You can choose for the colors to be alternating. In that case each row alternates between the two colors chosen.".into(),
+                self.settings.background.into(),
+            ),
+            Field::new(
+                "Total Rows".into(),
+                "The total number of rows of segments to show in the list. If set to 0, all the segments are shown. If set to a number lower than the total amount of segments, only a certain window of all the segments is shown. This window can scroll up or down.".into(),
                 Value::UInt(self.settings.visual_split_count as _),
             ),
             Field::new(
-                "Upcoming Splits".into(),
+                "Upcoming Segments".into(),
+                "If there's more segments than rows that are shown, the window showing the segments automatically scrolls up and down when the current segment changes. This number determines the minimum number of future segments to be shown in this scrolling window when it automatically scrolls.".into(),
                 Value::UInt(self.settings.split_preview_count as _),
             ),
             Field::new(
                 "Show Thin Separators".into(),
+                "Specifies whether thin separators should be shown between the individual segments shown by the component.".into(),
                 self.settings.show_thin_separators.into(),
             ),
             Field::new(
                 "Show Separator Before Last Split".into(),
+                "If the last segment is to always be shown, this determines whether to show a more pronounced separator in front of the last segment, if it is not directly adjacent to the segment shown right before it in the scrolling window.".into(),
                 self.settings.separator_last_split.into(),
             ),
             Field::new(
                 "Always Show Last Split".into(),
+                "If not every segment is shown in the scrolling window of segments, then this option determines whether the final segment is always to be shown, as it contains valuable information about the total duration of the chosen comparison, which is often the runner's Personal Best.".into(),
                 self.settings.always_show_last_split.into(),
             ),
             Field::new(
-                "Fill with Blank Space if Not Enough Splits".into(),
+                "Fill with Blank Space".into(),
+                "If there's not enough segments to fill the list, this option allows filling the remaining rows with blank space in order to maintain the number of total rows specified. Otherwise the number of total rows shown is reduced to the actual amount of segments.".into(),
                 self.settings.fill_with_blank_space.into(),
             ),
             Field::new(
-                "Display 2 Rows".into(),
+                "Show Times Below Segment Name".into(),
+                "Specifies whether to show the times below the segment name. Otherwise the times are shown next to the segment name.".into(),
                 self.settings.display_two_rows.into(),
             ),
             Field::new(
-                "Current Split Gradient".into(),
+                "Current Segment Gradient".into(),
+                "The gradient to show behind the current segment as an indicator of it being the current segment.".into(),
                 self.settings.current_split_gradient.into(),
             ),
             Field::new(
                 "Split Time Accuracy".into(),
+                "Specifies the accuracy to use for visualizing columns that contain split times.".into(),
                 self.settings.split_time_accuracy.into(),
             ),
             Field::new(
                 "Segment Time Accuracy".into(),
+                "Specifies the accuracy to use for visualizing columns that contain segment times.".into(),
                 self.settings.segment_time_accuracy.into(),
             ),
             Field::new(
                 "Delta Time Accuracy".into(),
+                "Specifies the accuracy to use for visualizing columns that contain the amount time you are ahead or behind.".into(),
                 self.settings.delta_time_accuracy.into(),
             ),
             Field::new(
                 "Drop Delta Decimals When Showing Minutes".into(),
+                "Specifies if the decimals should not be shown anymore when a column that contain the amount of time you are ahead or behind once is above one minute.".into(),
                 self.settings.delta_drop_decimals.into(),
             ),
             Field::new(
                 "Show Column Labels".into(),
+                "Specifies whether to show the names of the columns at the top of the list.".into(),
                 self.settings.show_column_labels.into(),
             ),
             Field::new(
                 "Columns".into(),
+                "The amount of columns to show in each row. Each column can be configured to show different information. The columns are defined from right to left.".into(),
                 Value::UInt(self.settings.columns.len() as _),
             ),
         ]);
@@ -498,40 +516,58 @@ impl Component {
         for column in &self.settings.columns {
             settings
                 .fields
-                .push(Field::new("Column Name".into(), column.name.clone().into()));
+                .push(Field::new(
+                    "Column Name".into(),
+                    "The name of the column. This is shown at the top of the list if the option to show column labels is enabled.".into(),
+                    column.name.clone().into(),
+                ));
 
             match &column.kind {
                 ColumnKind::Variable(column) => {
                     settings.fields.push(Field::new(
                         "Column Type".into(),
+                        "The type of information this column displays. This can be a time or a custom variable that you have stored in your splits.".into(),
                         settings::ColumnKind::Variable.into(),
                     ));
                     settings.fields.push(Field::new(
                         "Variable Name".into(),
+                        "The name of the custom variable that this column displays.".into(),
                         column.variable_name.clone().into(),
                     ));
                 }
                 ColumnKind::Time(column) => {
                     settings.fields.push(Field::new(
                         "Column Type".into(),
+                        "The type of information this column displays. This can be a time or a custom variable that you have stored in your splits.".into(),
                         settings::ColumnKind::Time.into(),
                     ));
                     settings
                         .fields
-                        .push(Field::new("Start With".into(), column.start_with.into()));
+                        .push(Field::new(
+                            "Start With".into(),
+                            "The value that this column starts with for each segment. The update trigger determines when this time is replaced.".into(),
+                            column.start_with.into(),
+                        ));
                     settings
                         .fields
-                        .push(Field::new("Update With".into(), column.update_with.into()));
+                        .push(Field::new(
+                            "Update With".into(),
+                            "Once a certain condition is met, which is usually being on the split or already having completed the split, the time gets updated with the value specified here.".into(),
+                            column.update_with.into(),
+                    ));
                     settings.fields.push(Field::new(
                         "Update Trigger".into(),
+                        "The condition that needs to be met for the time to get updated with the value specified in the update with field. Before this condition is met, the time is the value specified in the start with field.".into(),
                         column.update_trigger.into(),
                     ));
                     settings.fields.push(Field::new(
                         "Comparison".into(),
+                        "The comparison that is being compared against for this column. If not set, the current comparison is taken from the timer.".into(),
                         column.comparison_override.clone().into(),
                     ));
                     settings.fields.push(Field::new(
                         "Timing Method".into(),
+                        "Specifies the timing method to use for this column. If not specified, the current timing method of the timer is used for showing the time.".into(),
                         column.timing_method.into(),
                     ));
                 }

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -432,17 +432,17 @@ impl Component {
             ),
             Field::new(
                 "Total Rows".into(),
-                "The total number of rows of segments to show in the list. If set to 0, all the segments are shown. If set to a number lower than the total amount of segments, only a certain window of all the segments is shown. This window can scroll up or down.".into(),
+                "The total number of rows of segments to show in the list. If set to 0, all the segments are shown. If set to a number lower than the total number of segments, only a certain window of all the segments is shown. This window can scroll up or down.".into(),
                 Value::UInt(self.settings.visual_split_count as _),
             ),
             Field::new(
                 "Upcoming Segments".into(),
-                "If there's more segments than rows that are shown, the window showing the segments automatically scrolls up and down when the current segment changes. This number determines the minimum number of future segments to be shown in this scrolling window when it automatically scrolls.".into(),
+                "If there's more segments than rows that are shown, the window showing the segments automatically scrolls up and down when the current segment changes. This number determines the minimum number of future segments to be shown in this scrolling window.".into(),
                 Value::UInt(self.settings.split_preview_count as _),
             ),
             Field::new(
                 "Show Thin Separators".into(),
-                "Specifies whether thin separators should be shown between the individual segments shown by the component.".into(),
+                "Specifies whether thin separators should be shown between the individual segment rows.".into(),
                 self.settings.show_thin_separators.into(),
             ),
             Field::new(
@@ -452,12 +452,12 @@ impl Component {
             ),
             Field::new(
                 "Always Show Last Split".into(),
-                "If not every segment is shown in the scrolling window of segments, then this option determines whether the final segment is always to be shown, as it contains valuable information about the total duration of the chosen comparison, which is often the runner's Personal Best.".into(),
+                "If not every segment is shown in the scrolling window of segments, then this option determines whether the final segment should always be shown, as it contains the total duration of the chosen comparison. This can be valuable information, as it is often the runner's Personal Best.".into(),
                 self.settings.always_show_last_split.into(),
             ),
             Field::new(
                 "Fill with Blank Space".into(),
-                "If there's not enough segments to fill the list, this option allows filling the remaining rows with blank space in order to maintain the number of total rows specified. Otherwise the number of total rows shown is reduced to the actual amount of segments.".into(),
+                "If there's not enough segments to fill the list, this option allows filling the remaining rows with blank space in order to always show the number of total rows specified in the settings. Otherwise, the number of total rows shown is reduced to the actual number of segments.".into(),
                 self.settings.fill_with_blank_space.into(),
             ),
             Field::new(
@@ -482,12 +482,12 @@ impl Component {
             ),
             Field::new(
                 "Delta Time Accuracy".into(),
-                "Specifies the accuracy to use for visualizing columns that contain the amount time you are ahead or behind.".into(),
+                "Specifies the accuracy to use for visualizing columns that contain the amount of time you are ahead or behind.".into(),
                 self.settings.delta_time_accuracy.into(),
             ),
             Field::new(
                 "Drop Delta Decimals When Showing Minutes".into(),
-                "Specifies if the decimals should not be shown anymore when a column that contain the amount of time you are ahead or behind once is above one minute.".into(),
+                "Specifies if the decimals should not be shown anymore when a column that contains the amount of time you are ahead or behind is over a minute.".into(),
                 self.settings.delta_drop_decimals.into(),
             ),
             Field::new(
@@ -497,7 +497,7 @@ impl Component {
             ),
             Field::new(
                 "Columns".into(),
-                "The amount of columns to show in each row. Each column can be configured to show different information. The columns are defined from right to left.".into(),
+                "The number of columns to show in each row. Each column can be configured to show different information. The columns are defined from right to left.".into(),
                 Value::UInt(self.settings.columns.len() as _),
             ),
         ]);
@@ -545,29 +545,29 @@ impl Component {
                         .fields
                         .push(Field::new(
                             "Start With".into(),
-                            "The value that this column starts with for each segment. The update trigger determines when this time is replaced.".into(),
+                            "The value that this column starts with for each segment. The Update Trigger determines when this time is replaced.".into(),
                             column.start_with.into(),
                         ));
                     settings
                         .fields
                         .push(Field::new(
                             "Update With".into(),
-                            "Once a certain condition is met, which is usually being on the split or already having completed the split, the time gets updated with the value specified here.".into(),
+                            "Once a certain condition is met, which is usually being on the segment or having already completed the segment, the time gets updated with the value specified here.".into(),
                             column.update_with.into(),
                     ));
                     settings.fields.push(Field::new(
                         "Update Trigger".into(),
-                        "The condition that needs to be met for the time to get updated with the value specified in the update with field. Before this condition is met, the time is the value specified in the start with field.".into(),
+                        "The condition that needs to be met for the time to get updated with the value specified in the Update With field. Before this condition is met, the time is the value specified in the Start With field.".into(),
                         column.update_trigger.into(),
                     ));
                     settings.fields.push(Field::new(
                         "Comparison".into(),
-                        "The comparison that is being compared against for this column. If not set, the current comparison is taken from the timer.".into(),
+                        "The comparison that is being compared against for this column. If not specified, the current comparison is used.".into(),
                         column.comparison_override.clone().into(),
                     ));
                     settings.fields.push(Field::new(
                         "Timing Method".into(),
-                        "Specifies the timing method to use for this column. If not specified, the current timing method of the timer is used for showing the time.".into(),
+                        "Specifies the timing method to use for this column. If not specified, the current timing method is used.".into(),
                         column.timing_method.into(),
                     ));
                 }

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -130,14 +130,31 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the sum of best segments in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the sum of best segments. If not specified, the color is taken from the layout.".into(),
+                self.settings.value_color.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the sum of best segments shown.".into(),
+                self.settings.accuracy.into(),
+            ),
         ])
     }
 

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -270,44 +270,82 @@ impl Component {
     /// Accesses a generic description of the settings available for this
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
-        let (first, second, is_variable, is_split, left_color, right_color) =
-            match &self.settings.text {
-                Text::Center(text) => (
-                    Field::new("Text".into(), text.to_string().into()),
-                    None,
-                    false,
-                    false,
-                    "Text Color",
-                    "",
+        let (
+            first,
+            second,
+            is_variable,
+            is_split,
+            (left_color, left_color_text),
+            (right_color, right_color_text),
+        ) = match &self.settings.text {
+            Text::Center(text) => (
+                Field::new(
+                    "Text".into(),
+                    "Specifies the text to display in the center.".into(),
+                    text.to_string().into(),
                 ),
-                Text::Split(left, right) => (
-                    Field::new("Left".into(), left.to_string().into()),
-                    Some(Field::new("Right".into(), right.to_string().into())),
-                    false,
-                    true,
-                    "Left Color",
-                    "Right Color",
+                None,
+                false,
+                false,
+                ("Text Color", "The color of the text."),
+                ("", ""),
+            ),
+            Text::Split(left, right) => (
+                Field::new(
+                    "Left".into(),
+                    "Specifies the text to display on the left.".into(),
+                    left.to_string().into(),
                 ),
-                Text::Variable(var_name, is_split) => (
-                    Field::new("Variable".into(), var_name.to_string().into()),
-                    None,
-                    true,
-                    *is_split,
-                    if *is_split {
-                        "Name Color"
-                    } else {
-                        "Value Color"
-                    },
-                    "Value Color",
+                Some(Field::new(
+                    "Right".into(),
+                    "Specifies the text to display on the right.".into(),
+                    right.to_string().into(),
+                )),
+                false,
+                true,
+                ("Left Color", "The color of the text on the left."),
+                ("Right Color", "The color of the text on the right."),
+            ),
+            Text::Variable(var_name, is_split) => (
+                Field::new(
+                    "Variable".into(),
+                    "Specifies the name of the custom variable to display.".into(),
+                    var_name.to_string().into(),
                 ),
-            };
+                None,
+                true,
+                *is_split,
+                if *is_split {
+                    ("Name Color", "The color of the variable name.")
+                } else {
+                    ("Value Color", "The color of the variable value.")
+                },
+                ("Value Color", "The color of the variable value."),
+            ),
+        };
 
         let mut fields = vec![
-            Field::new("Background".into(), self.settings.background.into()),
-            Field::new("Use Variable".into(), is_variable.into()),
-            Field::new("Split".into(), is_split.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
+            Field::new(
+                "Use Variable".into(),
+                "Specifies whether to use a custom variable to display a dynamic value. Custom variables can be specified in the splits editor and provided automatically by auto splitters.".into(),
+                is_variable.into(),
+            ),
+            Field::new(
+                "Split".into(),
+                "Specifies whether to split the text into a left and right part. If this is not the case then only a single centered text is displayed.".into(),
+                is_split.into(),
+            ),
             first,
-            Field::new(left_color.into(), self.settings.left_center_color.into()),
+            Field::new(
+                left_color.into(),
+                left_color_text.into(),
+                self.settings.left_center_color.into(),
+            ),
         ];
 
         if let Some(second) = second {
@@ -317,10 +355,12 @@ impl Component {
         if is_split {
             fields.push(Field::new(
                 right_color.into(),
+                right_color_text.into(),
                 self.settings.right_color.into(),
             ));
             fields.push(Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the left and right text in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ));
         }

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -320,12 +320,12 @@ impl Component {
             ),
             Field::new(
                 "Segment Timer".into(),
-                "Specifies whether to show how much time has passed since the start current segment, rather than how much time has passed since the start of the current attempt.".into(),
+                "Specifies whether to show how much time has passed since the start of the current segment, rather than how much time has passed since the start of the current attempt.".into(),
                 self.settings.is_segment_timer.into(),
             ),
             Field::new(
                 "Timing Method".into(),
-                "Specifies the timing method to use. If not specified, the current timing method of the timer is used for showing the time.".into(),
+                "Specifies the timing method to use. If not specified, the current timing method is used.".into(),
                 self.settings.timing_method.into(),
             ),
             Field::new(
@@ -345,7 +345,7 @@ impl Component {
             ),
             Field::new(
                 "Digits Format".into(),
-                "Determines how many digits are to always be shown. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
+                "Specifies how many digits to show. If the duration is lower than the digits to be shown, zeros are shown instead.".into(),
                 self.settings.digits_format.into(),
             ),
             Field::new(

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -103,7 +103,7 @@ pub struct Settings {
     pub digits_format: DigitsFormat,
     /// The accuracy of the time shown.
     pub accuracy: Accuracy,
-    /// Specifies whether to show the how much time has passed since the start
+    /// Specifies whether to show how much time has passed since the start
     /// current segment, rather than how much time has passed since the start of
     /// the current attempt.
     pub is_segment_timer: bool,
@@ -313,17 +313,46 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component. It is also possible to apply the color associated with the time ahead or behind as the background color.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Segment Timer".into(),
+                "Specifies whether to show how much time has passed since the start current segment, rather than how much time has passed since the start of the current attempt.".into(),
                 self.settings.is_segment_timer.into(),
             ),
-            Field::new("Timing Method".into(), self.settings.timing_method.into()),
-            Field::new("Height".into(), u64::from(self.settings.height).into()),
-            Field::new("Text Color".into(), self.settings.color_override.into()),
-            Field::new("Show Gradient".into(), self.settings.show_gradient.into()),
-            Field::new("Digits Format".into(), self.settings.digits_format.into()),
-            Field::new("Accuracy".into(), self.settings.accuracy.into()),
+            Field::new(
+                "Timing Method".into(),
+                "Specifies the timing method to use. If not specified, the current timing method of the timer is used for showing the time.".into(),
+                self.settings.timing_method.into(),
+            ),
+            Field::new(
+                "Height".into(),
+                "The height of the timer.".into(),
+                u64::from(self.settings.height).into(),
+            ),
+            Field::new(
+                "Text Color".into(),
+                "The color of the time shown. If not specified, the color is automatically chosen based on how well the current attempt is going. Those colors can be specified in the general settings for the layout.".into(),
+                self.settings.color_override.into(),
+            ),
+            Field::new(
+                "Show Gradient".into(),
+                "Determines whether to display the timer's color as a gradient.".into(),
+                self.settings.show_gradient.into(),
+            ),
+            Field::new(
+                "Digits Format".into(),
+                "Determines how many digits are to always be shown. If the duration is lower than the digits to be shown, they are filled up with zeros.".into(),
+                self.settings.digits_format.into(),
+            ),
+            Field::new(
+                "Accuracy".into(),
+                "The accuracy of the time shown.".into(),
+                self.settings.accuracy.into(),
+            ),
         ])
     }
 

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -379,13 +379,13 @@ impl Component {
             ),
             Field::new(
                 "Show Finished Runs Count".into(),
-                "Specifies whether the amount of successfully finished attempts should be shown."
+                "Specifies whether the number of successfully finished attempts should be shown."
                     .into(),
                 self.settings.show_finished_runs_count.into(),
             ),
             Field::new(
                 "Show Attempt Count".into(),
-                "Specifies whether the total amount of attempts should be shown.".into(),
+                "Specifies whether the total number of attempts should be shown.".into(),
                 self.settings.show_attempt_count.into(),
             ),
             Field::new(
@@ -401,25 +401,25 @@ impl Component {
             ),
             Field::new(
                 "Display Game Icon".into(),
-                "Specifies whether the game's icon should be shown, in case there is a game icon stored in the splits."
+                "Specifies whether the game's icon should be shown, if there is a game icon stored in the splits."
                     .into(),
                 self.settings.display_game_icon.into(),
             ),
             Field::new(
                 "Show Region".into(),
-                "The category name can be extended by additional information. This extends it by the game's region, if it is provided in the variables tab of the splits editor."
+                "The category name can be extended with additional information. This extends it with the game's region, if it is provided in the variables tab of the splits editor."
                     .into(),
                 self.settings.show_region.into(),
             ),
             Field::new(
                 "Show Platform".into(),
-                "The category name can be extended by additional information. This extends it by the platform the game is being played on, if it is provided in the variables tab of the splits editor."
+                "The category name can be extended with additional information. This extends it with the platform the game is being played on, if it is provided in the variables tab of the splits editor."
                     .into(),
                 self.settings.show_platform.into(),
             ),
             Field::new(
                 "Show Variables".into(),
-                "The category name can be extended by additional information. This extends it by additional variables provided in the variables tab of the splits editor. This refers to speedrun.com variables, not custom variables."
+                "The category name can be extended with additional information. This extends it with additional variables provided in the variables tab of the splits editor. This refers to speedrun.com variables, not custom variables."
                     .into(),
                 self.settings.show_variables.into(),
             ),

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -354,33 +354,75 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
-            Field::new("Text Color".into(), self.settings.text_color.into()),
-            Field::new("Show Game Name".into(), self.settings.show_game_name.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
+            Field::new(
+                "Text Color".into(),
+                "The color of the title text. If no color is specified, the color is taken from the layout."
+                    .into(),
+                self.settings.text_color.into(),
+            ),
+            Field::new(
+                "Show Game Name".into(),
+                "Specifies whether the game name should be part of the title that is being shown."
+                    .into(),
+                self.settings.show_game_name.into(),
+            ),
             Field::new(
                 "Show Category Name".into(),
+                "Specifies whether the category name should be part of the title that is being shown."
+                    .into(),
                 self.settings.show_category_name.into(),
             ),
             Field::new(
                 "Show Finished Runs Count".into(),
+                "Specifies whether the amount of successfully finished attempts should be shown."
+                    .into(),
                 self.settings.show_finished_runs_count.into(),
             ),
             Field::new(
                 "Show Attempt Count".into(),
+                "Specifies whether the total amount of attempts should be shown.".into(),
                 self.settings.show_attempt_count.into(),
             ),
-            Field::new("Text Alignment".into(), self.settings.text_alignment.into()),
+            Field::new(
+                "Text Alignment".into(),
+                "Specifies the alignment of the title.".into(),
+                self.settings.text_alignment.into(),
+            ),
             Field::new(
                 "Display Text as Single Line".into(),
+                "Specifies if the title should be shown as a single line, instead of being separated into one line for the game name and one for the category name."
+                    .into(),
                 self.settings.display_as_single_line.into(),
             ),
             Field::new(
                 "Display Game Icon".into(),
+                "Specifies whether the game's icon should be shown, in case there is a game icon stored in the splits."
+                    .into(),
                 self.settings.display_game_icon.into(),
             ),
-            Field::new("Show Region".into(), self.settings.show_region.into()),
-            Field::new("Show Platform".into(), self.settings.show_platform.into()),
-            Field::new("Show Variables".into(), self.settings.show_variables.into()),
+            Field::new(
+                "Show Region".into(),
+                "The category name can be extended by additional information. This extends it by the game's region, if it is provided in the variables tab of the splits editor."
+                    .into(),
+                self.settings.show_region.into(),
+            ),
+            Field::new(
+                "Show Platform".into(),
+                "The category name can be extended by additional information. This extends it by the platform the game is being played on, if it is provided in the variables tab of the splits editor."
+                    .into(),
+                self.settings.show_platform.into(),
+            ),
+            Field::new(
+                "Show Variables".into(),
+                "The category name can be extended by additional information. This extends it by additional variables provided in the variables tab of the splits editor. This refers to speedrun.com variables, not custom variables."
+                    .into(),
+                self.settings.show_variables.into(),
+            ),
         ])
     }
 

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -117,14 +117,31 @@ impl Component {
     /// component and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Background".into(), self.settings.background.into()),
+            Field::new(
+                "Background".into(),
+                "The background shown behind the component.".into(),
+                self.settings.background.into(),
+            ),
             Field::new(
                 "Display 2 Rows".into(),
+                "Specifies whether to display the name of the component and the total playtime in two separate rows.".into(),
                 self.settings.display_two_rows.into(),
             ),
-            Field::new("Show Days (>24h)".into(), self.settings.show_days.into()),
-            Field::new("Label Color".into(), self.settings.label_color.into()),
-            Field::new("Value Color".into(), self.settings.value_color.into()),
+            Field::new(
+                "Show Days (>24h)".into(),
+                "Specifies whether to show the amount of days, when the total playtime reaches 24 hours or more.".into(),
+                self.settings.show_days.into(),
+            ),
+            Field::new(
+                "Label Color".into(),
+                "The color of the component's name. If not specified, the color is taken from the layout.".into(),
+                self.settings.label_color.into(),
+            ),
+            Field::new(
+                "Value Color".into(),
+                "The color of the total playtime. If not specified, the color is taken from the layout.".into(),
+                self.settings.value_color.into(),
+            ),
         ])
     }
 

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -129,7 +129,7 @@ impl Component {
             ),
             Field::new(
                 "Show Days (>24h)".into(),
-                "Specifies whether to show the amount of days, when the total playtime reaches 24 hours or more.".into(),
+                "Specifies whether to show the number of days, when the total playtime reaches 24 hours or more.".into(),
                 self.settings.show_days.into(),
             ),
             Field::new(

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -19,8 +19,8 @@ pub struct HotkeyConfig {
     pub undo: Option<Hotkey>,
     /// The key to use for skipping the current split.
     pub skip: Option<Hotkey>,
-    /// The key to use for pausing the current attempt and starting a new
-    /// attempt.
+    /// The key to use for pausing the current attempt. It can also be used for
+    /// starting a new attempt.
     pub pause: Option<Hotkey>,
     /// The key to use for removing all the pause times from the current time.
     pub undo_all_pauses: Option<Hotkey>,
@@ -55,19 +55,49 @@ impl HotkeyConfig {
     /// configuration and their current values.
     pub fn settings_description(&self) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Start / Split".into(), self.split.into()),
-            Field::new("Reset".into(), self.reset.into()),
-            Field::new("Undo Split".into(), self.undo.into()),
-            Field::new("Skip Split".into(), self.skip.into()),
-            Field::new("Pause".into(), self.pause.into()),
-            Field::new("Undo All Pauses".into(), self.undo_all_pauses.into()),
+            Field::new(
+                "Start / Split".into(),
+                "The hotkey to use for splitting and starting a new attempt.".into(),
+                self.split.into(),
+            ),
+            Field::new(
+                "Reset".into(),
+                "The hotkey to use for resetting the current attempt.".into(),
+                self.reset.into(),
+            ),
+            Field::new(
+                "Undo Split".into(),
+                "The hotkey to use for undoing the last split.".into(),
+                self.undo.into(),
+            ),
+            Field::new(
+                "Skip Split".into(),
+                "The hotkey to use for skipping the current split.".into(),
+                self.skip.into(),
+            ),
+            Field::new(
+                "Pause".into(),
+                "The hotkey to use for pausing the current attempt. It can also be used for starting a new attempt.".into(),
+                self.pause.into(),
+            ),
+            Field::new(
+                "Undo All Pauses".into(),
+                "The hotkey to use for removing all the pause times from the current time. This is useful in case you accidentally paused and want to undo it.".into(),
+                self.undo_all_pauses.into(),
+            ),
             Field::new(
                 "Previous Comparison".into(),
+                "The hotkey to use for switching to the previous comparison.".into(),
                 self.previous_comparison.into(),
             ),
-            Field::new("Next Comparison".into(), self.next_comparison.into()),
+            Field::new(
+                "Next Comparison".into(),
+                "The hotkey to use for switching to the next comparison.".into(),
+                self.next_comparison.into(),
+            ),
             Field::new(
                 "Toggle Timing Method".into(),
+                r#"The key to use for toggling between the "Real Time" and "Game Time" timing methods."#.into(),
                 self.toggle_timing_method.into(),
             ),
         ])

--- a/src/hotkey_config.rs
+++ b/src/hotkey_config.rs
@@ -97,7 +97,7 @@ impl HotkeyConfig {
             ),
             Field::new(
                 "Toggle Timing Method".into(),
-                r#"The key to use for toggling between the "Real Time" and "Game Time" timing methods."#.into(),
+                r#"The hotkey to use for toggling between the "Real Time" and "Game Time" timing methods."#.into(),
                 self.toggle_timing_method.into(),
             ),
         ])

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -86,37 +86,93 @@ impl GeneralSettings {
     /// cache.
     pub fn settings_description(&self, image_cache: &mut ImageCache) -> SettingsDescription {
         SettingsDescription::with_fields(vec![
-            Field::new("Layout Direction".into(), self.direction.into()),
-            Field::new("Custom Timer Font".into(), self.timer_font.clone().into()),
-            Field::new("Custom Times Font".into(), self.times_font.clone().into()),
-            Field::new("Custom Text Font".into(), self.text_font.clone().into()),
+            Field::new(
+                "Layout Direction".into(),
+                "The direction in which the components are laid out.".into(),
+                self.direction.into(),
+            ),
+            Field::new(
+                "Custom Timer Font".into(),
+                "Allows you to specify a custom font for the timer. If this is not set, the default font is used."
+                    .into(),
+                self.timer_font.clone().into(),
+            ),
+            Field::new(
+                "Custom Times Font".into(),
+                "Allows you to specify a custom font for the times. If this is not set, the default font is used."
+                    .into(),
+                self.times_font.clone().into(),
+            ),
+            Field::new(
+                "Custom Text Font".into(),
+                "Allows you to specify a custom font for the text. If this is not set, the default font is used."
+                    .into(),
+                self.text_font.clone().into(),
+            ),
             Field::new(
                 "Background".into(),
+                "The background shown behind the entire layout.".into(),
                 self.background.cache(image_cache).into(),
             ),
-            Field::new("Best Segment".into(), self.best_segment_color.into()),
+            Field::new(
+                "Best Segment".into(),
+                "The color to use for when you achieve a new best segment.".into(),
+                self.best_segment_color.into(),
+            ),
             Field::new(
                 "Ahead (Gaining Time)".into(),
+                "The color to use for when you are ahead of the comparison and are gaining even more time."
+                    .into(),
                 self.ahead_gaining_time_color.into(),
             ),
             Field::new(
                 "Ahead (Losing Time)".into(),
+                "The color to use for when you are ahead of the comparison, but are losing time."
+                    .into(),
                 self.ahead_losing_time_color.into(),
             ),
             Field::new(
                 "Behind (Gaining Time)".into(),
+                "The color to use for when you are behind the comparison, but are gaining back time."
+                    .into(),
                 self.behind_gaining_time_color.into(),
             ),
             Field::new(
                 "Behind (Losing Time)".into(),
+                "The color to use for when you are behind the comparison and are losing even more time."
+                    .into(),
                 self.behind_losing_time_color.into(),
             ),
-            Field::new("Not Running".into(), self.not_running_color.into()),
-            Field::new("Personal Best".into(), self.personal_best_color.into()),
-            Field::new("Paused".into(), self.paused_color.into()),
-            Field::new("Thin Separators".into(), self.thin_separators_color.into()),
-            Field::new("Separators".into(), self.separators_color.into()),
-            Field::new("Text".into(), self.text_color.into()),
+            Field::new(
+                "Not Running".into(),
+                "The color to use for when there is no active attempt.".into(),
+                self.not_running_color.into(),
+            ),
+            Field::new(
+                "Personal Best".into(),
+                "The color to use for when you achieve a new Personal Best.".into(),
+                self.personal_best_color.into(),
+            ),
+            Field::new(
+                "Paused".into(),
+                "The color to use for when the timer is paused.".into(),
+                self.paused_color.into(),
+            ),
+            Field::new(
+                "Thin Separators".into(),
+                "The color of thin separators.".into(),
+                self.thin_separators_color.into(),
+            ),
+            Field::new(
+                "Separators".into(),
+                "The color of normal separators.".into(),
+                self.separators_color.into(),
+            ),
+            Field::new(
+                "Text".into(),
+                "The color of the text that doesn't specify its own color.".into(),
+                self.text_color.into(),
+            ),
         ])
     }
 

--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -170,7 +170,7 @@ impl GeneralSettings {
             ),
             Field::new(
                 "Text".into(),
-                "The color of the text that doesn't specify its own color.".into(),
+                "The color to use for text that doesn't specify its own color.".into(),
                 self.text_color.into(),
             ),
         ])

--- a/src/settings/field.rs
+++ b/src/settings/field.rs
@@ -1,19 +1,25 @@
 use super::Value;
-use crate::platform::prelude::*;
+use alloc::borrow::Cow;
 use serde_derive::{Deserialize, Serialize};
 
 /// A Field describes a single setting by its name and its current value.
 #[derive(Serialize, Deserialize)]
 pub struct Field {
     /// The name of the setting.
-    pub text: String,
+    pub text: Cow<'static, str>,
+    /// The tooltip to show for the setting.
+    pub tooltip: Cow<'static, str>,
     /// The current value of the setting.
     pub value: Value,
 }
 
 impl Field {
     /// Creates a new field.
-    pub const fn new(text: String, value: Value) -> Self {
-        Self { text, value }
+    pub const fn new(text: Cow<'static, str>, tooltip: Cow<'static, str>, value: Value) -> Self {
+        Self {
+            text,
+            tooltip,
+            value,
+        }
     }
 }


### PR DESCRIPTION
This adds tooltips to all settings exposed by `livesplit-core`. Copilot helped a lot here.

cc #800 