### PR TITLE
Added runtime_get current_tick

### DIFF
--- a/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
@@ -41,6 +41,19 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "runtime_set_tick_rate",
         })?
+        .func_wrap("env", "runtime_get_current_tick", {
+            |caller: Caller<'_, Context<T>>| -> u64 {
+                caller
+                    .data()
+                    .shared_data
+                    .current_tick
+                    .load(atomic::Ordering::Relaxed)
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "runtime_get_current_tick",
+        })?
         .func_wrap("env", "runtime_print_message", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);

--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -208,6 +208,7 @@ impl Default for Config {
 struct SharedData {
     settings_map: ArcSwap<IndexMap<Arc<str>, settings::Value>>,
     tick_rate: AtomicU64,
+    current_tick: AtomicU64,
 }
 
 struct ExclusiveData<T> {
@@ -244,6 +245,13 @@ impl<T: Timer> ExecutionGuard<'_, T> {
     /// time.
     pub fn update(&mut self) -> Result<()> {
         let data = &mut *self.data;
+
+        data.store
+            .data_mut()
+            .shared_data
+            .current_tick
+            .fetch_add(1, atomic::Ordering::Relaxed);
+
         if data.trapped {
             return Ok(());
         }
@@ -367,6 +375,7 @@ impl CompiledAutoSplitter {
         let shared_data = Arc::new(SharedData {
             settings_map: ArcSwap::new(settings_map.unwrap_or_default().values),
             tick_rate: AtomicU64::new(f64::to_bits(1.0 / 120.0)),
+            current_tick: AtomicU64::new(0),
         });
 
         let mut store = Store::new(


### PR DESCRIPTION
This adds a new tick field that increases by 1 at every call of the update function. This can be used for different purposes, eg. for caching data or to check (together with the current tick rate, albeit in an approximate way), the amount of time passed when executing code between iterations of the main autosplitting loop.