### PR TITLE
Initial Drop shadow support

### DIFF
--- a/src/layout/general_settings.rs
+++ b/src/layout/general_settings.rs
@@ -24,6 +24,8 @@ pub struct GeneralSettings {
     pub text_font: Option<Font>,
     /// The background to show behind the layout.
     pub background: LayoutBackground,
+    /// Draw drop shadow
+    pub drop_shadow: bool,
     /// The color to use for when the runner achieved a best segment.
     pub best_segment_color: Color,
     /// The color to use for when the runner is ahead of the comparison and is
@@ -62,6 +64,7 @@ impl Default for GeneralSettings {
             background: LayoutBackground::Gradient(Gradient::Plain(Color::hsla(
                 0.0, 0.0, 0.06, 1.0,
             ))),
+            drop_shadow: false,
             best_segment_color: Color::hsla(50.0, 1.0, 0.5, 1.0),
             ahead_gaining_time_color: Color::hsla(136.0, 1.0, 0.4, 1.0),
             ahead_losing_time_color: Color::hsla(136.0, 0.55, 0.6, 1.0),
@@ -113,6 +116,11 @@ impl GeneralSettings {
                 "Background".into(),
                 "The background shown behind the entire layout.".into(),
                 self.background.cache(image_cache).into(),
+            ),
+            Field::new(
+                "Drop Shadow".into(),
+                "Draws shadow behind timer & splits".into(),
+                self.drop_shadow.into(),
             ),
             Field::new(
                 "Best Segment".into(),
@@ -190,17 +198,18 @@ impl GeneralSettings {
             2 => self.times_font = value.into(),
             3 => self.text_font = value.into(),
             4 => self.background = LayoutBackground::from(value).from_cache(image_cache),
-            5 => self.best_segment_color = value.into(),
-            6 => self.ahead_gaining_time_color = value.into(),
-            7 => self.ahead_losing_time_color = value.into(),
-            8 => self.behind_gaining_time_color = value.into(),
-            9 => self.behind_losing_time_color = value.into(),
-            10 => self.not_running_color = value.into(),
-            11 => self.personal_best_color = value.into(),
-            12 => self.paused_color = value.into(),
-            13 => self.thin_separators_color = value.into(),
-            14 => self.separators_color = value.into(),
-            15 => self.text_color = value.into(),
+            5 => self.drop_shadow = value.into(),
+            6 => self.best_segment_color = value.into(),
+            7 => self.ahead_gaining_time_color = value.into(),
+            8 => self.ahead_losing_time_color = value.into(),
+            9 => self.behind_gaining_time_color = value.into(),
+            10 => self.behind_losing_time_color = value.into(),
+            11 => self.not_running_color = value.into(),
+            12 => self.personal_best_color = value.into(),
+            13 => self.paused_color = value.into(),
+            14 => self.thin_separators_color = value.into(),
+            15 => self.separators_color = value.into(),
+            16 => self.text_color = value.into(),
             _ => panic!("Unsupported Setting Index"),
         }
     }

--- a/src/layout/layout_state.rs
+++ b/src/layout/layout_state.rs
@@ -30,6 +30,8 @@ pub struct LayoutState {
     pub separators_color: Color,
     /// The text color to use for text that doesn't specify its own color.
     pub text_color: Color,
+    /// Draws drop shadow
+    pub drop_shadow: bool,
 }
 
 #[cfg(feature = "std")]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -119,6 +119,7 @@ impl Layout {
         state.separators_color = settings.separators_color;
         state.text_color = settings.text_color;
         state.direction = settings.direction;
+        state.drop_shadow = settings.drop_shadow;
     }
 
     /// Calculates the layout's state based on the timer provided. You can use

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -779,6 +779,9 @@ fn parse_general_settings(layout: &mut Layout, reader: &mut Reader<'_>) -> Resul
         }),
         "ImageOpacity" => percentage(reader, |v| image_opacity = v),
         "ImageBlur" => percentage(reader, |v| image_blur = v),
