### PR TITLE
Allow copying comparisons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ libc = { version = "0.2.101", optional = true }
 seahash = "4.1.0"
 
 [target.'cfg(windows)'.dev-dependencies]
-sysinfo = { version = "0.30.0", default-features = false }
+winreg = "0.52.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = "0.5.0"

--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -352,7 +352,7 @@ pub unsafe extern "C" fn RunEditor_active_parse_and_set_comparison_time(
 }
 
 /// Adds a new custom comparison. It can't be added if it starts with
-/// `[Race]` or already exists.
+/// `[Race]` or it already exists.
 #[no_mangle]
 pub unsafe extern "C" fn RunEditor_add_comparison(
     this: &mut RunEditor,
@@ -423,6 +423,18 @@ pub unsafe extern "C" fn RunEditor_parse_and_generate_goal_comparison(
     time: *const c_char,
 ) -> bool {
     this.parse_and_generate_goal_comparison(str(time)).is_ok()
+}
+
+/// Copies a comparison with the given name as a new custom comparison with the
+/// new name provided. It can't be added if it starts with `[Race]` or it
+/// already exists. The old comparison needs to exist.
+#[no_mangle]
+pub unsafe extern "C" fn RunEditor_copy_comparison(
+    this: &mut RunEditor,
+    old_name: *const c_char,
+    new_name: *const c_char,
+) -> bool {
+    this.copy_comparison(str(old_name), str(new_name)).is_ok()
 }
 
 /// Clears out the Attempt History and the Segment Histories of all the

--- a/src/comparison/latest_run.rs
+++ b/src/comparison/latest_run.rs
@@ -27,7 +27,7 @@ pub const NAME: &str = "Latest Run";
 
 fn generate(segments: &mut [Segment], method: TimingMethod) {
     let mut attempt_id = None;
-    for segment in segments.iter_mut().rev() {
+    for segment in segments.iter().rev() {
         if let Some(max_index) = segment.segment_history().try_get_max_index() {
             attempt_id = Some(max_index);
             break;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -90,17 +90,26 @@ impl PartialEq for ComparisonGenerators {
     }
 }
 
-/// Error type for an invalid comparison name
+/// Error type for an invalid comparison name to be added.
 #[derive(PartialEq, Eq, Debug, snafu::Snafu)]
-pub enum ComparisonError {
+pub enum AddComparisonError {
     /// Comparison name starts with "\[Race\]".
     NameStartsWithRace,
     /// Comparison name is a duplicate.
     DuplicateName,
 }
 
-/// Result type for an invalid comparison name
-pub type ComparisonResult<T> = Result<T, ComparisonError>;
+/// Error type for copying a comparison.
+#[derive(PartialEq, Eq, Debug, snafu::Snafu)]
+pub enum CopyComparisonError {
+    /// There is no comparison with the provided name to copy.
+    NoSuchComparison,
+    /// The new comparison could not be added.
+    AddComparison {
+        /// The underlying error.
+        source: AddComparisonError,
+    },
+}
 
 impl Run {
     /// Creates a new Run object with no segments.
@@ -443,7 +452,7 @@ impl Run {
     /// Adds a new custom comparison. If a custom comparison with that name
     /// already exists, it is not added.
     #[inline]
-    pub fn add_custom_comparison<S>(&mut self, comparison: S) -> ComparisonResult<()>
+    pub fn add_custom_comparison<S>(&mut self, comparison: S) -> Result<(), AddComparisonError>
     where
         S: PopulateString,
     {
@@ -756,11 +765,11 @@ impl Run {
 
     /// Checks a given name against the current comparisons in the Run to
     /// ensure that it is valid for use.
-    pub fn validate_comparison_name(&self, new: &str) -> ComparisonResult<()> {
+    pub fn validate_comparison_name(&self, new: &str) -> Result<(), AddComparisonError> {
         if new.starts_with(RACE_COMPARISON_PREFIX) {
-            Err(ComparisonError::NameStartsWithRace)
+            Err(AddComparisonError::NameStartsWithRace)
         } else if self.comparisons().any(|c| c == new) {
-            Err(ComparisonError::DuplicateName)
+            Err(AddComparisonError::DuplicateName)
         } else {
             Ok(())
         }

--- a/src/run/parser/livesplit.rs
+++ b/src/run/parser/livesplit.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     platform::prelude::*,
-    run::{ComparisonError, LinkedLayout},
+    run::{AddComparisonError, LinkedLayout},
     settings::Image,
     util::{
         ascii_char::AsciiChar,
@@ -52,7 +52,7 @@ pub enum Error {
     /// Parsed comparison has an invalid name.
     InvalidComparisonName {
         /// The underlying error.
-        source: ComparisonError,
+        source: AddComparisonError,
     },
     /// Failed to parse a boolean.
     ParseBool,
@@ -82,8 +82,8 @@ impl From<crate::timing::ParseError> for Error {
     }
 }
 
-impl From<ComparisonError> for Error {
-    fn from(source: ComparisonError) -> Self {
+impl From<AddComparisonError> for Error {
+    fn from(source: AddComparisonError) -> Self {
         Self::InvalidComparisonName { source }
     }
 }
@@ -295,10 +295,10 @@ fn parse_segment(
                         } else {
                             time_old(reader, |t| *segment.comparison_mut(&comparison) = t)?;
                         }
-                        if let Err(ComparisonError::NameStartsWithRace) =
+                        if let Err(AddComparisonError::NameStartsWithRace) =
                             run.add_custom_comparison(comparison)
                         {
-                            return Err(ComparisonError::NameStartsWithRace.into());
+                            return Err(AddComparisonError::NameStartsWithRace.into());
                         }
                         Ok(())
                     } else {

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -1,6 +1,6 @@
 //! Provides the parser for Time Split Tracker splits files.
 
-use super::super::ComparisonError;
+use super::super::AddComparisonError;
 use crate::{
     comparison::RACE_COMPARISON_PREFIX,
     platform::{path::Path, prelude::*},
@@ -124,13 +124,13 @@ pub fn parse(
         loop {
             match run.add_custom_comparison(&**comparison) {
                 Ok(_) => break,
-                Err(ComparisonError::DuplicateName) => {
+                Err(AddComparisonError::DuplicateName) => {
                     let comparison = comparison.to_mut();
                     comparison.drain(orig_len..);
                     let _ = write!(comparison, " {number}");
                     number += 1;
                 }
-                Err(ComparisonError::NameStartsWithRace) => {
+                Err(AddComparisonError::NameStartsWithRace) => {
                     let comparison = comparison.to_mut();
                     // After removing the `[Race]`, there might be some
                     // whitespace we want to trim too.

--- a/src/run/tests/comparison.rs
+++ b/src/run/tests/comparison.rs
@@ -1,4 +1,4 @@
-use crate::run::{ComparisonError, Run};
+use crate::run::{AddComparisonError, Run};
 
 #[test]
 fn adding_a_new_comparison_works() {
@@ -11,5 +11,5 @@ fn adding_a_new_comparison_works() {
 fn adding_a_duplicate_fails() {
     let mut run = Run::new();
     let c = run.add_custom_comparison("Best Segments");
-    assert_eq!(c, Err(ComparisonError::DuplicateName));
+    assert_eq!(c, Err(AddComparisonError::DuplicateName));
 }

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -60,13 +60,18 @@ fn default() {
 #[cfg(all(feature = "font-loading", windows))]
 #[test]
 fn font_fallback() {
-    let build_number: u64 = sysinfo::System::kernel_version().unwrap().parse().unwrap();
+    let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
+    let cur_ver = hklm
+        .open_subkey(r"SOFTWARE\Microsoft\Windows NT\CurrentVersion")
+        .unwrap();
+    let build_number: String = cur_ver.get_value("CurrentBuildNumber").unwrap();
+    let build_number: u64 = build_number.parse().unwrap();
+    let revision: u32 = cur_ver.get_value("UBR").unwrap();
 
-    if build_number < 22000 {
-        // The hash is different before Windows 11.
+    if (build_number, revision) < (22631, 3672) {
+        // The hash is different before Windows 11 23H2 (end of May 2024 update).
         println!(
-            "Skipping font fallback test on Windows with build number {}.",
-            build_number
+            "Skipping font fallback test on Windows with build number {build_number}.{revision}.",
         );
         return;
     }
@@ -122,8 +127,8 @@ fn font_fallback() {
     check(
         &state,
         &image_cache,
-        "d908fda633352ba5",
-        "299f188d2a8ccf5d",
+        "e3c55d333d082bab",
+        "267615d875c8cf61",
         "font_fallback",
     );
 }


### PR DESCRIPTION
This adds functionality to the run editor to allow copying comparisons. This is not only useful for copying custom comparisons, but also for "baking" the times of a generated comparison, such as the `Latest Run` or the `Average Segments` to a custom comparison that you can keep around as long as you want. This is somewhat also meant to replace the functionality of storing the current run as a Personal Best. Instead you can just store the `Latest Run` as a custom comparison after you are done with it.