### PR TITLE
Fix panic when formatting `TimeStamp::MIN`

### DIFF
--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -70,7 +70,7 @@ impl Display for Inner {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {
                 f.write_str(MINUS)?;
-                ((-total_seconds) as u64, (-nanoseconds) as u32)
+                (total_seconds.wrapping_neg() as u64, (-nanoseconds) as u32)
             } else {
                 (total_seconds as u64, nanoseconds as u32)
             };
@@ -97,5 +97,144 @@ impl Display for Inner {
         } else {
             f.write_str(DASH)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn min() {
+        // This verifies that flipping the sign of the minimum value doesn't
+        // cause a panic.
+        let time = TimeSpan::from(crate::platform::Duration::MIN);
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "−2562047788015215:30:08");
+    }
+
+    #[test]
+    fn max() {
+        let time = TimeSpan::from(crate::platform::Duration::MAX);
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "2562047788015215:30:07");
+    }
+
+    #[test]
+    fn zero() {
+        let time = TimeSpan::zero();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "0:00");
+    }
+
+    #[test]
+    fn empty() {
+        let inner = Regular::new().format(None);
+        assert_eq!(inner.to_string(), "—");
+    }
+
+    #[test]
+    fn slightly_positive() {
+        let time = TimeSpan::from_str("0.000000001").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "0:00");
+
+        assert_eq!(
+            Regular::new()
+                .format(TimeSpan::from_seconds(0.5))
+                .to_string(),
+            "0:00"
+        );
+        assert_eq!(
+            Regular::new()
+                .format(TimeSpan::from_seconds(1.5))
+                .to_string(),
+            "0:01"
+        );
+    }
+
+    #[test]
+    fn slightly_negative() {
+        let time = TimeSpan::from_str("-0.000000001").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "−0:00");
+
+        assert_eq!(
+            Regular::new()
+                .format(TimeSpan::from_seconds(-1.5))
+                .to_string(),
+            "−0:01"
+        );
+        assert_eq!(
+            Regular::new()
+                .format(TimeSpan::from_seconds(-0.5))
+                .to_string(),
+            "−0:00"
+        );
+    }
+
+    #[test]
+    fn seconds() {
+        let time = TimeSpan::from_str("23.1234").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "0:23");
+    }
+
+    #[test]
+    fn minutes() {
+        let time = TimeSpan::from_str("12:34.987654321").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "12:34");
+    }
+
+    #[test]
+    fn hours() {
+        let time = TimeSpan::from_str("12:34:56.123456789").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "12:34:56");
+    }
+
+    #[test]
+    fn seconds_with_hundredths() {
+        let time = TimeSpan::from_str("23.1234").unwrap();
+        let inner = Regular::with_accuracy(Accuracy::Hundredths).format(Some(time));
+        assert_eq!(inner.to_string(), "0:23.12");
+    }
+
+    #[test]
+    fn minutes_with_hundredths() {
+        let time = TimeSpan::from_str("12:34.987654321").unwrap();
+        let inner = Regular::with_accuracy(Accuracy::Hundredths).format(Some(time));
+        assert_eq!(inner.to_string(), "12:34.98");
+    }
+
+    #[test]
+    fn hours_with_hundredths() {
+        let time = TimeSpan::from_str("12:34:56.123456789").unwrap();
+        let inner = Regular::with_accuracy(Accuracy::Hundredths).format(Some(time));
+        assert_eq!(inner.to_string(), "12:34:56.12");
+    }
+
+    #[test]
+    fn negative() {
+        let time = TimeSpan::from_str("-12:34:56.123456789").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "−12:34:56");
+    }
+
+    #[test]
+    fn days() {
+        let time = TimeSpan::from_str("2148:34:56.123456789").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "2148:34:56");
+    }
+
+    #[test]
+    fn negative_days() {
+        let time = TimeSpan::from_str("-2148:34:56.123456789").unwrap();
+        let inner = Regular::new().format(Some(time));
+        assert_eq!(inner.to_string(), "−2148:34:56");
     }
 }


### PR DESCRIPTION
In order to print the minus sign of times, we detect the need for the minus sign, print it and then print the absolute value of the time. However, integers have a minimum value of which the absolute value is larger than the maximum value of the integer. So for example `i8` has a minimum value of `-128` and a maximum value of `127`. The absolute value therefore can't be represented. This caused a panic when formatting `TimeStamp::MIN` when overflow checks are enabled, such as when compiling with the debug profile.

There was also a big lack of tests for the formatting of times. Tests are now included for all the important cases.