### PR TITLE
Move Text Shadow Support to Rendering Backends

### DIFF
--- a/src/rendering/entity.rs
+++ b/src/rendering/entity.rs
@@ -6,8 +6,8 @@ use core::{
 use crate::settings::BackgroundImage;
 
 use super::{
-    resource::{Handle, LabelHandle},
     Background, FillShader, Rgba, Transform,
+    resource::{Handle, LabelHandle},
 };
 
 struct FxHasher(u64);
@@ -80,8 +80,9 @@ pub enum Entity<P, I, L> {
     StrokePath(Handle<P>, f32, Rgba, Transform),
     /// An image.
     Image(Handle<I>, Transform),
-    /// A text label.
-    Label(LabelHandle<L>, FillShader, Transform),
+    /// A text label with a [`FillShader`] that describes the text color and an
+    /// optional text shadow.
+    Label(LabelHandle<L>, FillShader, Option<Rgba>, Transform),
 }
 
 pub fn calculate_hash<P, I, L>(
@@ -153,9 +154,13 @@ impl<P, I, L> Hash for Entity<P, I, L> {
                 image.hash(state);
                 hash_transform(transform, state);
             }
-            Entity::Label(label, shader, transform) => {
+            Entity::Label(label, shader, text_shadow, transform) => {
                 label.hash(state);
                 hash_shader(shader, state);
+                mem::discriminant(text_shadow).hash(state);
+                if let Some(text_shadow) = text_shadow {
+                    hash_floats(text_shadow, state);
+                }
                 hash_transform(transform, state);
             }
         }

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -90,8 +90,8 @@ pub mod web;
 
 use self::{
     consts::{
-        DEFAULT_TEXT_SIZE, DEFAULT_VERTICAL_WIDTH, PADDING, SHADOW_OFFSET, TEXT_ALIGN_BOTTOM,
-        TEXT_ALIGN_TOP, TWO_ROW_HEIGHT,
+        DEFAULT_TEXT_SIZE, DEFAULT_VERTICAL_WIDTH, PADDING, TEXT_ALIGN_BOTTOM, TEXT_ALIGN_TOP,
+        TWO_ROW_HEIGHT,
     },
     font::{AbbreviatedLabel, CachedLabel, FontCache},
     icon::{CachedImage, ImageHandle},
@@ -606,21 +606,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
             (max_x - x) / scale,
         );
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.bottom_layer_mut().push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::left_aligned(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                ),
-            ));
-        }
-
         self.scene.bottom_layer_mut().push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::left_aligned(&self.transform, pos, scale),
         ));
 
@@ -643,21 +632,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
             Some((max_x - x) / scale),
         );
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.bottom_layer_mut().push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::left_aligned(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                ),
-            ));
-        }
-
         self.scene.bottom_layer_mut().push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::left_aligned(&self.transform, pos, scale),
         ));
 
@@ -681,24 +659,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
             Some((max_x - min_x) / scale),
         );
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.bottom_layer_mut().push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::centered(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                    label.width(scale),
-                    min_x,
-                    max_x,
-                ),
-            ));
-        }
-
         self.scene.bottom_layer_mut().push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::centered(
                 &self.transform,
                 pos,
@@ -727,24 +691,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
             (max_x - min_x) / scale,
         );
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.bottom_layer_mut().push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::centered(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                    label.width(scale),
-                    min_x,
-                    max_x,
-                ),
-            ));
-        }
-
         self.scene.bottom_layer_mut().push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::centered(
                 &self.transform,
                 pos,
@@ -768,21 +718,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
         let label = label.update(text, &mut self.handles, &mut self.fonts.text.font, None);
         let width = label.width(scale);
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.layer_mut(layer).push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::left_aligned(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                ),
-            ));
-        }
-
         self.scene.layer_mut(layer).push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::right_aligned(&self.transform, pos, scale, width),
         ));
 
