### PR TITLE
Disable event tap on macOS before stopping run loop

### DIFF
--- a/crates/livesplit-hotkey/src/macos/cg.rs
+++ b/crates/livesplit-hotkey/src/macos/cg.rs
@@ -220,5 +220,7 @@ extern "C" {
         userInfo: *mut c_void,
     ) -> MachPortRef;
 
+    pub fn CGEventTapEnable(tap: MachPortRef, enable: bool);
+
     pub fn CGEventGetIntegerValueField(event: EventRef, field: EventField) -> i64;
 }

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -16,8 +16,8 @@ use self::{
         CFRunLoopGetCurrent, CFRunLoopRemoveSource, CFRunLoopRun,
     },
     cg::{
-        CGEventGetFlags, CGEventTapCreate, EventField, EventFlags, EventMask, EventRef,
-        EventTapLocation, EventTapOptions, EventTapPlacement, EventTapProxy, EventType,
+        CGEventGetFlags, CGEventTapCreate, CGEventTapEnable, EventField, EventFlags, EventMask,
+        EventRef, EventTapLocation, EventTapOptions, EventTapPlacement, EventTapProxy, EventType,
     },
 };
 use crate::{ConsumePreference, Hotkey, KeyCode, Modifiers, Result};
@@ -163,6 +163,7 @@ impl Hook {
             if CFRunLoopContainsSource(event_loop, source.0, kCFRunLoopDefaultMode) {
                 CFRunLoopRemoveSource(event_loop, source.0, kCFRunLoopDefaultMode);
             }
+            CGEventTapEnable(port.0, false);
         });
 
         let event_loop = receiver


### PR DESCRIPTION
This shouldn't be necessary according to the documentation, but it fixes #855.