### PR TITLE
Listen to Hotkeys in Child Windows on the Web

### DIFF
--- a/capi/src/hotkey_system.rs
+++ b/capi/src/hotkey_system.rs
@@ -85,3 +85,18 @@ pub unsafe extern "C" fn HotkeySystem_resolve(
         _ => output_str(name),
     }
 }
+
+#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+use wasm_bindgen::prelude::*;
+
+/// On the web you can use this to listen to keyboard events on an additional
+/// child window as well.
+#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+#[wasm_bindgen]
+pub unsafe fn HotkeySystem_add_window(
+    hotkey_system: *const HotkeySystem,
+    window: web_sys::Window,
+) -> bool {
+    // SAFETY: The caller guarantees that `hotkey_system` is valid.
+    unsafe { (*hotkey_system).add_window(window).is_ok() }
+}

--- a/capi/src/web_rendering.rs
+++ b/capi/src/web_rendering.rs
@@ -3,7 +3,7 @@
 
 use livesplit_core::{layout::LayoutState, rendering::web, settings::ImageCache};
 use wasm_bindgen::prelude::*;
-use web_sys::Element;
+use web_sys::HtmlElement;
 
 /// The web renderer renders into a canvas element. The element can then be
 /// attached anywhere in the DOM with any desired positioning and size.
@@ -30,7 +30,7 @@ impl WebRenderer {
 
     /// Returns the HTML element. This can be attached anywhere in the DOM with
     /// any desired positioning and size.
-    pub fn element(&self) -> Element {
+    pub fn element(&self) -> HtmlElement {
         self.inner.element().clone()
     }
 
@@ -42,8 +42,6 @@ impl WebRenderer {
         image_cache: *const ImageCache,
     ) -> Option<Box<[f32]>> {
         // SAFETY: The caller must ensure that the pointers are valid.
-        unsafe {
-            self.inner.render(&*state, &*image_cache).map(Box::from)
-        }
+        unsafe { self.inner.render(&*state, &*image_cache).map(Box::from) }
     }
 }

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -93,6 +93,13 @@ impl Hook {
     pub fn unregister(&self, hotkey: Hotkey) -> Result<()> {
         self.0.unregister(hotkey)
     }
+
+    /// On the web you can use this to listen to keyboard events on an
+    /// additional child window as well.
+    #[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+    pub fn add_window(&self, window: web_sys::Window) -> Result<()> {
+        self.0.add_window(window)
+    }
 }
 
 /// The result type for this crate.

--- a/src/hotkey_system.rs
+++ b/src/hotkey_system.rs
@@ -1,9 +1,8 @@
 use alloc::borrow::Cow;
 
 use crate::{
-    event,
+    HotkeyConfig, event,
     hotkey::{ConsumePreference, Hook, Hotkey, KeyCode},
-    HotkeyConfig,
 };
 
 pub use crate::hotkey::Result;
@@ -33,7 +32,7 @@ enum Action {
 }
 
 impl Action {
-    fn set_hotkey(self, config: &mut HotkeyConfig, hotkey: Option<Hotkey>) {
+    const fn set_hotkey(self, config: &mut HotkeyConfig, hotkey: Option<Hotkey>) {
         match self {
             Action::Split => config.split = hotkey,
             Action::Reset => config.reset = hotkey,
@@ -287,5 +286,12 @@ impl<S: event::CommandSink + Clone + Send + 'static> HotkeySystem<S> {
     /// Resolves the key according to the current keyboard layout.
     pub fn resolve(&self, key_code: KeyCode) -> Cow<'static, str> {
         key_code.resolve(&self.hook)
+    }
+
+    /// On the web you can use this to listen to keyboard events on an
+    /// additional child window as well.
+    #[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+    pub fn add_window(&self, window: web_sys::Window) -> Result<()> {
+        self.hook.add_window(window)
     }
 }

--- a/src/rendering/web/mod.rs
+++ b/src/rendering/web/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Blob, Element, HtmlCanvasElement, ImageBitmap, Path2d, Window};
+use web_sys::{Blob, HtmlCanvasElement, HtmlElement, ImageBitmap, Path2d, Window};
 
 use crate::{
     layout::LayoutState,
@@ -478,7 +478,7 @@ impl FontHandling {
 /// attached anywhere in the DOM with any desired positioning and size.
 pub struct Renderer {
     manager: SceneManager<Path, Image, Rc<CanvasFont>, CanvasLabel>,
-    div: Element,
+    div: HtmlElement,
     allocator: CanvasAllocator,
     canvas_bottom: HtmlCanvasElement,
     canvas_top: HtmlCanvasElement,
@@ -623,7 +623,9 @@ impl Renderer {
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();
 
-        let div = document.create_element("div").unwrap();
+        let div: HtmlElement = document.create_element("div").unwrap().unchecked_into();
+
+        div.set_attribute("style", "position: relative;").unwrap();
 
         let canvas_bottom: HtmlCanvasElement =
             document.create_element("canvas").unwrap().unchecked_into();
@@ -689,7 +691,7 @@ impl Renderer {
 
     /// Returns the HTML element. This can be attached anywhere in the DOM with
     /// any desired positioning and size.
-    pub const fn element(&self) -> &Element {
+    pub const fn element(&self) -> &HtmlElement {
         &self.div
     }
 


### PR DESCRIPTION
This allows you to add a child window to a hotkey hook on the web, allowing it to receive hotkey events for the window as well.

Additionally, there's some small changes to the Web Renderer:
- The child canvas elements are relative, but the parent was not marked as absolute.
- The parent element is always an HTML element, which was not reflected in the type. It's technically also a `div` element, but we don't want to guarantee that, since it could be changed in the future. This may be the case if we switch to only a single canvas element in the future.