@@ -827,21 +766,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
         let label = label.update(text, &mut self.handles, &mut self.fonts.times.font, None);
         let width = label.width(scale);
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.layer_mut(layer).push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::right_aligned(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                    width,
-                ),
-            ));
-        }
         self.scene.layer_mut(layer).push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::right_aligned(&self.transform, pos, scale, width),
         ));
 
@@ -860,22 +788,10 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
         let label = label.update(text, &mut self.handles, &mut self.fonts.timer.font, None);
         let width = label.width(scale);
 
-        if let Some(text_shadow) = &self.state.text_shadow {
-            self.scene.layer_mut(layer).push(Entity::Label(
-                label.share(),
-                solid(text_shadow),
-                font::right_aligned(
-                    &self.transform.pre_translate(SHADOW_OFFSET, SHADOW_OFFSET),
-                    pos,
-                    scale,
-                    width,
-                ),
-            ));
-        }
-
         self.scene.layer_mut(layer).push(Entity::Label(
             label.share(),
             shader,
+            self.state.text_shadow.as_ref().map(Color::to_array),
             font::right_aligned(&self.transform, pos, scale, width),
         ));
 

--- a/src/rendering/web/bindings.rs
+++ b/src/rendering/web/bindings.rs
@@ -16,9 +16,17 @@ extern "C" {
     #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = lineWidth)]
     pub fn set_line_width(this: &CanvasRenderingContext2d, value: f64);
     #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = font)]
-    pub fn set_font(this: &CanvasRenderingContext2d, value: &js_sys::JsString);
+    pub fn set_font(this: &CanvasRenderingContext2d, value: &JsString);
     #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = fontKerning)]
     pub fn set_font_kerning(this: &CanvasRenderingContext2d, value: &JsString);
+    #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = shadowColor)]
+    pub fn set_shadow_color(this: &CanvasRenderingContext2d, value: &JsString);
+    #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = shadowBlur)]
+    pub fn set_shadow_blur(this: &CanvasRenderingContext2d, value: f64);
+    #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = shadowOffsetX)]
+    pub fn set_shadow_offset_x(this: &CanvasRenderingContext2d, value: f64);
+    #[wasm_bindgen(structural, method, setter, js_class = "CanvasRenderingContext2D", js_name = shadowOffsetY)]
+    pub fn set_shadow_offset_y(this: &CanvasRenderingContext2d, value: f64);
     #[wasm_bindgen(catch, method, structural, js_class = "CanvasRenderingContext2D", js_name = drawImage)]
     pub fn draw_image_with_image_bitmap_and_dw_and_dh(
         this: &CanvasRenderingContext2d,

--- a/tests/layout_files/TextShadow.ls1l
+++ b/tests/layout_files/TextShadow.ls1l
@@ -1,0 +1,171 @@
+{
+    "components": [
+        {
+            "Timer": {
+                "background": "Transparent",
+                "timing_method": null,
+                "height": 60,
+                "color_override": null,
+                "show_gradient": true,
+                "digits_format": "SingleDigitSeconds",
+                "accuracy": "Hundredths",
+                "is_segment_timer": false
+            }
+        },
+        {
+            "Timer": {
+                "background": "Transparent",
+                "timing_method": null,
+                "height": 145,
+                "color_override": null,
+                "show_gradient": true,
+                "digits_format": "SingleDigitSeconds",
+                "accuracy": "Hundredths",
+                "is_segment_timer": false
+            }
+        },
+        {
+            "Text": {
+                "background": {
+                    "Vertical": [
+                        [
+                            1,
+                            1,
+                            1,
+                            0.06
+                        ],
+                        [
+                            1,
+                            1,
+                            1,
+                            0.005
+                        ]
+                    ]
+                },
+                "display_two_rows": false,
+                "left_center_color": null,
+                "right_color": null,
+                "text": {
+                    "Center": "Some Text"
+                }
+            }
+        },
+        {
+            "Text": {
+                "background": {
+                    "Vertical": [
+                        [
+                            1,
+                            1,
+                            1,
+                            0.06
+                        ],
+                        [
+                            1,
+                            1,
+                            1,
+                            0.005
+                        ]
+                    ]
+                },
+                "display_two_rows": false,
+                "left_center_color": [
+                    0.976,
+                    0.008675556,
+                    0.008675556,
+                    0.3
+                ],
+                "right_color": null,
+                "text": {
+                    "Center": "Semi Transparent"
+                }
+            }
+        }
+    ],
+    "general": {
+        "direction": "Vertical",
+        "timer_font": null,
+        "times_font": null,
+        "text_font": null,
+        "text_shadow": [
+            0,
+            0,
+            0,
+            0.5
+        ],
+        "background": {
+            "Plain": [
+                1,
+                1,
+                1,
+                1
+            ]
+        },
+        "best_segment_color": [
+            1,
+            0.8333334,
+            0,
+            1
+        ],
+        "ahead_gaining_time_color": [
+            0,
+            0.8,
+            0.21333352,
+            1
+        ],
+        "ahead_losing_time_color": [
+            0.38000003,
+            0.82000005,
+            0.49733347,
+            1
+        ],
+        "behind_gaining_time_color": [
+            0.82000005,
+            0.38000003,
+            0.38000003,
+            1
+        ],
+        "behind_losing_time_color": [
+            0.8,
+            0,
+            0,
+            1
+        ],
+        "not_running_color": [
+            0.67,
+            0.67,
+            0.67,
+            1
+        ],
+        "personal_best_color": [
+            0.08000004,
+            0.64733326,
+            1,
+            1
+        ],
+        "paused_color": [
+            0.48,
+            0.48,
+            0.48,
+            1
+        ],
+        "thin_separators_color": [
+            1,
+            1,
+            1,
+            0.09
+        ],
+        "separators_color": [
+            1,
+            1,
+            1,
+            0.35
+        ],
+        "text_color": [
+            1,
+            1,
+            1,
+            1
+        ]
+    }
+}

--- a/tests/layout_files/mod.rs
+++ b/tests/layout_files/mod.rs
@@ -6,3 +6,4 @@ pub const SUBSPLITS: &str = include_str!("subsplits.lsl");
 pub const WSPLIT: &str = include_str!("WSplit.lsl");
 pub const WITH_TIMER_DELTA_BACKGROUND: &str = include_str!("WithTimerDeltaBackground.lsl");
 pub const WITH_BACKGROUND_IMAGE: &str = include_str!("WithBackgroundImage.lsl");
+pub const TEXT_SHADOW: &str = include_str!("TextShadow.ls1l");

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -26,6 +26,10 @@ fn lsl(data: &str) -> Layout {
     layout::parser::parse(data).unwrap()
 }
 
+fn ls1l(data: &str) -> Layout {
+    Layout::from_settings(serde_json::from_str(data).unwrap())
+}
+
 #[test]
 fn default() {
     let mut run = tests_helper::create_run(&["A", "B", "C", "D"]);
@@ -44,8 +48,8 @@ fn default() {
     check(
         &state,
         &image_cache,
-        "c0ad948aed86074f",
-        "b48906628d71c0aa",
+        "40afc8d9b921c018",
+        "29bf0ddd39a138e7",
         "default",
     );
 }
@@ -167,8 +171,8 @@ fn font_fallback() {
         &state,
         &image_cache,
         [320, 750],
-        "8ebc585aec6909e2",
-        "4371062136f5eb3b",
+        "d21ee9034ca0baed",
+        "e339132ee6cf8e94",
         "font_fallback",
     );
 }
@@ -183,8 +187,8 @@ fn actual_split_file() {
     check(
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
-        "5b731b527871c67d",
-        "e43f5bf67ada675c",
+        "0bd8b41b95ae974c",
+        "0a4b3f4cb44ffbbb",
         "actual_split_file",
     );
 }
@@ -256,8 +260,8 @@ fn all_components() {
         &state,
         &image_cache,
         [300, 800],
-        "cb6ddee1b2cb296e",
-        "3935895199fbf883",
+        "ca9b92ae7357d0cd",
+        "5e74113e4352d0b9",
         "all_components",
     );
 
@@ -265,8 +269,8 @@ fn all_components() {
         &state,
         &image_cache,
         [150, 800],
-        "70c4e38cea684e91",
-        "33b14971943c049c",
+        "ccbcbb6285133a58",
+        "aef452d4bff2f3bd",
         "all_components_thin",
     );
 }
@@ -293,8 +297,8 @@ fn score_split() {
         &state,
         &image_cache,
         [300, 400],
-        "c39b32c0e13ced4c",
-        "73de0c5abaa29100",
+        "6385959af93932cb",
+        "ebbe996276cd8dd0",
         "score_split",
     );
 }