+        "DropShadow" => {
+            parse_bool(reader, |b| settings.drop_shadow = b)
+        }
         _ => end_tag(reader),
     })?;
 

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -2,6 +2,7 @@ use crate::{
     component::detailed_timer::State,
     layout::LayoutState,
     rendering::{
+        FillShader,
         component::timer,
         consts::{vertical_padding, BOTH_PADDINGS, PADDING},
         font::CachedLabel,
@@ -43,6 +44,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     layout_state: &LayoutState,
 ) {
     context.render_background([width, height], &component.background);
+    
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
 
     let vertical_padding = vertical_padding(height);
     let icon_size = height - 2.0 * vertical_padding;
@@ -63,6 +67,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         context,
         [width, top_height],
         &component.timer,
+        layout_state
     );
 
     if let Some(segment_name) = &component.segment_name {
@@ -78,7 +83,10 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             [left_side, 0.6 * top_height],
             0.5 * top_height,
             segment_name_color,
+            shadow_offset,
+            shadow_color,
             timer_end,
+            layout_state
         );
     }
 
@@ -89,6 +97,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         context,
         [width, bottom_height],
         &component.segment_timer,
+        layout_state
     );
 
     context.translate(0.0, -top_height);
@@ -112,7 +121,10 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                 [left_side, comparison2_y],
                 comparison_text_scale,
                 comparison_names_color,
+                shadow_offset,
+                shadow_color,
                 segment_timer_end,
+                layout_state
             )
             .max(name_end);
 
@@ -137,7 +149,10 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                 [left_side, comparison1_y],
                 comparison_text_scale,
                 comparison_names_color,
+                shadow_offset,
+                shadow_color,
                 segment_timer_end,
+                layout_state
             )
             .max(name_end);
 
@@ -165,6 +180,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             [time_x, comparison2_y],
             comparison_text_scale,
             comparison_times_color,
+            shadow_offset,
+            shadow_color,
+            layout_state
         );
     }
     if let Some(comparison) = &component.comparison1 {
@@ -175,6 +193,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             [time_x, comparison1_y],
             comparison_text_scale,
             comparison_times_color,
+            shadow_offset,
+            shadow_color,
+            layout_state
         );
     }
 }

--- a/src/rendering/component/key_value.rs
+++ b/src/rendering/component/key_value.rs
@@ -4,7 +4,7 @@ use crate::{
     rendering::{
         font::{AbbreviatedLabel, CachedLabel},
         resource::ResourceAllocator,
-        RenderContext,
+        RenderContext, FillShader
     },
 };
 
@@ -30,6 +30,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     layout_state: &LayoutState,
 ) {
     context.render_background(dim, &component.background);
+
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
     context.render_key_value_component(
         &component.key,
         &component.key_abbreviations,
@@ -38,8 +41,12 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         &mut cache.value,
         component.updates_frequently,
         dim,
+        shadow_offset,
+        shadow_color,
+        shadow_color,
         component.key_color.unwrap_or(layout_state.text_color),
         component.value_color.unwrap_or(layout_state.text_color),
         component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
+        layout_state
     );
 }

--- a/src/rendering/component/mod.rs
+++ b/src/rendering/component/mod.rs
@@ -169,7 +169,7 @@ pub(super) fn render<A: ResourceAllocator>(
             text::render(cache.text(), context, dim, component, state)
         }
         ComponentState::Timer(component) => {
-            timer::render(cache.timer(), context, dim, component);
+            timer::render(cache.timer(), context, dim, component, state);
         }
         ComponentState::Title(component) => {
             title::render(cache.title(), context, dim, component, state)

--- a/src/rendering/component/splits.rs
+++ b/src/rendering/component/splits.rs
@@ -10,7 +10,7 @@ use crate::{
         font::CachedLabel,
         resource::ResourceAllocator,
         scene::Layer,
-        solid, RenderContext,
+        solid, RenderContext, FillShader
     },
     settings::{Gradient, ListGradient},
 };
@@ -96,6 +96,8 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
 
     cache.longest_column_values.clear();
 
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
     for split in &component.splits {
         if split.columns.len() > cache.longest_column_values.len() {
             cache
@@ -202,6 +204,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                     [right_x, TEXT_ALIGN_TOP],
                     DEFAULT_TEXT_SIZE,
                     text_color,
+                    shadow_offset,
+                    shadow_color,
+                    layout_state
                 );
                 let label_width = right_x - left_x;
                 if label_width > *max_width {
@@ -275,6 +280,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                         [right_x, split_height + TEXT_ALIGN_BOTTOM],
                         DEFAULT_TEXT_SIZE,
                         solid(&column.visual_color),
+                        shadow_offset,
+                        shadow_color,
+                        layout_state
                     );
                 }
                 right_x -= max_width + PADDING;
@@ -290,7 +298,10 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                 [icon_right, TEXT_ALIGN_TOP],
                 DEFAULT_TEXT_SIZE,
                 text_color,
