### PR TITLE
Add timer_current_split_index and timer_segment_splitted

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -105,9 +105,12 @@ unsafe extern "C" {
     /// when the attempt is finished, but has not been reset.
     /// So you need to be careful when using this value for indexing.
     /// Same index does not imply same split on undo and then split.
-    pub safe fn timer_current_split_index() -> i32;
+    pub safe fn timer_current_split_index() -> i64;
     /// Whether the segment at `idx` was splitted this attempt.
-    pub safe fn timer_segment_splitted(idx: i32) -> bool;
+    /// Returns `1` if the segment was splitted, or `0` if skipped.
+    /// If `idx` is greater than or equal to the current split index,
+    /// `-1` is returned instead.
+    pub safe fn timer_segment_splitted(idx: u64) -> i32;
 
     /// Starts the timer.
     pub safe fn timer_start();

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -105,9 +105,12 @@
 //!     /// when the attempt is finished, but has not been reset.
 //!     /// So you need to be careful when using this value for indexing.
 //!     /// Same index does not imply same split on undo and then split.
-//!     pub safe fn timer_current_split_index() -> i32;
+//!     pub safe fn timer_current_split_index() -> i64;
 //!     /// Whether the segment at `idx` was splitted this attempt.
-//!     pub safe fn timer_segment_splitted(idx: i32) -> bool;
+//!     /// Returns `1` if the segment was splitted, or `0` if skipped.
+//!     /// If `idx` is greater than or equal to the current split index,
+//!     /// `-1` is returned instead.
+//!     pub safe fn timer_segment_splitted(idx: u64) -> i32;
 //!
 //!     /// Starts the timer.
 //!     pub safe fn timer_start();

--- a/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
@@ -20,7 +20,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
                     .data()
                     .timer
                     .current_split_index()
-                    .map_or(-1, |i| i as i32)
+                    .map_or(-1, |i| i as i64)
             }
         })
         .map_err(|source| CreationError::LinkFunction {
@@ -28,11 +28,12 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "timer_current_split_index",
         })?
         .func_wrap("env", "timer_segment_splitted", {
-            |caller: Caller<'_, Context<T>>, index: i32| {
-                let Ok(idx) = usize::try_from(index) else {
-                    return Ok(0u32);
-                };
-                Ok(caller.data().timer.segment_splitted(idx) as u32)
+            |caller: Caller<'_, Context<T>>, index: u64| {
+                Ok(caller
+                    .data()
+                    .timer
+                    .segment_splitted(index as usize)
+                    .map_or(-1, |b| b as i32))
             }
         })
         .map_err(|source| CreationError::LinkFunction {

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -43,7 +43,11 @@ pub trait Timer: Send {
     /// Same index does not imply same split on undo and then split.
     fn current_split_index(&self) -> Option<usize>;
     /// Whether the segment at `idx` was splitted this attempt.
-    fn segment_splitted(&self, idx: usize) -> bool;
+    /// Returns `Some(true)` if the segment was splitted,
+    /// or `Some(false)` if skipped.
+    /// If `idx` is greater than or equal to the current split index,
+    /// `None` is returned instead.
+    fn segment_splitted(&self, idx: usize) -> Option<bool>;
     /// Starts the timer.
     fn start(&mut self);
     /// Splits the current segment.

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -17,8 +17,8 @@ impl Timer for DummyTimer {
     fn current_split_index(&self) -> Option<usize> {
         None
     }
-    fn segment_splitted(&self, _idx: usize) -> bool {
-        false
+    fn segment_splitted(&self, _idx: usize) -> Option<bool> {
+        None
     }
     fn start(&mut self) {}
     fn split(&mut self) {}

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -105,9 +105,12 @@
 //!     /// when the attempt is finished, but has not been reset.
 //!     /// So you need to be careful when using this value for indexing.
 //!     /// Same index does not imply same split on undo and then split.
-//!     pub safe fn timer_current_split_index() -> i32;
-//!     /// Whether the segment given by `idx` was splitted this attempt.
-//!     pub safe fn timer_segment_splitted(idx: i32) -> bool;
+//!     pub safe fn timer_current_split_index() -> i64;
+//!     /// Whether the segment at `idx` was splitted this attempt.
+//!     /// Returns `1` if the segment was splitted, or `0` if skipped.
+//!     /// If `idx` is greater than or equal to the current split index,
+//!     /// `-1` is returned instead.
+//!     pub safe fn timer_segment_splitted(idx: u64) -> i32;
 //!
 //!     /// Starts the timer.
 //!     pub safe fn timer_start();
@@ -800,13 +803,19 @@ impl<E: event::CommandSink + TimerQuery + Send> AutoSplitTimer for Timer<E> {
         self.0.get_timer().current_split_index()
     }
 
-    fn segment_splitted(&self, idx: usize) -> bool {
-        self.0
-            .get_timer()
-            .run()
-            .segments()
-            .get(idx)
-            .is_some_and(|segment| segment.split_time().real_time.is_some())
+    fn segment_splitted(&self, idx: usize) -> Option<bool> {
+        let t = self.0.get_timer();
+        if !(idx < t.current_split_index()?) {
+            return None;
+        }
+        Some(
+            t.run()
+                .segments()
+                .get(idx)?
+                .split_time()
+                .real_time
+                .is_some(),
+        )
     }
 
     fn start(&mut self) {


### PR DESCRIPTION
Adds timer_current_split_index and timer_segment_splitted, which allow autosplitters to detect split/skip/undo events, even if they were done manually by the user.

I've tested it with a demo autosplitter that sets custom variables to display the events it detects, and recorded that here: https://www.youtube.com/watch?v=l1kdwRjxT9Y

This PR is an alternative to https://github.com/LiveSplit/livesplit-core/pull/882, implementing similar functionality by a different method. Using https://github.com/LiveSplit/livesplit-core/pull/882 's timer_current_attempt_segments_splitted requires using alloc, but using this PR's timer_current_split_index and timer_segment_splitted does not.