### PR TITLE
Turn More Functions Into `const fn` Functions

### DIFF
--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -15,14 +15,14 @@ mod wasm_bindgen;
 use clap::Parser;
 use std::{
     collections::BTreeMap,
-    fs::{self, create_dir_all, remove_dir_all, File},
+    fs::{self, File, create_dir_all, remove_dir_all},
     io::{BufWriter, Read, Result},
     path::PathBuf,
     rc::Rc,
 };
 use syn::{
-    parse_file, Expr, ExprLit, FnArg, Item, ItemFn, Lit, Meta, MetaList, Pat, ReturnType,
-    Signature, Type as SynType, Visibility,
+    Expr, ExprLit, FnArg, Item, ItemFn, Lit, Meta, MetaList, Pat, ReturnType, Signature,
+    Type as SynType, Visibility, parse_file,
 };
 
 #[derive(clap::Parser)]
@@ -106,7 +106,7 @@ fn get_type(ty: &SynType) -> Type {
             ty
         }
         SynType::Path(path) => {
-            let segment = path.path.segments.iter().last().expect("Weird path");
+            let segment = path.path.segments.iter().next_back().expect("Weird path");
             let mut name = segment.ident.to_string();
             let is_nullable = if let Some(rest) = name.strip_prefix("Nullable") {
                 name = rest.to_string();

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -1,8 +1,8 @@
 //! Provides different helper functions.
 
 use crate::{
-    comparison::best_segments, settings::SemanticColor, timing::Snapshot, Run, Segment, TimeSpan,
-    Timer, TimerPhase, TimingMethod,
+    Run, Segment, TimeSpan, Timer, TimerPhase, TimingMethod, comparison::best_segments,
+    settings::SemanticColor, timing::Snapshot,
 };
 
 /// Gets the last non-live delta in the [`Run`] starting from `segment_index`.
@@ -254,7 +254,7 @@ pub fn live_segment_delta(
 ///
 /// - `timer`: The current [`Timer`].
 /// - `split_delta`: Specifies whether to return a split delta rather than a
-///    segment delta and to start showing the live segment once you are behind.
+///   segment delta and to start showing the live segment once you are behind.
 /// - `comparison`: The comparison that you are comparing with.
 /// - `method`: The [`TimingMethod`] that you are using.
 ///
@@ -300,7 +300,7 @@ pub fn check_live_delta(
 /// - `time_difference`: The delta that you want to find a color for.
 /// - `segment_index`: The split number that is associated with this delta.
 /// - `show_segment_deltas`: Can show ahead gaining and behind losing colors if
-///    true.
+///   true.
 /// - `show_best_segments`: Can show the best segment color if true.
 /// - `comparison`: The comparison that you are comparing this delta to.
 /// - `method`: The [`TimingMethod`] of this delta.

--- a/src/component/blank_space.rs
+++ b/src/component/blank_space.rs
@@ -73,7 +73,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 
@@ -83,7 +83,7 @@ impl Component {
     }
 
     /// Updates the component's state.
-    pub fn update_state(&self, state: &mut State) {
+    pub const fn update_state(&self, state: &mut State) {
         state.background = self.settings.background;
         state.size = self.settings.size;
     }

--- a/src/component/current_comparison.rs
+++ b/src/component/current_comparison.rs
@@ -4,9 +4,9 @@
 
 use super::key_value;
 use crate::{
+    Timer,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
-    Timer,
 };
 use serde_derive::{Deserialize, Serialize};
 
@@ -62,7 +62,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -5,15 +5,15 @@
 
 use super::key_value;
 use crate::{
+    TimerPhase,
     analysis::current_pace,
     comparison,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::{
-        formatter::{Accuracy, Regular, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, Regular, TimeFormatter},
     },
-    TimerPhase,
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
@@ -79,7 +79,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -4,15 +4,15 @@
 
 use super::key_value;
 use crate::{
+    GeneralLayoutSettings,
     analysis::{delta, state_helper},
     comparison,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
     timing::{
-        formatter::{Accuracy, Delta, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, Delta, TimeFormatter},
     },
-    GeneralLayoutSettings,
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
@@ -80,7 +80,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -11,11 +11,10 @@
 // edge. "Content" is the rest (the area inside).
 
 use crate::{
-    analysis, comparison,
+    GeneralLayoutSettings, TimeSpan, Timer, TimerPhase, analysis, comparison,
     platform::prelude::*,
     settings::{Color, Field, SettingsDescription, Value},
     timing::Snapshot,
-    GeneralLayoutSettings, TimeSpan, Timer, TimerPhase,
 };
 use alloc::borrow::Cow;
 use serde_derive::{Deserialize, Serialize};
@@ -206,7 +205,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 
@@ -388,7 +387,7 @@ impl Component {
         Some(x_axis)
     }
 
-    fn copy_settings_to_state(&self, state: &mut State) {
+    const fn copy_settings_to_state(&self, state: &mut State) {
         let settings = &self.settings;
         (state.top_background_color, state.bottom_background_color) = if settings.flip_graph {
             (

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -68,7 +68,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -6,15 +6,15 @@
 
 use super::key_value;
 use crate::{
+    TimerPhase,
     analysis::possible_time_save,
     comparison,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::{
-        formatter::{Accuracy, SegmentTime, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, SegmentTime, TimeFormatter},
     },
-    TimerPhase,
 };
 use alloc::borrow::Cow;
 use core::fmt::Write as FmtWrite;
@@ -86,7 +86,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -8,14 +8,13 @@
 
 use super::key_value;
 use crate::{
-    analysis, comparison,
+    GeneralLayoutSettings, TimerPhase, analysis, comparison,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
     timing::{
-        formatter::{Accuracy, Delta, SegmentTime, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, Delta, SegmentTime, TimeFormatter},
     },
-    GeneralLayoutSettings, TimerPhase,
 };
 use alloc::borrow::Cow;
 use core::fmt::Write as FmtWrite;
@@ -88,7 +87,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -5,12 +5,12 @@
 
 use super::key_value;
 use crate::{
+    Timer, TimerPhase,
     analysis::state_helper::comparison_single_segment_time,
     comparison,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::formatter::{Accuracy, SegmentTime, TimeFormatter},
-    Timer, TimerPhase,
 };
 use alloc::borrow::Cow;
 use core::fmt::Write;
@@ -79,7 +79,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -38,7 +38,7 @@ impl Component {
     }
 
     /// Updates the component's state.
-    pub fn update_state(&self, _state: &mut State) {}
+    pub const fn update_state(&self, _state: &mut State) {}
 
     /// Calculates the component's state.
     pub const fn state(&self) -> State {

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -6,13 +6,13 @@
 //! [`Segment`](crate::run::Segment) needs to be shown all the time.
 
 use crate::{
+    GeneralLayoutSettings,
     platform::prelude::*,
     settings::{
         self, Color, Field, Gradient, ImageCache, ImageId, ListGradient, SettingsDescription, Value,
     },
-    timing::{formatter::Accuracy, Snapshot},
+    timing::{Snapshot, formatter::Accuracy},
     util::{Clear, ClearVec},
-    GeneralLayoutSettings,
 };
 use core::cmp::{max, min};
 use serde_derive::{Deserialize, Serialize};
@@ -242,19 +242,19 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 
     /// Scrolls up the window of the segments that are shown. Doesn't move the
     /// scroll window if it reaches the top of the segments.
-    pub fn scroll_up(&mut self) {
+    pub const fn scroll_up(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_sub(1);
     }
 
     /// Scrolls down the window of the segments that are shown. Doesn't move the
     /// scroll window if it reaches the bottom of the segments.
-    pub fn scroll_down(&mut self) {
+    pub const fn scroll_down(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_add(1);
     }
 

--- a/src/component/sum_of_best.rs
+++ b/src/component/sum_of_best.rs
@@ -9,11 +9,11 @@
 
 use super::key_value;
 use crate::{
+    Timer,
     analysis::sum_of_segments::calculate_best,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::formatter::{Accuracy, Regular, TimeFormatter},
-    Timer,
 };
 use core::fmt::Write;
 use serde_derive::{Deserialize, Serialize};
@@ -78,7 +78,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -5,11 +5,11 @@
 
 use super::key_value;
 use crate::{
+    Timer,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::formatter,
     util::PopulateString,
-    Timer,
 };
 use alloc::borrow::Cow;
 use core::mem;
@@ -178,7 +178,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -4,14 +4,14 @@
 //! current attempt is doing compared to the chosen comparison.
 
 use crate::{
+    GeneralLayoutSettings, TimeSpan, TimerPhase, TimingMethod,
     analysis::split_color,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
     timing::{
-        formatter::{timer as formatter, Accuracy, DigitsFormat, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, DigitsFormat, TimeFormatter, timer as formatter},
     },
-    GeneralLayoutSettings, TimeSpan, TimerPhase, TimingMethod,
 };
 use core::fmt::Write;
 use serde_derive::{Deserialize, Serialize};
@@ -174,7 +174,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -4,11 +4,11 @@
 //! total number of finished runs can be shown.
 
 use crate::{
+    Timer, TimerPhase,
     platform::prelude::*,
     settings::{
         Alignment, Color, Field, Gradient, Image, ImageCache, ImageId, SettingsDescription, Value,
     },
-    Timer, TimerPhase,
 };
 use core::fmt::Write;
 use livesplit_title_abbreviations::{abbreviate as abbreviate_title, abbreviate_category};
@@ -152,7 +152,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/component/total_playtime.rs
+++ b/src/component/total_playtime.rs
@@ -4,11 +4,11 @@
 
 use super::key_value;
 use crate::{
+    Timer, TimingMethod,
     analysis::total_playtime,
     platform::prelude::*,
     settings::{Color, Field, Gradient, SettingsDescription, Value},
     timing::formatter::{Days, Regular, TimeFormatter},
-    Timer, TimingMethod,
 };
 use core::fmt::Write;
 use serde_derive::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ impl Component {
     }
 
     /// Grants mutable access to the settings of the component.
-    pub fn settings_mut(&mut self) -> &mut Settings {
+    pub const fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
     }
 

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -348,7 +348,7 @@ impl Component {
 
     /// Tells the component to scroll up. This may be interpreted differently
     /// based on the kind of component. Most components will ignore this.
-    pub fn scroll_up(&mut self) {
+    pub const fn scroll_up(&mut self) {
         if let Component::Splits(component) = self {
             component.scroll_up();
         }
@@ -356,7 +356,7 @@ impl Component {
 
     /// Tells the component to scroll down. This may be interpreted differently
     /// based on the kind of component. Most components will ignore this.
-    pub fn scroll_down(&mut self) {
+    pub const fn scroll_down(&mut self) {
         if let Component::Splits(component) = self {
             component.scroll_down();
         }

--- a/src/layout/editor/mod.rs
+++ b/src/layout/editor/mod.rs
@@ -52,7 +52,6 @@ impl Editor {
     /// Closes the Layout Editor and gives back access to the modified Layout.
     /// In case you want to implement a Cancel Button, just drop the Layout
     /// object you get here.
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Drop unsupported.
     pub fn close(self) -> Layout {
         self.layout
     }
@@ -131,6 +130,7 @@ impl Editor {
     }
 
     /// Moves the selected component up, unless the first component is selected.
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn move_component_up(&mut self) {
         if self.can_move_component_up() {
             self.layout

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -76,7 +76,7 @@ impl Layout {
 
     /// Grants mutable access to the general settings of the layout that apply
     /// to all components.
-    pub fn general_settings_mut(&mut self) -> &mut GeneralSettings {
+    pub const fn general_settings_mut(&mut self) -> &mut GeneralSettings {
         &mut self.settings
     }
 

--- a/src/rendering/resource/handles.rs
+++ b/src/rendering/resource/handles.rs
@@ -24,7 +24,6 @@ impl<A> Handles<A> {
     }
 
     /// Get the handles's next ID.
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Drop is unsupported.
     pub fn into_next_id(self) -> usize {
         self.next_id
     }

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -106,7 +106,6 @@ impl Editor {
     /// Closes the Run Editor and gives back access to the modified Run object.
     /// In case you want to implement a Cancel Button, just drop the Run object
     /// you get here.
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Drop is unsupported.
     pub fn close(self) -> Run {
         self.run
     }
@@ -129,6 +128,7 @@ impl Editor {
         self.update_segment_list();
     }
 
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     fn active_segment_index(&self) -> usize {
         *self.selected_segments.last().unwrap()
     }
@@ -203,7 +203,7 @@ impl Editor {
         self.selected_segments.push(index);
     }
 
-    fn raise_run_edited(&mut self) {
+    const fn raise_run_edited(&mut self) {
         self.run.mark_as_modified();
     }
 
@@ -245,7 +245,7 @@ impl Editor {
 
     /// Sets the timer offset. The timer offset specifies the time, the timer
     /// starts at when starting a new attempt.
-    pub fn set_offset(&mut self, offset: TimeSpan) {
+    pub const fn set_offset(&mut self, offset: TimeSpan) {
         self.run.set_offset(offset);
         self.raise_run_edited();
     }
@@ -266,7 +266,7 @@ impl Editor {
     /// Sets the attempt count. Changing this has no affect on the attempt
     /// history or the segment history. This number is mostly just a visual
     /// number for the runner.
-    pub fn set_attempt_count(&mut self, attempts: u32) {
+    pub const fn set_attempt_count(&mut self, attempts: u32) {
         self.run.set_attempt_count(attempts);
         self.raise_run_edited();
     }

--- a/src/run/editor/segment_row.rs
+++ b/src/run/editor/segment_row.rs
@@ -1,7 +1,7 @@
 use core::borrow::Borrow;
 
-use super::{parse_positive, Editor, ParseError};
-use crate::{settings::Image, util::PopulateString, TimeSpan};
+use super::{Editor, ParseError, parse_positive};
+use crate::{TimeSpan, settings::Image, util::PopulateString};
 
 /// A Segment Row describes the segment in the Run Editor actively selected for
 /// editing.
@@ -59,7 +59,7 @@ impl<'a> SegmentRow<&'a Editor> {
 }
 
 impl<'a> SegmentRow<&'a mut Editor> {
-    pub(super) fn new_mut(index: usize, editor: &'a mut Editor) -> Self {
+    pub(super) const fn new_mut(index: usize, editor: &'a mut Editor) -> Self {
         SegmentRow { index, editor }
     }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -134,6 +134,7 @@ impl Run {
 
     /// Accesses the name of the game this Run is for.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn game_name(&self) -> &str {
         &self.game_name
     }
@@ -161,6 +162,7 @@ impl Run {
 
     /// Accesses the name of the category this Run is for.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn category_name(&self) -> &str {
         &self.category_name
     }
@@ -182,7 +184,7 @@ impl Run {
 
     /// Sets the amount of runs that have been attempted with these splits.
     #[inline]
-    pub fn set_attempt_count(&mut self, attempts: u32) {
+    pub const fn set_attempt_count(&mut self, attempts: u32) {
         self.attempt_count = attempts;
     }
 
@@ -196,13 +198,13 @@ impl Run {
     /// Grants mutable access to the additional metadata of this Run, like the
     /// platform and region of the game.
     #[inline]
-    pub fn metadata_mut(&mut self) -> &mut RunMetadata {
+    pub const fn metadata_mut(&mut self) -> &mut RunMetadata {
         &mut self.metadata
     }
 
     /// Sets the time an attempt of this Run should start at.
     #[inline]
-    pub fn set_offset(&mut self, offset: TimeSpan) {
+    pub const fn set_offset(&mut self, offset: TimeSpan) {
         self.offset = offset;
     }
 
@@ -214,20 +216,21 @@ impl Run {
 
     /// Marks a Run that a new Attempt has started. If you use it with a Timer,
     /// this is done automatically.
-    pub fn start_next_run(&mut self) {
+    pub const fn start_next_run(&mut self) {
         self.attempt_count += 1;
         self.has_been_modified = true;
     }
 
     /// Accesses the Segments of this Run object.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn segments(&self) -> &[Segment] {
         &self.segments
     }
 
     /// Grants mutable access to the Segments of this Run object.
     #[inline]
-    pub fn segments_mut(&mut self) -> &mut Vec<Segment> {
+    pub const fn segments_mut(&mut self) -> &mut Vec<Segment> {
         &mut self.segments
     }
 
@@ -262,6 +265,7 @@ impl Run {
     /// information. Information about the individual segments is stored within
     /// each segment.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn attempt_history(&self) -> &[Attempt] {
         &self.attempt_history
     }
@@ -270,6 +274,7 @@ impl Run {
     /// includes `Personal Best` but excludes all the other Comparison
     /// Generators.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn custom_comparisons(&self) -> &[String] {
         &self.custom_comparisons
     }
@@ -282,7 +287,7 @@ impl Run {
     ///
     /// You may not delete the `Personal Best` comparison.
     #[inline]
-    pub fn custom_comparisons_mut(&mut self) -> &mut Vec<String> {
+    pub const fn custom_comparisons_mut(&mut self) -> &mut Vec<String> {
         &mut self.custom_comparisons
     }
 
@@ -311,6 +316,7 @@ impl Run {
 
     /// Accesses the Auto Splitter Settings that are encoded as XML.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn auto_splitter_settings(&self) -> &str {
         &self.auto_splitter_settings
     }
@@ -322,6 +328,7 @@ impl Run {
     /// You need to ensure that the Auto Splitter Settings are encoded as data
     /// that would be valid as an interior of an XML element.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn auto_splitter_settings_mut(&mut self) -> &mut String {
         &mut self.auto_splitter_settings
     }
@@ -385,14 +392,14 @@ impl Run {
     /// Marks the Run as modified, so that it is known that there are changes
     /// that should be saved.
     #[inline]
-    pub fn mark_as_modified(&mut self) {
+    pub const fn mark_as_modified(&mut self) {
         self.has_been_modified = true;
     }
 
     /// Marks the Run as unmodified, so that it is known that all the changes
     /// have been saved.
     #[inline]
-    pub fn mark_as_unmodified(&mut self) {
+    pub const fn mark_as_unmodified(&mut self) {
         self.has_been_modified = false;
     }
 

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -1,8 +1,8 @@
 use crate::{
     platform::prelude::*,
     util::{
-        ordered_map::{Iter, Map},
         PopulateString,
+        ordered_map::{Iter, Map},
     },
 };
 use serde_derive::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub struct CustomVariable {
 impl CustomVariable {
     /// Turns the custom variable into a permanent one. If it already is
     /// permanent variable, nothing happens.
-    pub fn permanent(&mut self) -> &mut Self {
+    pub const fn permanent(&mut self) -> &mut Self {
         self.is_permanent = true;
         self
     }
@@ -91,6 +91,7 @@ impl RunMetadata {
     /// changed once the Personal Best doesn't match up with that record
     /// anymore. This may be empty if there's no association.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn run_id(&self) -> &str {
         &self.run_id
     }
@@ -109,6 +110,7 @@ impl RunMetadata {
     /// Accesses the name of the platform this game is run on. This may be empty
     /// if it's not specified.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn platform_name(&self) -> &str {
         &self.platform_name
     }
@@ -133,13 +135,14 @@ impl RunMetadata {
     /// Specifies whether this speedrun is done on an emulator. Keep in mind
     /// that `false` may also mean that this information is simply not known.
     #[inline]
-    pub fn set_emulator_usage(&mut self, uses_emulator: bool) {
+    pub const fn set_emulator_usage(&mut self, uses_emulator: bool) {
         self.uses_emulator = uses_emulator;
     }
 
     /// Accesses the name of the region this game is from. This may be empty if
     /// it's not specified.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn region_name(&self) -> &str {
         &self.region_name
     }

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -2,8 +2,8 @@ use hashbrown::HashMap;
 
 use super::Comparisons;
 use crate::{
-    comparison::personal_best, platform::prelude::*, settings::Image, util::PopulateString,
-    SegmentHistory, Time, TimeSpan, TimingMethod,
+    SegmentHistory, Time, TimeSpan, TimingMethod, comparison::personal_best, platform::prelude::*,
+    settings::Image, util::PopulateString,
 };
 
 /// A `Segment` describes a point in a speedrun that is suitable for storing a
@@ -45,6 +45,7 @@ impl Segment {
 
     /// Accesses the name of the segment.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -73,7 +74,7 @@ impl Segment {
     /// Grants mutable access to the comparison times stored in the Segment.
     /// This includes both the custom comparisons and the generated ones.
     #[inline]
-    pub fn comparisons_mut(&mut self) -> &mut Comparisons {
+    pub const fn comparisons_mut(&mut self) -> &mut Comparisons {
         &mut self.comparisons
     }
 
@@ -134,13 +135,13 @@ impl Segment {
 
     /// Grants mutable access to the Best Segment Time.
     #[inline]
-    pub fn best_segment_time_mut(&mut self) -> &mut Time {
+    pub const fn best_segment_time_mut(&mut self) -> &mut Time {
         &mut self.best_segment_time
     }
 
     /// Sets the Best Segment Time.
     #[inline]
-    pub fn set_best_segment_time(&mut self, time: Time) {
+    pub const fn set_best_segment_time(&mut self, time: Time) {
         self.best_segment_time = time;
     }
 
@@ -152,13 +153,13 @@ impl Segment {
 
     /// Grants mutable access to the split time of the current attempt.
     #[inline]
-    pub fn split_time_mut(&mut self) -> &mut Time {
+    pub const fn split_time_mut(&mut self) -> &mut Time {
         &mut self.split_time
     }
 
     /// Sets the split time of the current attempt.
     #[inline]
-    pub fn set_split_time(&mut self, time: Time) {
+    pub const fn set_split_time(&mut self, time: Time) {
         self.split_time = time;
     }
 
@@ -176,7 +177,7 @@ impl Segment {
 
     /// Grants mutable access to the Segment History of this segment.
     #[inline]
-    pub fn segment_history_mut(&mut self) -> &mut SegmentHistory {
+    pub const fn segment_history_mut(&mut self) -> &mut SegmentHistory {
         &mut self.segment_history
     }
 
@@ -187,7 +188,7 @@ impl Segment {
 
     /// Grants mutable access to the segment's variables for the current
     /// attempt.
-    pub fn variables_mut(&mut self) -> &mut HashMap<String, String> {
+    pub const fn variables_mut(&mut self) -> &mut HashMap<String, String> {
         &mut self.variables
     }
 

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -177,6 +177,7 @@ impl Image {
     /// Accesses the image's data. If the image's data is empty, this returns an
     /// empty slice.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn data(&self) -> &[u8] {
         self
     }

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -1,4 +1,5 @@
 use crate::{
+    TimingMethod,
     component::{
         splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith},
         timer::DeltaGradient,
@@ -8,7 +9,6 @@ use crate::{
     platform::prelude::*,
     settings::{Alignment, Color, Font, Gradient, ImageId, LayoutBackground, ListGradient},
     timing::formatter::{Accuracy, DigitsFormat},
-    TimingMethod,
 };
 use core::result::Result as StdResult;
 use serde_derive::{Deserialize, Serialize};
@@ -220,7 +220,6 @@ pub enum Error {
 /// The Result type for conversions from Values to other types.
 pub type Result<T> = StdResult<T, Error>;
 
-#[allow(clippy::missing_const_for_fn)] // FIXME: Drop is unsupported.
 impl Value {
     /// Tries to convert the value into a boolean.
     pub fn into_bool(self) -> Result<bool> {

--- a/src/timing/timer/active_attempt.rs
+++ b/src/timing/timer/active_attempt.rs
@@ -1,6 +1,6 @@
 use crate::{
-    event::{Error, Event, Result},
     AtomicDateTime, Run, Time, TimeSpan, TimeStamp, TimingMethod,
+    event::{Error, Event, Result},
 };
 
 #[derive(Debug, Clone)]
@@ -149,7 +149,7 @@ impl ActiveAttempt {
         }
     }
 
-    pub fn current_split_index_mut(&mut self) -> Option<&mut usize> {
+    pub const fn current_split_index_mut(&mut self) -> Option<&mut usize> {
         match &mut self.state {
             State::NotEnded {
                 current_split_index,

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -171,7 +171,7 @@ impl Timer {
     /// Marks the Run as unmodified, so that it is known that all the changes
     /// have been saved.
     #[inline]
-    pub fn mark_as_unmodified(&mut self) {
+    pub const fn mark_as_unmodified(&mut self) {
         self.run.mark_as_unmodified();
     }
 
@@ -220,13 +220,13 @@ impl Timer {
 
     /// Sets the current timing method to the timing method provided.
     #[inline]
-    pub fn set_current_timing_method(&mut self, method: TimingMethod) {
+    pub const fn set_current_timing_method(&mut self, method: TimingMethod) {
         self.current_timing_method = method;
     }
 
     /// Toggles between the `Real Time` and `Game Time` timing methods.
     #[inline]
-    pub fn toggle_timing_method(&mut self) {
+    pub const fn toggle_timing_method(&mut self) {
         self.current_timing_method = match self.current_timing_method {
             TimingMethod::RealTime => TimingMethod::GameTime,
             TimingMethod::GameTime => TimingMethod::RealTime,
@@ -236,6 +236,7 @@ impl Timer {
     /// Returns the current comparison that is being compared against. This may
     /// be a custom comparison or one of the Comparison Generators.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn current_comparison(&self) -> &str {
         &self.current_comparison
     }
@@ -669,7 +670,7 @@ impl Timer {
 
     /// Deinitializes Game Time for the current attempt.
     #[inline]
-    pub fn deinitialize_game_time(&mut self) {
+    pub const fn deinitialize_game_time(&mut self) {
         if let Some(active_attempt) = &mut self.active_attempt {
             active_attempt.loading_times = None;
         }


### PR DESCRIPTION
Clippy now suggests that we should turn more functions into `const fn` functions, so this is what we do here. It seems like it can't reason about `Deref` and thus thinks more functions can be `const fn` than what is actually possible.