### PR TITLE
Prevent `TimeStamp`s from being modified

### DIFF
--- a/src/platform/no_std/time.rs
+++ b/src/platform/no_std/time.rs
@@ -53,14 +53,6 @@ impl Instant {
     }
 }
 
-impl Sub<Duration> for Instant {
-    type Output = Instant;
-
-    fn sub(self, rhs: Duration) -> Instant {
-        Self(self.0 - rhs)
-    }
-}
-
 impl Sub for Instant {
     type Output = Duration;
 

--- a/src/platform/normal/mod.rs
+++ b/src/platform/normal/mod.rs
@@ -127,15 +127,6 @@ cfg_if::cfg_if! {
             }
         }
 
-        impl Sub<Duration> for Instant {
-            type Output = Instant;
-
-            #[inline]
-            fn sub(self, rhs: Duration) -> Instant {
-                Self(self.0 - rhs)
-            }
-        }
-
         impl Sub for Instant {
             type Output = Duration;
 
@@ -171,15 +162,6 @@ cfg_if::cfg_if! {
             }
         }
 
-        impl Sub<Duration> for Instant {
-            type Output = Instant;
-
-            #[inline]
-            fn sub(self, rhs: Duration) -> Instant {
-                Self((self.0 as i64 - i64::try_from(rhs.whole_nanoseconds()).unwrap()) as u64)
-            }
-        }
-
         impl Sub for Instant {
             type Output = Duration;
 
@@ -200,15 +182,6 @@ cfg_if::cfg_if! {
             #[inline]
             pub fn now() -> Self {
                 Self(std::time::Instant::now())
-            }
-        }
-
-        impl Sub<Duration> for Instant {
-            type Output = Instant;
-
-            #[inline]
-            fn sub(self, rhs: Duration) -> Instant {
-                Self(time::ext::InstantExt::sub_signed(self.0, rhs))
             }
         }
 

--- a/src/platform/wasm/unknown/time.rs
+++ b/src/platform/wasm/unknown/time.rs
@@ -41,14 +41,6 @@ impl Instant {
     }
 }
 
-impl Sub<Duration> for Instant {
-    type Output = Instant;
-
-    fn sub(self, rhs: Duration) -> Instant {
-        Self(self.0 - rhs)
-    }
-}
-
 impl Sub for Instant {
     type Output = Duration;
 

--- a/src/platform/wasm/web/time.rs
+++ b/src/platform/wasm/web/time.rs
@@ -81,14 +81,6 @@ impl Instant {
     }
 }
 
-impl Sub<Duration> for Instant {
-    type Output = Instant;
-
-    fn sub(self, rhs: Duration) -> Instant {
-        Self(self.0 - rhs)
-    }
-}
-
 impl Sub for Instant {
     type Output = Duration;
 

--- a/src/timing/time_stamp.rs
+++ b/src/timing/time_stamp.rs
@@ -1,7 +1,4 @@
-use crate::{
-    platform::{Duration, Instant},
-    TimeSpan,
-};
+use crate::{platform::Instant, TimeSpan};
 use core::ops::Sub;
 
 /// A `TimeStamp` stores a point in time that can be used to calculate a
@@ -24,14 +21,5 @@ impl Sub for TimeStamp {
     #[inline]
     fn sub(self, rhs: TimeStamp) -> TimeSpan {
         TimeSpan::from(self.0 - rhs.0)
-    }
-}
-
-impl Sub<TimeSpan> for TimeStamp {
-    type Output = TimeStamp;
-
-    #[inline]
-    fn sub(self, rhs: TimeSpan) -> TimeStamp {
-        TimeStamp(self.0 - Duration::from(rhs))
     }
 }

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -180,8 +180,8 @@ fn actual_split_file() {
     check(
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
-        "42b2292f5c884c17",
-        "1e4c66359bdc32e8",
+        "c1e9e757c15a35ae",
+        "4fe65a630b531c54",
         "actual_split_file",
     );
 }
@@ -228,8 +228,8 @@ fn timer_delta_background() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [250, 300],
-        "e96525c84aa77f66",
-        "bd8139d0f625af38",
+        "748fa26a41a8d5a3",
+        "8bae1351d0dd52d7",
         "timer_delta_background_stopped",
     );
 }

--- a/tests/run_files/livesplit1.0.lss
+++ b/tests/run_files/livesplit1.0.lss
@@ -3,7 +3,7 @@
   <GameIcon />
   <GameName>Pac-Man World 3</GameName>
   <CategoryName>Any%</CategoryName>
-  <Offset>00:00:00</Offset>
+  <Offset>12:34:56</Offset>
   <AttemptCount>3</AttemptCount>
   <RunHistory>
     <Time id="1">


### PR DESCRIPTION
Our `TimeStamp` type is internally an `Instant`. The representation of `Instant` depends on the platform, but for many platforms it internally consists of unsigned numbers. For WASI its worse, because the moment the WASI VM starts, the time starts at 0. This means any subtraction from the time results in a numeric underflow and might panic. To prevent this from happening, `TimeStamp`s can no longer be manually modified, they always represent valid points in time.