### PR TITLE
Add timer_current_attempt_segments_splitted

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -99,6 +99,14 @@ impl MemoryRangeFlags {
 unsafe extern "C" {
     /// Gets the state that the timer currently is in.
     pub safe fn timer_get_state() -> TimerState;
+    /// Lists segments splitted or skipped in the current attempt.
+    /// Returns `false` if the buffer is too small.
+    /// After this call, no matter whether it was successful or not,
+    /// the `buf_len_ptr` will be set to the required buffer size.
+    pub fn timer_current_attempt_segments_splitted(
+        buf_ptr: *mut bool,
+        buf_len_ptr: *mut usize,
+    ) -> bool;
 
     /// Starts the timer.
     pub safe fn timer_start();

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -35,6 +35,8 @@ pub enum LogLevel {
 pub trait Timer: Send {
     /// Returns the current state of the timer.
     fn state(&self) -> TimerState;
+    /// Lists segments splitted or skipped in the current attempt.
+    fn current_attempt_segments_splitted(&self) -> Vec<bool>;
     /// Starts the timer.
     fn start(&mut self);
     /// Splits the current segment.

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -14,6 +14,9 @@ impl Timer for DummyTimer {
     fn state(&self) -> TimerState {
         TimerState::NotRunning
     }
+    fn current_attempt_segments_splitted(&self) -> Vec<bool> {
+        Vec::new()
+    }
     fn start(&mut self) {}
     fn split(&mut self) {}
     fn skip_split(&mut self) {}


### PR DESCRIPTION
Adds timer_current_attempt_segments_splitted, which allows autosplitters to detect split/skip/undo events, even if they were done manually by the user.

I've tested it with a demo autosplitter that sets custom variables to display the events it detects, and recorded that here: https://www.youtube.com/watch?v=RfeMQrF71oY

This PR is an alternative to https://github.com/LiveSplit/livesplit-core/pull/884, implementing similar functionality by a different method. Using this PR's timer_current_attempt_segments_splitted requires using alloc, but using https://github.com/LiveSplit/livesplit-core/pull/884 's timer_current_split_index and timer_segment_splitted does not.