@@ -311,7 +315,7 @@ fn dark_layout() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         "a47c590792c1bab5",
-        "3a3a4f53c146d472",
+        "4ad7d528b3dc653d",
         "dark_layout",
     );
 }
@@ -334,8 +338,8 @@ fn subsplits_layout() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [300, 800],
-        "620825a1f684554a",
-        "355e302202735dbe",
+        "fc9658d65e0e0511",
+        "e54f03f006192781",
         "subsplits_layout",
     );
 }
@@ -358,8 +362,8 @@ fn background_image() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [300, 300],
-        "044e60eab4dc7faf",
-        "0ba24da5eb4cd8a6",
+        "81f6d2122b32065f",
+        "57f284ed4a717a0d",
         "background_image",
     );
 }
@@ -385,8 +389,8 @@ fn display_two_rows() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [200, 100],
-        "029a6bfd857f3820",
-        "aa626e5a8b7c5997",
+        "0541122a81430490",
+        "c5f95ed36a74130e",
         "display_two_rows",
     );
 }
@@ -412,8 +416,8 @@ fn single_line_title() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [300, 60],
-        "d4a0f104cc3b83c1",
-        "a57d9897ebecbc2c",
+        "12d4b767f55e5545",
+        "13bc0a3729c5df16",
         "single_line_title",
     );
 }
