### PR TITLE
Increase PNG compression level

### DIFF
--- a/src/run/parser/llanfair.rs
+++ b/src/run/parser/llanfair.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use core::{result::Result as StdResult, str};
 #[cfg(feature = "std")]
-use image::{codecs::png, ExtendedColorType, ImageBuffer, ImageEncoder, Rgba};
+use image::{ExtendedColorType, ImageBuffer, ImageEncoder, Rgba};
 use snafu::{OptionExt, ResultExt};
 
 /// The Error type for splits files that couldn't be parsed by the Llanfair
@@ -187,7 +187,7 @@ pub fn parse(source: &[u8]) -> Result<Run> {
             #[cfg(feature = "std")]
             if let Some(image) = ImageBuffer::<Rgba<u8>, _>::from_raw(width, height, _image_data) {
                 buf.clear();
-                if png::PngEncoder::new(&mut buf)
+                if crate::util::image::create_reencoder(&mut buf)
                     .write_image(image.as_ref(), width, height, ExtendedColorType::Rgba8)
                     .is_ok()
                 {

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -18,7 +18,7 @@ use crate::{
     RealTime, Run, Segment, Time, TimeSpan,
 };
 #[cfg(feature = "std")]
-use image::{codecs::png, ExtendedColorType, ImageEncoder};
+use image::{ExtendedColorType, ImageEncoder};
 #[cfg(feature = "std")]
 use snafu::OptionExt;
 
@@ -123,7 +123,7 @@ where
         })?;
 
         png_buf.clear();
-        png::PngEncoder::new(&mut *png_buf)
+        crate::util::image::create_reencoder(&mut *png_buf)
             .write_image(image, width, height, ExtendedColorType::Rgba8)
             .map_err(|_| Error::Image)?;
 

--- a/src/settings/image/shrinking.rs
+++ b/src/settings/image/shrinking.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use image::{guess_format, load_from_memory_with_format, ImageEncoder, ImageFormat};
 
-use crate::util::image::get_dimensions;
+use crate::util::image::{create_reencoder, get_dimensions};
 
 fn shrink_inner(data: &[u8], max_dim: u32) -> Option<Cow<'_, [u8]>> {
     let format = guess_format(data).ok()?;
@@ -27,8 +27,10 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Option<Cow<'_, [u8]>> {
         if is_too_large {
             image = image.thumbnail(max_dim, max_dim);
         }
+
         let mut data = Vec::new();
-        image::codecs::png::PngEncoder::new(&mut data)
+
+        create_reencoder(&mut data)
             .write_image(
                 image.as_bytes(),
                 image.width(),
@@ -36,6 +38,7 @@ fn shrink_inner(data: &[u8], max_dim: u32) -> Option<Cow<'_, [u8]>> {
                 image.color().into(),
             )
             .ok()?;
+
         data.into()
     } else {
         data.into()

--- a/src/util/image.rs
+++ b/src/util/image.rs
@@ -1,14 +1,21 @@
-use std::io::Cursor;
+use image::codecs::png::{CompressionType, FilterType, PngEncoder};
 
-use bytemuck_derive::{Pod, Zeroable};
-use image::{
-    codecs::{bmp, farbfeld, hdr, ico, jpeg, pnm, tga, tiff, webp},
-    ImageDecoder, ImageFormat,
-};
+pub fn create_reencoder(target_buf: &mut Vec<u8>) -> PngEncoder<&mut Vec<u8>> {
+    PngEncoder::new_with_quality(target_buf, CompressionType::Best, FilterType::default())
+}
 
-use crate::util::byte_parsing::{big_endian::U32, strip_pod};
+#[cfg(any(feature = "image-shrinking", feature = "svg-rendering"))]
+pub fn get_dimensions(format: image::ImageFormat, data: &[u8]) -> Option<(u32, u32)> {
+    use std::io::Cursor;
 
-pub fn get_dimensions(format: ImageFormat, data: &[u8]) -> Option<(u32, u32)> {
+    use bytemuck_derive::{Pod, Zeroable};
+    use image::{
+        codecs::{bmp, farbfeld, hdr, ico, jpeg, pnm, tga, tiff, webp},
+        ImageDecoder, ImageFormat,
+    };
+
+    use crate::util::byte_parsing::{big_endian::U32, strip_pod};
+
     Some(match format {
         ImageFormat::Png => {
             // We encounter a lot of PNG images in splits files and decoding

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod ascii_set;
 pub(crate) mod byte_parsing;
 pub(crate) mod caseless;
 mod clear_vec;
-#[cfg(any(feature = "image-shrinking", feature = "svg-rendering"))]
+#[cfg(feature = "std")]
 pub(crate) mod image;
 pub(crate) mod not_nan;
 pub mod ordered_map;

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -217,7 +217,7 @@ fn all_components() {
         &image_cache,
         [300, 800],
         "7e7aa83a3b80e1da",
-        "39b5d1923053c5d9",
+        "fa3c0357219389d8",
         "all_components",
     );
 
@@ -226,7 +226,7 @@ fn all_components() {
         &image_cache,
         [150, 800],
         "97afa51bfd8a8597",
-        "82b26ae781d58b78",
+        "eda169eec3995eeb",
         "all_components_thin",
     );
 }
@@ -271,7 +271,7 @@ fn dark_layout() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         "a47c590792c1bab5",
-        "3f8dfb2da2d43648",
+        "91a89f563eb4f43d",
         "dark_layout",
     );
 }


### PR DESCRIPTION
This commit increases the compression level for when we encode PNG images. We do this for Llanfair files (Gered and original) were the images are uncompressed and also for when we encounter BMP images in LiveSplit files or we scale down images. Increasing the compression level doesn't seem to really take much more time, but has a decent impact on the size of the images.