### PR TITLE
Improve Handling of `NotNaN` Types

### DIFF
--- a/src/util/not_nan.rs
+++ b/src/util/not_nan.rs
@@ -1,11 +1,95 @@
-use core::cmp::Ordering;
+use core::{
+    cmp::Ordering,
+    ops::{Add, Mul, Neg},
+};
 
+/// Never `NaN`, but can be any other [`f64`].
+#[derive(Copy, Clone)]
 #[repr(transparent)]
-pub struct NotNaN(pub f64);
+pub struct NotNaN(f64);
+
+impl NotNaN {
+    pub const INFINITY: Self = Self(f64::INFINITY);
+}
+
+/// Never `NaN` and always has a positive sign. May be positive infinity.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct PositiveNotNaN(f64);
+
+/// Never `NaN` and is always larger than (and not equal to) 0. May be positive
+/// infinity.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct PositiveNotNaNNotZero(f64);
+
+impl From<PositiveNotNaNNotZero> for PositiveNotNaN {
+    fn from(value: PositiveNotNaNNotZero) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<PositiveNotNaN> for NotNaN {
+    fn from(value: PositiveNotNaN) -> Self {
+        Self(value.0)
+    }
+}
+
+impl PositiveNotNaN {
+    pub const ZERO: Self = Self(0.0);
+    pub const ONE: Self = Self(1.0);
+}
+
+impl PositiveNotNaNNotZero {
+    pub const TWO: Self = Self(2.0);
+}
+
+// The following cases result in NaN:
+//  - `NaN * x`: We ensure neither input is NaN.
+//  - `0 * Infinity`: We handle this by ensuring at least one side is not 0.
+//
+// IEEE Std 754-2008 7.2:
+// > a) any general-computational or signaling-computational operation on a
+// > signaling NaN (see 6.2), except for some conversions (see 5.12)
+// > b) multiplication: multiplication(0, ∞) or multiplication(∞, 0)
+impl Mul<PositiveNotNaNNotZero> for PositiveNotNaN {
+    type Output = Self;
+
+    fn mul(self, rhs: PositiveNotNaNNotZero) -> Self {
+        Self(self.0 * rhs.0)
+    }
+}
+
+// The following cases result in NaN:
+//  - `NaN + x`: We ensure neither input is NaN.
+//  - `Infinity + -Infinity`: We handle this by ensuring the inputs are
+//    positive.
+//
+// IEEE Std 754-2008 7.2:
+// > a) any general-computational or signaling-computational operation on a
+// > signaling NaN (see 6.2), except for some conversions (see 5.12)
+// > b) addition or subtraction or fusedMultiplyAdd: magnitude subtraction of infinities, such as:
+// > addition(+∞, −∞)
+impl Add for PositiveNotNaN {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+// Negating a non-NaN value results in a non-NaN value.
+impl Neg for NotNaN {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self(-self.0)
+    }
+}
 
 impl PartialEq for NotNaN {
     fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
+        self.0 == other.0
     }
 }
 
@@ -19,6 +103,7 @@ impl PartialOrd for NotNaN {
 
 impl Ord for NotNaN {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or(Ordering::Equal)
+        // SAFETY: The value is guaranteed to not be NaN. See above.
+        unsafe { self.0.partial_cmp(&other.0).unwrap_unchecked() }
     }
 }


### PR DESCRIPTION
In Rust 1.81 it has become essential to handle `NaN` properly when sorting. An incorrect implementation of `Ord` now leads to panics when sorting. In order to prevent this, we now try to prove that the values are never `NaN` to begin with.