@@ -450,9 +454,29 @@ fn horizontal() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [1500, 40],
-        "25cf654aa17999af",
-        "af5ed8ad60fd9b22",
+        "81d12a01d1b00092",
+        "c22903674f3b0767",
         "horizontal",
+    );
+}
+
+#[test]
+fn text_shadow() {
+    let run = lss(run_files::CELESTE);
+    let mut timer = Timer::new(run).unwrap();
+    let mut layout = ls1l(layout_files::TEXT_SHADOW);
+    let mut image_cache = ImageCache::new();
+
+    tests_helper::start_run(&mut timer);
+    tests_helper::make_progress_run_with_splits_opt(&mut timer, &[Some(12.34)]);
+
+    check_dims(
+        &layout.state(&mut image_cache, &timer.snapshot()),
+        &image_cache,
+        [400, 400],
+        "ee437905156e2d64",
+        "d21a7fdd462f99fb",
+        "text_shadow",
     );
 }
 


### PR DESCRIPTION
Instead of duplicating every label, it is much better for the rendering backends to handle the text shadow support by themselves. This also enables them to do it in a faster or more sophisticated way, such as using a proper text shadow blur.

## Web Backend

We use the `shadowColor`, `shadowOffsetX`, `shadowOffsetY`, and `shadowBlur` properties of the `CanvasRenderingContext2D` to draw the text shadows.

## Software Backend

We still basically just duplicate the labels. `tiny-skia` does not have a good way to add shadows or have any support for blurring.

## SVG Backend

We unfortunately also just duplicate the labels. The reason is that we tried to use a `feDropShadow` filter, but it seems to be cut off in Chrome and weirdly enough **segfaults** Firefox.

https://x.com/CryZe107/status/1903132316358082813