### PR TITLE
Support the `web` Target of `wasm-bindgen`

### DIFF
--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -312,12 +312,38 @@ fn write_files(classes: &BTreeMap<String, Class>, opt: &Opt) -> Result<()> {
     path.push("wasm_bindgen");
     create_dir_all(&path)?;
     {
-        path.push("index.js");
-        wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, false)?;
+        path.push("bundler");
+        create_dir_all(&path)?;
+        {
+            path.push("index.js");
+            wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, false, true)?;
+            path.pop();
+
+            path.push("index.ts");
+            wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, true, true)?;
+            path.pop();
+        }
         path.pop();
 
-        path.push("index.ts");
-        wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, true)?;
+        path.push("web");
+        create_dir_all(&path)?;
+        {
+            path.push("index.js");
+            wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, false, false)?;
+            path.pop();
+
+            path.push("index.ts");
+            wasm_bindgen::write(BufWriter::new(File::create(&path)?), classes, true, false)?;
+            path.pop();
+
+            path.push("preload.js");
+            wasm_bindgen::write_preload(BufWriter::new(File::create(&path)?), false)?;
+            path.pop();
+
+            path.push("preload.ts");
+            wasm_bindgen::write_preload(BufWriter::new(File::create(&path)?), true)?;
+            path.pop();
+        }
         path.pop();
     }
     path.pop();


### PR DESCRIPTION
This emits the bindings in a way such that they are compatible with not only the `bundler` target of `wasm-bindgen`, but also the `web` target. This allows us to circumvent `webpack`, which means we are not limited by the features it supports anymore. In particular, this unblocks the usage of reference types.