### PR TITLE
Expose all the comparisons in the C API

### DIFF
--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -279,6 +279,25 @@ pub extern "C" fn Run_custom_comparison(this: &Run, index: usize) -> *const c_ch
     output_str(&this.custom_comparisons()[index])
 }
 
+/// Returns the amount of total comparisons stored in this Run.
+#[no_mangle]
+pub extern "C" fn Run_comparisons_len(this: &Run) -> usize {
+    this.custom_comparisons().len() + this.comparison_generators().len()
+}
+
+/// Accesses a comparison stored in this Run by its index. This includes both
+/// custom comparisons as well as all the Comparison Generators. You may not
+/// provide an out of bounds index.
+#[no_mangle]
+pub extern "C" fn Run_comparison(this: &Run, index: usize) -> *const c_char {
+    let custom_len = this.custom_comparisons().len();
+    output_str(if index < custom_len {
+        &this.custom_comparisons()[index]
+    } else {
+        this.comparison_generators()[index - custom_len].name()
+    })
+}
+
 /// Accesses the Auto Splitter Settings that are encoded as XML.
 #[no_mangle]
 pub extern "C" fn Run_auto_splitter_settings(this: &Run) -> *const c_char {

--- a/capi/src/timer.rs
+++ b/capi/src/timer.rs
@@ -217,6 +217,16 @@ pub extern "C" fn Timer_current_comparison(this: &Timer) -> *const c_char {
     output_str(this.current_comparison())
 }
 
+/// Tries to set the current comparison to the comparison specified. If the
+/// comparison doesn't exist <FALSE> is returned.
+#[no_mangle]
+pub unsafe extern "C" fn Timer_set_current_comparison(
+    this: &mut Timer,
+    comparison: *const c_char,
+) -> bool {
+    this.set_current_comparison(str(comparison)).is_ok()
+}
+
 /// Switches the current comparison to the next comparison in the list.
 #[no_mangle]
 pub extern "C" fn Timer_switch_to_next_comparison(this: &mut Timer) {


### PR DESCRIPTION
This exposes all the comparisons in the C API and makes it possible to set the comparison via a string. This will enable LiveSplit One to show a list of comparisons to choose from.