### PR TITLE
Remove 2nd Tokio Runtime in Auto Splitting Runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,11 +91,7 @@ splits-io-api = { version = "0.4.0", optional = true }
 
 # Auto Splitting
 livesplit-auto-splitting = { path = "crates/livesplit-auto-splitting", version = "0.1.0", optional = true }
-tokio = { version = "1.24.2", default-features = false, features = [
-    "rt",
-    "sync",
-    "time",
-], optional = true }
+arc-swap = { version = "1.7.1", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
@@ -191,7 +187,7 @@ wasm-web = [
     "web-sys",
 ]
 networking = ["std", "splits-io-api"]
-auto-splitting = ["std", "livesplit-auto-splitting", "tokio", "log"]
+auto-splitting = ["std", "livesplit-auto-splitting", "arc-swap", "log"]
 
 [lib]
 bench = false

--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -190,7 +190,7 @@ fn single_process() -> ProcessRefreshKind {
 #[non_exhaustive]
 pub struct Config {
     /// This enables debug information for the WebAssembly module. This is
-    /// useful for debugging purposes. By default this `true` if the feature
+    /// useful for debugging purposes. By default this is `true` if the feature
     /// `debugger-support` is enabled.
     pub debug_info: bool,
     /// This enables optimizations for the WebAssembly module. This is enabled
@@ -198,8 +198,8 @@ pub struct Config {
     /// splitter.
     pub optimize: bool,
     /// This enables backtrace details for the WebAssembly module. If a trap
-    /// occurs more details are printed in the backtrace. By default this `true`
-    /// if the feature `enhanced-backtrace` is enabled.
+    /// occurs more details are printed in the backtrace. By default this is
+    /// `true` if the feature `enhanced-backtrace` is enabled.
     pub backtrace_details: bool,
 }
 


### PR DESCRIPTION
Wasmtime's WASI implementation nowadays internally has its own Tokio runtime. You can only ever run a single Tokio runtime on a thread at the same time. Wasmtime provides async support, so this likely would have also solved the issue. However, this probably would've made it harder to use the runtime in other situations. So instead we just remove our own runtime, which was not really necessary anyway.