### PR TITLE
Add a fallback for the time tracking in the web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 ]
 edition = "2021"
 resolver = "2"
-rust-version = "1.71"
+rust-version = "1.73"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -104,7 +104,9 @@ js-sys = { version = "0.3.55", optional = true }
 wasm-bindgen = { version = "0.2.78", optional = true }
 wasm-bindgen-futures = { version = "0.4.28", optional = true }
 web-sys = { version = "0.3.28", default-features = false, features = [
+    "Document",
     "Performance",
+    "VisibilityState",
     "Window",
 ], optional = true }
 


### PR DESCRIPTION
Every browser's `performance.now()` implementation is not spec compliant, unless the browser is running on Windows. On every other operating system, `performance.now()` does not properly keep ticking while the operating system is suspended / sleeping. There isn't much that we can do. What we can do is we calculate the initial difference between `performance.now()` and `Date.now()` and store it in a thread local. Later, when the phone gets locked, `performance.now()` starts to break. However, we can detect when the phone gets unlocked again by listening to the `visibilitychange` event. This is where we can update the difference again. This of course isn't ideal, as `Date.now()` gets adjusted by NTP synchronizations, but it's the best we can do.

More information:
https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#ticking_during_sleep