+                shadow_offset,
+                shadow_color,
                 left_x - PADDING,
+                layout_state
             );
         }
         context.translate(delta_x, delta_y);

--- a/src/rendering/component/text.rs
+++ b/src/rendering/component/text.rs
@@ -5,7 +5,7 @@ use crate::{
         consts::{DEFAULT_TEXT_SIZE, PADDING, TEXT_ALIGN_TOP},
         font::{AbbreviatedLabel, CachedLabel},
         resource::ResourceAllocator,
-        solid, RenderContext,
+        solid, RenderContext, FillShader
     },
 };
 
@@ -31,6 +31,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     layout_state: &LayoutState,
 ) {
     context.render_background([width, height], &component.background);
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
+
     match &component.text {
         TextState::Center(text) => context.render_text_centered(
             text,
@@ -44,6 +47,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
                     .left_center_color
                     .unwrap_or(layout_state.text_color),
             ),
+            shadow_offset,
+            shadow_color,
+            layout_state
         ),
         TextState::Split(left, right) => context.render_key_value_component(
             left,
@@ -53,11 +59,13 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             &mut cache.label2,
             false,
             [width, height],
-            component
-                .left_center_color
-                .unwrap_or(layout_state.text_color),
+            shadow_offset,
+            shadow_color,
+            shadow_color,
+            component.left_center_color.unwrap_or(layout_state.text_color),
             component.right_color.unwrap_or(layout_state.text_color),
             component.display_two_rows || layout_state.direction == LayoutDirection::Horizontal,
+            layout_state
         ),
     }
 }

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -1,5 +1,6 @@
 use crate::{
     component::timer::State,
+    layout::LayoutState,
     rendering::{
         consts::PADDING, font::CachedLabel, resource::ResourceAllocator, scene::Layer, FillShader,
         RenderContext,
@@ -25,8 +26,12 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     context: &mut RenderContext<'_, A>,
     [width, height]: [f32; 2],
     component: &State,
+    layout_state: &LayoutState
 ) -> f32 {
     context.render_background([width, height], &component.background);
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
+
     let shader = FillShader::VerticalGradient(
         component.top_color.to_array(),
         component.bottom_color.to_array(),
@@ -39,6 +44,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         [width - PADDING, 0.85 * height],
         0.7 * height,
         shader,
+        shadow_offset,
+        shadow_color,
+        layout_state
     );
     context.render_timer(
         &component.time,
@@ -47,5 +55,8 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         [x, 0.85 * height],
         height,
         shader,
+        shadow_offset,
+        shadow_color,
+        layout_state
     )
 }

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         font::{AbbreviatedLabel, CachedLabel},
         resource::ResourceAllocator,
-        solid, Layer, RenderContext,
+        solid, Layer, RenderContext, FillShader
     },
 };
 
@@ -41,6 +41,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     layout_state: &LayoutState,
 ) {
     context.render_background([width, height], &component.background);
+    let shadow_offset = [0.05, 0.05];
+    let shadow_color = FillShader::SolidColor([0.0, 0.0, 0.0, 0.5]);
+    
     let text_color = component.text_color.unwrap_or(layout_state.text_color);
     let text_color = solid(&text_color);
 
@@ -80,6 +83,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         [width - PADDING, height + TEXT_ALIGN_BOTTOM],
         DEFAULT_TEXT_SIZE,
         text_color,
+        shadow_offset,
+        shadow_color,
+        layout_state
     ) - PADDING;
 
     let (line1_y, line1_end_x) = if !component.line2.is_empty() {
@@ -91,7 +97,10 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             [line_x, height + TEXT_ALIGN_BOTTOM],
             DEFAULT_TEXT_SIZE,
             component.is_centered,
+            shadow_offset,
+            shadow_color,
             text_color,
+            layout_state
         );
         (TEXT_ALIGN_TOP, width - PADDING)
     } else {
@@ -106,6 +115,9 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         [line_x, line1_y],
         DEFAULT_TEXT_SIZE,
         component.is_centered,
+        shadow_offset,
+        shadow_color,
         text_color,
+        layout_state
     );
 }

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -284,6 +284,7 @@ impl BorrowedRenderer {
             [width as _, height as _],
             state,
             image_cache,
+            state
         );
 
         let scene = self.scene_manager.scene();


### PR DESCRIPTION
Transparent background renders everything without a shadow, which obviously causes bright text to be unreadable on bright backgrounds.

Color and offset of the shadow are hard coded, but I guess it shouldn't be hard to also introduce them as available settings.

