### PR TITLE
Fix Bounding Box Calculation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 runner = "wasmtime run --dir ."
 
 [target.x86_64-pc-windows-msvc]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
-      - '*'
+      - "*"
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
           # WebAssembly
           - WebAssembly Unknown
           - WebAssembly Web
-          - WebAssembly WASI
+          - WebAssembly WASI 0.1
 
           # Windows
           - Windows aarch64
@@ -237,8 +237,8 @@ jobs:
             install_target: true
             features: "--features wasm-web"
 
-          - label: WebAssembly WASI
-            target: wasm32-wasi
+          - label: WebAssembly WASI 0.1
+            target: wasm32-wasip1
             auto_splitting: skip
             cross: skip
             dylib: skip
@@ -706,7 +706,7 @@ jobs:
       - name: Use Node 10
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: "10.x"
       - name: Build TypeScript documentation
         run: |
           cd capi/js

--- a/.github/workflows/build_static.sh
+++ b/.github/workflows/build_static.sh
@@ -19,7 +19,7 @@ main() {
         wasm32-unknown-unknown)
             $cargo rustc -p livesplit-core-capi --crate-type cdylib --target $TARGET $release_flag $FEATURES
             ;;
-        wasm32-wasi)
+        wasm32-wasip1)
             $cargo rustc -p livesplit-core-capi --crate-type cdylib --target $TARGET $release_flag $FEATURES
             ;;
         *)

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -22,7 +22,7 @@ main() {
         features="$features,software-rendering"
     fi
 
-    if [ "$TARGET" = "wasm32-wasi" ]; then
+    if [ "$TARGET" = "wasm32-wasip1" ]; then
         curl https://wasmtime.dev/install.sh -sSf | bash
         export PATH="$HOME/.wasmtime/bin:$PATH"
     else

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -37,7 +37,7 @@ fn compile(crate_name: &str) -> anyhow::Result<AutoSplitter<DummyTimer>> {
         .current_dir(&path)
         .arg("build")
         .arg("--target")
-        .arg("wasm32-wasi")
+        .arg("wasm32-wasip1")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .output()
@@ -49,7 +49,7 @@ fn compile(crate_name: &str) -> anyhow::Result<AutoSplitter<DummyTimer>> {
     }
 
     path.push("target");
-    path.push("wasm32-wasi");
+    path.push("wasm32-wasip1");
     path.push("debug");
     let wasm_path = fs::read_dir(path)
         .unwrap()

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -831,7 +831,10 @@ fn calculate_bounds(layer: &[Entity<SkiaPath, SkiaImage, SkiaLabel>]) -> [f32; 2
             Entity::Label(label, _, transform) => {
                 for glyph in label.read().unwrap().glyphs() {
                     if let Some(path) = &glyph.path {
-                        let transform = transform.pre_translate(glyph.x, glyph.y);
+                        let transform = transform
+                            .pre_translate(glyph.x, glyph.y)
+                            .pre_scale(glyph.scale, glyph.scale);
+
                         let bounds = path.bounds();
                         for y in [bounds.top(), bounds.bottom()] {
                             let transformed_y = transform.transform_y(y);


### PR DESCRIPTION
At some point when changing our text engine, we introduced a scale value for each individual glyph, possibly during the transition to `cosmic-text`. This is correctly being used when rendering the text, but not when calculating the bounding box of the text. This meant that for certain fonts the dirty region of the image, that is cleared on each frame, was not calculated correctly and thus the previous text was still visible.