### PR TITLE
Fix Pointers to Lengths in Auto Splitting API

### DIFF
--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -27,13 +27,13 @@ sysinfo = { version = "0.33.1", default-features = false, features = [
   "system",
 ] }
 time = { version = "0.3.3", default-features = false }
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "ead1c7417284d1230d210cf13a6fcd26484aa5b1", default-features = false, features = [
+wasmtime = { version = "32.0.0", default-features = false, features = [
   "cranelift",
   "gc-drc",
   "parallel-compilation",
   "runtime",
 ] }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "ead1c7417284d1230d210cf13a6fcd26484aa5b1", default-features = false, features = [
+wasmtime-wasi = { version = "32.0.0", default-features = false, features = [
   "preview1",
 ] }
 

--- a/crates/livesplit-auto-splitting/src/runtime/api/process.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/process.rs
@@ -242,6 +242,9 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
 
                 let len_bytes = get_arr_mut(memory, len_ptr)?;
                 if let Some(path) = path {
+                    // Record the previous length to check if the provided buffer is large enough
+                    // to hold the path. This ensures error handling works as intended and prevents
+                    // potential buffer overflows.
                     let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (path.len() as u32).to_le_bytes();
 

--- a/crates/livesplit-auto-splitting/src/runtime/api/process.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/process.rs
@@ -1,13 +1,13 @@
 use std::str;
 
-use anyhow::{format_err, Context as _, Result};
+use anyhow::{Context as _, Result, format_err};
 use slotmap::{Key, KeyData};
 use wasmtime::{Caller, Linker};
 
 use crate::{
+    CreationError, Process, Timer,
     runtime::{Context, ProcessKey},
     timer::LogLevel,
-    CreationError, Process, Timer,
 };
 
 use super::{get_arr_mut, get_slice_mut, get_str, get_two_slice_mut, memory_and_context};
@@ -214,6 +214,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 if let Ok(path) = path {
                     let path_len = u32::from_le_bytes(*path_len_bytes) as usize;
                     *path_len_bytes = (path.len() as u32).to_le_bytes();
+
                     if path_len < path.len() {
                         return Ok(0u32);
                     }
@@ -241,9 +242,9 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
 
                 let len_bytes = get_arr_mut(memory, len_ptr)?;
                 if let Some(path) = path {
+                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (path.len() as u32).to_le_bytes();
 
-                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     if len < path.len() {
                         return Ok(0u32);
                     }

--- a/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
@@ -3,10 +3,10 @@ use std::{
     sync::atomic,
 };
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use wasmtime::{Caller, Linker};
 
-use crate::{runtime::Context, timer::LogLevel, CreationError, Timer};
+use crate::{CreationError, Timer, runtime::Context, timer::LogLevel};
 
 use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
 
@@ -56,9 +56,11 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .func_wrap("env", "runtime_get_os", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
+
                 let len_bytes = get_arr_mut(memory, len_ptr)?;
                 let len = u32::from_le_bytes(*len_bytes) as usize;
                 *len_bytes = (OS.len() as u32).to_le_bytes();
+
                 if len < OS.len() {
                     return Ok(0u32);
                 }
@@ -74,9 +76,11 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .func_wrap("env", "runtime_get_arch", {
             |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
+
                 let len_bytes = get_arr_mut(memory, len_ptr)?;
                 let len = u32::from_le_bytes(*len_bytes) as usize;
                 *len_bytes = (ARCH.len() as u32).to_le_bytes();
+
                 if len < ARCH.len() {
                     return Ok(0u32);
                 }

--- a/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
@@ -1,10 +1,11 @@
-use anyhow::{format_err, Result};
+use anyhow::{Result, format_err};
 use slotmap::{Key, KeyData};
 use wasmtime::{Caller, Linker};
 
 use crate::{
+    CreationError, Timer,
     runtime::{Context, SettingValueKey, SettingsListKey, SettingsMapKey},
-    settings, CreationError, Timer,
+    settings,
 };
 
 use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
@@ -302,9 +303,9 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let len_bytes = get_arr_mut(memory, buf_len_ptr)?;
 
                 if let settings::Value::String(value) = setting_value {
+                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (value.len() as u32).to_le_bytes();
 
-                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     if len < value.len() {
                         return Ok(0u32);
                     }

--- a/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
@@ -303,6 +303,9 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let len_bytes = get_arr_mut(memory, buf_len_ptr)?;
 
                 if let settings::Value::String(value) = setting_value {
+                    // Store the original length before updating the pointer.
+                    // This ensures the original value is used for error handling logic
+                    // to determine if the buffer is large enough to hold the string.
                     let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (value.len() as u32).to_le_bytes();
 

--- a/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
@@ -1,10 +1,11 @@
-use anyhow::{format_err, Result};
+use anyhow::{Result, format_err};
 use slotmap::{Key, KeyData};
 use wasmtime::{Caller, Linker};
 
 use crate::{
+    CreationError, Timer,
     runtime::{Context, SettingValueKey, SettingsMapKey},
-    settings, CreationError, Timer,
+    settings,
 };
 
 use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
@@ -202,9 +203,9 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let slot = settings_map.get_by_index(index.try_into().unwrap_or(usize::MAX));
 
                 if let Some((key, _)) = slot {
+                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (key.len() as u32).to_le_bytes();
 
-                    let len = u32::from_le_bytes(*len_bytes) as usize;
                     if len < key.len() {
                         return Ok(0u32);
                     }

--- a/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
@@ -203,6 +203,8 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                 let slot = settings_map.get_by_index(index.try_into().unwrap_or(usize::MAX));
 
                 if let Some((key, _)) = slot {
+                    // Capture the original length before overwriting it, as it is used
+                    // to check if the buffer is large enough to hold the key.
                     let len = u32::from_le_bytes(*len_bytes) as usize;
                     *len_bytes = (key.len() as u32).to_le_bytes();
 


### PR DESCRIPTION
Apparently, multiple parts of the API accidentally wrote the lengths of the value back to the length pointers before reading the length. So the error cases never actually worked correctly.