### PR TITLE
Use `CLOCK_BOOTTIME` on Fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tiny-skia = { version = "0.11.1", default-features = false, features = [
 tiny-skia-path = { version = "0.11.1", default-features = false, optional = true }
 
 # SVG Rendering
-foldhash = { version = "0.1.3", optional = true }
+foldhash = { version = "0.1.3", default-features = false, optional = true }
 
 # Networking
 splits-io-api = { version = "0.4.0", optional = true }
@@ -117,7 +117,7 @@ windows-sys = { version = "0.59.0", features = [
     "Win32_Graphics_Gdi",
 ], optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "l4re", target_os = "android", target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "l4re", target_os = "android", target_os = "fuchsia", target_os = "macos", target_os = "ios"))'.dependencies]
 # We need libc for our own implementation of Instant
 libc = { version = "0.2.101", optional = true }
 


### PR DESCRIPTION
Fuchsia added kernel support for a monotonic clock that keeps running while the system is suspended. They technically have not yet exposed it through their libc, but one maintainer said that they will do so soon.