### PR TITLE
Update `wasmtime` and `sysinfo`

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -22,18 +22,18 @@ proc-maps = { version = "0.3.0", default-features = false }
 read-process-memory = { version = "0.1.4", default-features = false }
 slotmap = { version = "1.0.2", default-features = false }
 snafu = "0.8.0"
-sysinfo = { version = "0.31.2", default-features = false, features = [
+sysinfo = { version = "0.32.0", default-features = false, features = [
   "multithread",
   "system",
 ] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { version = "24.0.0", default-features = false, features = [
+wasmtime = { version = "25.0.1", default-features = false, features = [
   "cranelift",
   "gc",
   "parallel-compilation",
   "runtime",
 ] }
-wasmtime-wasi = { version = "24.0.0", default-features = false, features = [
+wasmtime-wasi = { version = "25.0.1", default-features = false, features = [
   "preview1",
 ] }
 

--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -126,24 +126,22 @@ impl ProcessList {
     pub fn refresh(&mut self) {
         let now = Instant::now();
         if now >= self.next_check {
-            self.system
-                .refresh_processes_specifics(ProcessesToUpdate::All, multiple_processes());
+            self.system.refresh_processes_specifics(
+                ProcessesToUpdate::All,
+                true,
+                multiple_processes(),
+            );
             self.next_check = now + Duration::from_secs(1);
         }
     }
 
     pub fn refresh_single_process(&mut self, pid: sysinfo::Pid) {
-        if self
-            .system
-            .refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), single_process())
-            == 0
+        if self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            true,
+            single_process(),
+        ) == 0
         {
-            // FIXME: Unfortunately `refresh_process_specifics` doesn't remove
-            // the process if it doesn't exist anymore. There also doesn't seem
-            // to be a way to manually remove it. So we have to do a full
-            // refresh of all processes.
-            self.system
-                .refresh_processes_specifics(ProcessesToUpdate::All, multiple_processes());
             self.next_check = Instant::now() + Duration::from_secs(1);
         }
     }


### PR DESCRIPTION
The latter now allows us to remove dead processes from the process list without having to run the operation twice.