### PR TITLE
Fix issue of type i64 in Rust not properly getting converted to BigInt in TypeScript

### DIFF
--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -27,7 +27,7 @@ fn get_hl_type_without_null(ty: &Type) -> String {
                 "i8" => "number",
                 "i16" => "number",
                 "i32" => "number",
-                "i64" => "number",
+                "i64" => "BigInt",
                 "u8" => "number",
                 "u16" => "number",
                 "u32" => "number",

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -31,7 +31,7 @@ fn get_hl_type_without_null(ty: &Type) -> String {
                 "u8" => "number",
                 "u16" => "number",
                 "u32" => "number",
-                "u64" => "number",
+                "u64" => "BigInt",
                 "usize" => "number",
                 "isize" => "number",
                 "f32" => "number",


### PR DESCRIPTION
When compiling `livesplit-core` to WASM TypeScript from Rust, a compilation error is produced in the resulting `index.ts` file for the `wholeSeconds` function. The return type for this function is incorrectly set to `number` instead of `BigInt`, this PR corrects that problem by modifying the `wasm_bindgen.rs` file appropriately.

Admittedly, I don't know much about Rust so I could be handling this wrong, but I believe this is the correct fix and it seems to be working correctly for me. Let me know if I need to make any additional changes to get this working properly again 👍