### PR TITLE
Add a timeout message

### DIFF
--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -952,6 +952,8 @@ fn watchdog<T: event::CommandSink + TimerQuery + Send>(shared_state: Arc<SharedS
                     if let Some(auto_splitter) = &*shared_state.auto_splitter.load() {
                         auto_splitter.interrupt_handle().interrupt();
                     }
+                } else {
+                    has_timed_out = false;
                 }
 
                 new_state


### PR DESCRIPTION
To distinguish between errors where an auto-splitter update took too long, from other errors, such as panics, running out of stack space, etc.