### PR TITLE
Fix resume_game_time: don't jump to real_time

### DIFF
--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -707,11 +707,12 @@ impl Timer {
     pub fn resume_game_time(&mut self) -> Result {
         let active_attempt = self.active_attempt.as_mut().ok_or(Error::NoRunInProgress)?;
 
-        if active_attempt.game_time_paused_at.take().is_some() {
+        if active_attempt.game_time_paused_at.is_some() {
             let current_time = active_attempt.current_time(&self.run);
 
             let diff = catch! { current_time.real_time - current_time.game_time? };
             active_attempt.set_loading_times(diff.unwrap_or_default(), &self.run);
+            active_attempt.game_time_paused_at.take();
 
             Ok(Event::GameTimeResumed)
         } else {

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -712,7 +712,7 @@ impl Timer {
 
             let diff = catch! { current_time.real_time - current_time.game_time? };
             active_attempt.set_loading_times(diff.unwrap_or_default(), &self.run);
-            active_attempt.game_time_paused_at.take();
+            active_attempt.game_time_paused_at = None;
 
             Ok(Event::GameTimeResumed)
         } else {

--- a/src/timing/timer/tests/events.rs
+++ b/src/timing/timer/tests/events.rs
@@ -807,13 +807,6 @@ mod resume_game_time {
         let event = timer.resume_game_time().unwrap();
 
         assert_eq!(event, Event::GameTimeResumed);
-
-        let time = timer
-            .active_attempt
-            .as_ref()
-            .unwrap()
-            .current_time(timer.run());
-        assert_ne!(time.game_time.unwrap(), time.real_time);
     }
 
     #[test]

--- a/src/timing/timer/tests/events.rs
+++ b/src/timing/timer/tests/events.rs
@@ -808,7 +808,11 @@ mod resume_game_time {
 
         assert_eq!(event, Event::GameTimeResumed);
 
-        let time = timer.active_attempt.as_ref().unwrap().current_time(timer.run());
+        let time = timer
+            .active_attempt
+            .as_ref()
+            .unwrap()
+            .current_time(timer.run());
         assert_ne!(time.game_time.unwrap(), time.real_time);
     }
 

--- a/src/timing/timer/tests/events.rs
+++ b/src/timing/timer/tests/events.rs
@@ -807,6 +807,9 @@ mod resume_game_time {
         let event = timer.resume_game_time().unwrap();
 
         assert_eq!(event, Event::GameTimeResumed);
+
+        let time = timer.active_attempt.as_ref().unwrap().current_time(timer.run());
+        assert_ne!(time.game_time.unwrap(), time.real_time);
     }
 
     #[test]

--- a/src/timing/timer/tests/mod.rs
+++ b/src/timing/timer/tests/mod.rs
@@ -673,3 +673,19 @@ fn skipping_keeps_timer_paused() {
     assert_eq!(timer.current_phase(), TimerPhase::Paused);
     assert_eq!(timer.current_split_index(), Some(0));
 }
+
+#[test]
+fn paused_then_resumed_game_time_lags_behind_real_time() {
+    let mut timer = timer();
+
+    timer.start().unwrap();
+    timer.pause_game_time().unwrap();
+    timer.resume_game_time().unwrap();
+
+    let time = timer
+        .active_attempt
+        .as_ref()
+        .unwrap()
+        .current_time(timer.run());
+    assert!(time.game_time.unwrap() < time.real_time);
+}


### PR DESCRIPTION
Fixes a bug in `resume_game_time` that caused the game time to jump forward to the real time after a pause and resume. Now, the game time resumes from the time it was paused at, as it should.

The test included in this PR fails if `active_attempt.game_time_paused_at = None;` is moved to the beginning of the `if` body, but passes with the PR as it is.