### PR TITLE
Update `hashbrown` to `0.15.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bytemuck_derive = { version = "1.4.1", default_features = false }
 cfg-if = "1.0.0"
 itoa = { version = "1.0.3", default-features = false }
 time = { version = "0.3.36", default-features = false }
-hashbrown = "0.14.0"
+hashbrown = "0.15.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.7.0", default-features = false }
 livesplit-title-abbreviations = { path = "crates/livesplit-title-abbreviations", version = "0.3.0" }
@@ -84,7 +84,7 @@ tiny-skia = { version = "0.11.1", default-features = false, features = [
 tiny-skia-path = { version = "0.11.1", default-features = false, optional = true }
 
 # SVG Rendering
-ahash = { version = "0.8.11", default-features = false, optional = true }
+foldhash = { version = "0.1.3", optional = true }
 
 # Networking
 splits-io-api = { version = "0.4.0", optional = true }
@@ -135,6 +135,7 @@ default = ["image-shrinking", "std"]
 std = [
     "base64-simd/detect",
     "base64-simd/std",
+    "foldhash?/std",
     "image",
     "libc",
     "livesplit-hotkey/std",
@@ -166,7 +167,7 @@ rendering = ["more-image-formats", "image?/gif"]
 default-text-engine = ["rendering", "cosmic-text"]
 font-loading = ["std", "default-text-engine"]
 software-rendering = ["default-text-engine", "tiny-skia", "tiny-skia-path"]
-svg-rendering = ["default-text-engine", "ahash"]
+svg-rendering = ["default-text-engine", "foldhash"]
 web-rendering = [
     "wasm-web",
     "rendering",

--- a/src/rendering/svg.rs
+++ b/src/rendering/svg.rs
@@ -3,10 +3,9 @@
 use core::{
     cell::{Cell, RefCell},
     fmt::{self, Write},
-    hash::{BuildHasher, BuildHasherDefault},
+    hash::BuildHasher,
 };
 
-use ahash::AHasher;
 use alloc::rc::Rc;
 use hashbrown::{HashSet, HashTable};
 
@@ -477,7 +476,7 @@ struct Defs {
 
 impl Defs {
     fn add_gradient(&mut self, vertical: bool, start: &[f32; 4], end: &[f32; 4]) -> Rc<Gradient> {
-        let hasher = BuildHasherDefault::<AHasher>::default();
+        let hasher = foldhash::fast::FixedState::default();
         let hasher = |val: &Gradient| hasher.hash_one(val);
         let gradient = Gradient {
             id: Cell::new(0),


### PR DESCRIPTION
With this update `hashbrown` is now using the `foldhash` crate instead of the `ahash` crate. Since we also depend on `ahash`, we also now switch to `foldhash` for our hashing needs.