### PR TITLE
Some Cleanup for Rust 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
     "/README.md",
 ]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/capi/bind_gen/src/swift/code.rs
+++ b/capi/bind_gen/src/swift/code.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Result, Write},
 };
 
-fn get_hl_type(ty: &Type) -> Cow<str> {
+fn get_hl_type(ty: &Type) -> Cow<'_, str> {
     if ty.is_custom {
         match ty.kind {
             TypeKind::Ref => Cow::Owned(format!("{}Ref", ty.name)),
@@ -46,7 +46,7 @@ fn get_ll_type(ty: &Type) -> &str {
     }
 }
 
-fn get_input_name(name: &str) -> Cow<str> {
+fn get_input_name(name: &str) -> Cow<'_, str> {
     if name == "this" {
         Cow::Borrowed("self")
     } else {

--- a/capi/src/auto_splitting_runtime.rs
+++ b/capi/src/auto_splitting_runtime.rs
@@ -12,10 +12,10 @@ type AutoSplittingRuntime = livesplit_core::auto_splitting::Runtime<livesplit_co
 use livesplit_core::SharedTimer;
 
 #[cfg(not(feature = "auto-splitting"))]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct AutoSplittingRuntime;
 
-#[allow(warnings)]
+#[expect(warnings)]
 #[cfg(not(feature = "auto-splitting"))]
 impl AutoSplittingRuntime {
     pub fn new() -> Self {

--- a/capi/src/command_sink.rs
+++ b/capi/src/command_sink.rs
@@ -11,8 +11,8 @@
 use std::{borrow::Cow, future::Future, ops::Deref, pin::Pin, sync::Arc};
 
 use livesplit_core::{
-    event::{self, Result},
     TimeSpan, Timer, TimingMethod,
+    event::{self, Result},
 };
 
 use crate::shared_timer::OwnedSharedTimer;
@@ -50,7 +50,7 @@ pub(crate) trait CommandSinkAndQuery: Send + Sync + 'static {
     fn dyn_undo_all_pauses(&self) -> Fut;
     fn dyn_switch_to_previous_comparison(&self) -> Fut;
     fn dyn_switch_to_next_comparison(&self) -> Fut;
-    fn dyn_set_current_comparison(&self, comparison: Cow<'_, str>) -> Fut;
+    fn dyn_set_current_comparison(&self, comparison: Cow<str>) -> Fut;
     fn dyn_toggle_timing_method(&self) -> Fut;
     fn dyn_set_current_timing_method(&self, method: TimingMethod) -> Fut;
     fn dyn_initialize_game_time(&self) -> Fut;
@@ -58,7 +58,7 @@ pub(crate) trait CommandSinkAndQuery: Send + Sync + 'static {
     fn dyn_pause_game_time(&self) -> Fut;
     fn dyn_resume_game_time(&self) -> Fut;
     fn dyn_set_loading_times(&self, time: TimeSpan) -> Fut;
-    fn dyn_set_custom_variable(&self, name: Cow<'_, str>, value: Cow<'_, str>) -> Fut;
+    fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut;
 }
 
 type Fut = Pin<Box<dyn Future<Output = Result> + 'static>>;
@@ -107,7 +107,7 @@ where
     fn dyn_switch_to_next_comparison(&self) -> Fut {
         Box::pin(self.switch_to_next_comparison())
     }
-    fn dyn_set_current_comparison(&self, comparison: Cow<'_, str>) -> Fut {
+    fn dyn_set_current_comparison(&self, comparison: Cow<str>) -> Fut {
         Box::pin(self.set_current_comparison(comparison))
     }
     fn dyn_toggle_timing_method(&self) -> Fut {
@@ -131,7 +131,7 @@ where
     fn dyn_set_loading_times(&self, time: TimeSpan) -> Fut {
         Box::pin(self.set_loading_times(time))
     }
-    fn dyn_set_custom_variable(&self, name: Cow<'_, str>, value: Cow<'_, str>) -> Fut {
+    fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut {
         Box::pin(self.set_custom_variable(name, value))
     }
 }
@@ -187,7 +187,7 @@ impl event::CommandSink for CommandSink {
 
     fn set_current_comparison(
         &self,
-        comparison: Cow<'_, str>,
+        comparison: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         self.0.dyn_set_current_comparison(comparison)
     }
@@ -225,8 +225,8 @@ impl event::CommandSink for CommandSink {
 
     fn set_custom_variable(
         &self,
-        name: Cow<'_, str>,
-        value: Cow<'_, str>,
+        name: Cow<str>,
+        value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         self.0.dyn_set_custom_variable(name, value)
     }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -4,8 +4,7 @@
     clippy::perf,
     clippy::style,
     clippy::needless_pass_by_ref_mut,
-    missing_docs,
-    rust_2018_idioms
+    missing_docs
 )]
 #![allow(clippy::missing_safety_doc, non_camel_case_types, non_snake_case)]
 
@@ -101,7 +100,7 @@ use livesplit_core::{Time, TimeSpan};
 /// type
 pub type Json = *const c_char;
 /// type
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type Nullablec_char = c_char;
 
 thread_local! {

--- a/capi/src/software_renderer.rs
+++ b/capi/src/software_renderer.rs
@@ -17,7 +17,7 @@ impl SoftwareRenderer {
         panic!("The software renderer is not compiled in.")
     }
 
-    #[allow(warnings)]
+    #[expect(warnings)]
     fn render(
         &mut self,
         _: &LayoutState,

--- a/capi/src/web_command_sink.rs
+++ b/capi/src/web_command_sink.rs
@@ -222,7 +222,7 @@ impl CommandSink for WebCommandSink {
 
     fn set_current_comparison(
         &self,
-        comparison: Cow<'_, str>,
+        comparison: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         debug_assert!(!self.locked.get());
         handle_action_value(
@@ -303,8 +303,8 @@ impl CommandSink for WebCommandSink {
 
     fn set_custom_variable(
         &self,
-        name: Cow<'_, str>,
-        value: Cow<'_, str>,
+        name: Cow<str>,
+        value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         debug_assert!(!self.locked.get());
         handle_action_value(self.set_custom_variable.as_ref().and_then(|f| {

--- a/capi/src/web_rendering.rs
+++ b/capi/src/web_rendering.rs
@@ -20,7 +20,7 @@ impl WebRenderer {
     /// default fonts. They are called "timer" and "fira". Make sure they are
     /// fully loaded before creating the renderer as otherwise information about
     /// a fallback font is cached instead.
-    #[allow(clippy::new_without_default)]
+    #[expect(clippy::new_without_default)]
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {

--- a/crates/livesplit-auto-splitting/Cargo.toml
+++ b/crates/livesplit-auto-splitting/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "livesplit-auto-splitting is a library that provides a runtime for running auto splitters that can control a speedrun timer. These auto splitters are provided as WebAssembly modules."
 keywords = ["speedrun", "timer", "livesplit", "auto-splitting"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -570,8 +570,7 @@
     clippy::style,
     clippy::missing_const_for_fn,
     clippy::undocumented_unsafe_blocks,
-    missing_docs,
-    rust_2018_idioms
+    missing_docs
 )]
 #![forbid(clippy::incompatible_msrv)]
 
@@ -595,6 +594,7 @@ const _: () = {
     assert_send_sync::<Process>();
     assert_send_sync::<Runtime>();
     assert_send_sync::<CompiledAutoSplitter>();
+    #[expect(dead_code)] // Not actually dead, as we use it for the assertion inside.
     const fn with_timer<T: Send + Sync + Timer>() {
         assert_send_sync::<AutoSplitter<T>>();
     }

--- a/crates/livesplit-auto-splitting/src/process.rs
+++ b/crates/livesplit-auto-splitting/src/process.rs
@@ -46,7 +46,7 @@ pub struct Process {
 }
 
 impl std::fmt::Debug for Process {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Process")
             .field("pid", &self.pid)
             .field("path", &self.path)

--- a/crates/livesplit-auto-splitting/src/runtime/api/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/mod.rs
@@ -1,6 +1,6 @@
 use std::str;
 
-use anyhow::{format_err, Context as _, Result};
+use anyhow::{Context as _, Result, format_err};
 use wasmtime::{Caller, Linker};
 
 use crate::{CreationError, Timer};
@@ -29,7 +29,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
 }
 
 fn memory_and_context<'a, T: Timer>(
-    caller: &'a mut Caller<'_, Context<T>>,
+    caller: &'a mut Caller<Context<T>>,
 ) -> (&'a mut [u8], &'a mut Context<T>) {
     caller.data().memory.unwrap().data_and_store_mut(caller)
 }

--- a/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
@@ -13,7 +13,7 @@ use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "runtime_set_tick_rate", {
-            |mut caller: Caller<'_, Context<T>>, ticks_per_sec: f64| -> Result<()> {
+            |mut caller: Caller<Context<T>>, ticks_per_sec: f64| -> Result<()> {
                 caller.data_mut().timer.log_runtime(
                     format_args!("New Tick Rate: {ticks_per_sec}"),
                     LogLevel::Debug,
@@ -42,7 +42,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "runtime_set_tick_rate",
         })?
         .func_wrap("env", "runtime_print_message", {
-            |mut caller: Caller<'_, Context<T>>, ptr: u32, len: u32| {
+            |mut caller: Caller<Context<T>>, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
                 let message = get_str(memory, ptr, len)?;
                 context.timer.log_auto_splitter(format_args!("{message}"));
@@ -54,7 +54,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "runtime_print_message",
         })?
         .func_wrap("env", "runtime_get_os", {
-            |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
+            |mut caller: Caller<Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
 
                 let len_bytes = get_arr_mut(memory, len_ptr)?;
@@ -74,7 +74,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "runtime_get_os",
         })?
         .func_wrap("env", "runtime_get_arch", {
-            |mut caller: Caller<'_, Context<T>>, ptr: u32, len_ptr: u32| {
+            |mut caller: Caller<Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);
 
                 let len_bytes = get_arr_mut(memory, len_ptr)?;

--- a/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/setting_value.rs
@@ -13,7 +13,7 @@ use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "setting_value_new_map", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64| {
                 let context = caller.data_mut();
 
                 let settings_map = context
@@ -33,7 +33,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_map",
         })?
         .func_wrap("env", "setting_value_new_list", {
-            |mut caller: Caller<'_, Context<T>>, settings_list: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64| {
                 let context = caller.data_mut();
 
                 let settings_list = context
@@ -53,7 +53,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_list",
         })?
         .func_wrap("env", "setting_value_new_bool", {
-            |mut caller: Caller<'_, Context<T>>, value: u32| {
+            |mut caller: Caller<Context<T>>, value: u32| {
                 Ok(caller
                     .data_mut()
                     .setting_values
@@ -67,7 +67,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_bool",
         })?
         .func_wrap("env", "setting_value_new_i64", {
-            |mut caller: Caller<'_, Context<T>>, value: i64| {
+            |mut caller: Caller<Context<T>>, value: i64| {
                 Ok(caller
                     .data_mut()
                     .setting_values
@@ -81,7 +81,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_i64",
         })?
         .func_wrap("env", "setting_value_new_f64", {
-            |mut caller: Caller<'_, Context<T>>, value: f64| {
+            |mut caller: Caller<Context<T>>, value: f64| {
                 Ok(caller
                     .data_mut()
                     .setting_values
@@ -95,7 +95,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_f64",
         })?
         .func_wrap("env", "setting_value_new_string", {
-            |mut caller: Caller<'_, Context<T>>, ptr: u32, len: u32| {
+            |mut caller: Caller<Context<T>>, ptr: u32, len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
                 let value = get_str(memory, ptr, len)?;
                 Ok(context
@@ -110,7 +110,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_new_string",
         })?
         .func_wrap("env", "setting_value_free", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64| {
+            |mut caller: Caller<Context<T>>, setting_value: u64| {
                 caller
                     .data_mut()
                     .setting_values
@@ -124,7 +124,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_free",
         })?
         .func_wrap("env", "setting_value_copy", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64| {
+            |mut caller: Caller<Context<T>>, setting_value: u64| {
                 let ctx = caller.data_mut();
 
                 let setting_value = ctx
@@ -141,7 +141,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_copy",
         })?
         .func_wrap("env", "setting_value_get_type", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64| -> Result<u32> {
+            |mut caller: Caller<Context<T>>, setting_value: u64| -> Result<u32> {
                 let (_, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -164,7 +164,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_type",
         })?
         .func_wrap("env", "setting_value_get_map", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64, value_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, value_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -192,7 +192,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_map",
         })?
         .func_wrap("env", "setting_value_get_list", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64, value_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, value_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -220,7 +220,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_list",
         })?
         .func_wrap("env", "setting_value_get_bool", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64, value_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, value_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -243,7 +243,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_bool",
         })?
         .func_wrap("env", "setting_value_get_i64", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64, value_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, value_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -266,7 +266,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_i64",
         })?
         .func_wrap("env", "setting_value_get_f64", {
-            |mut caller: Caller<'_, Context<T>>, setting_value: u64, value_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, value_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context
@@ -289,10 +289,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "setting_value_get_f64",
         })?
         .func_wrap("env", "setting_value_get_string", {
-            |mut caller: Caller<'_, Context<T>>,
-             setting_value: u64,
-             buf_ptr: u32,
-             buf_len_ptr: u32| {
+            |mut caller: Caller<Context<T>>, setting_value: u64, buf_ptr: u32, buf_len_ptr: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let setting_value = context

--- a/crates/livesplit-auto-splitting/src/runtime/api/settings_list.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/settings_list.rs
@@ -1,16 +1,17 @@
-use anyhow::{format_err, Result};
+use anyhow::{Result, format_err};
 use slotmap::{Key, KeyData};
 use wasmtime::{Caller, Linker};
 
 use crate::{
+    CreationError, Timer,
     runtime::{Context, SettingValueKey, SettingsListKey},
-    settings, CreationError, Timer,
+    settings,
 };
 
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "settings_list_new", {
-            |mut caller: Caller<'_, Context<T>>| {
+            |mut caller: Caller<Context<T>>| {
                 let ctx = caller.data_mut();
                 ctx.settings_lists
                     .insert(settings::List::new())
@@ -23,7 +24,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_new",
         })?
         .func_wrap("env", "settings_list_free", {
-            |mut caller: Caller<'_, Context<T>>, settings_list: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64| {
                 caller
                     .data_mut()
                     .settings_lists
@@ -37,7 +38,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_free",
         })?
         .func_wrap("env", "settings_list_copy", {
-            |mut caller: Caller<'_, Context<T>>, settings_list: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64| {
                 let ctx = caller.data_mut();
 
                 let settings_list = ctx
@@ -54,7 +55,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_copy",
         })?
         .func_wrap("env", "settings_list_len", {
-            |caller: Caller<'_, Context<T>>, settings_list: u64| {
+            |caller: Caller<Context<T>>, settings_list: u64| {
                 let ctx = caller.data();
 
                 let len = ctx
@@ -73,7 +74,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_len",
         })?
         .func_wrap("env", "settings_list_get", {
-            |mut caller: Caller<'_, Context<T>>, settings_list: u64, index: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64, index: u64| {
                 let ctx = caller.data_mut();
 
                 let maybe_value = if let Ok(index) = index.try_into() {
@@ -99,7 +100,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_get",
         })?
         .func_wrap("env", "settings_list_push", {
-            |mut caller: Caller<'_, Context<T>>, settings_list: u64, setting_value: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64, setting_value: u64| {
                 let context = caller.data_mut();
 
                 let settings_list = context
@@ -122,10 +123,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_list_push",
         })?
         .func_wrap("env", "settings_list_insert", {
-            |mut caller: Caller<'_, Context<T>>,
-             settings_list: u64,
-             index: u64,
-             setting_value: u64| {
+            |mut caller: Caller<Context<T>>, settings_list: u64, index: u64, setting_value: u64| {
                 let context = caller.data_mut();
 
                 let settings_list = context

--- a/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/settings_map.rs
@@ -13,7 +13,7 @@ use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "settings_map_new", {
-            |mut caller: Caller<'_, Context<T>>| {
+            |mut caller: Caller<Context<T>>| {
                 let ctx = caller.data_mut();
                 ctx.settings_maps
                     .insert(settings::Map::new())
@@ -26,7 +26,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_new",
         })?
         .func_wrap("env", "settings_map_free", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64| {
                 caller
                     .data_mut()
                     .settings_maps
@@ -40,7 +40,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_free",
         })?
         .func_wrap("env", "settings_map_load", {
-            |mut caller: Caller<'_, Context<T>>| {
+            |mut caller: Caller<Context<T>>| {
                 let ctx = caller.data_mut();
                 let settings_map = ctx.shared_data.get_settings_map();
                 ctx.settings_maps.insert(settings_map).data().as_ffi()
@@ -51,7 +51,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_load",
         })?
         .func_wrap("env", "settings_map_store", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64| {
                 let ctx = caller.data_mut();
 
                 let settings_map = ctx
@@ -70,7 +70,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_store",
         })?
         .func_wrap("env", "settings_map_store_if_unchanged", {
-            |mut caller: Caller<'_, Context<T>>, old_settings_map: u64, new_settings_map: u64| {
+            |mut caller: Caller<Context<T>>, old_settings_map: u64, new_settings_map: u64| {
                 let ctx = caller.data_mut();
 
                 let old_settings_map = ctx
@@ -100,7 +100,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_store_if_unchanged",
         })?
         .func_wrap("env", "settings_map_copy", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64| {
                 let ctx = caller.data_mut();
 
                 let settings_map = ctx
@@ -117,7 +117,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_copy",
         })?
         .func_wrap("env", "settings_map_insert", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              settings_map: u64,
              key_ptr: u32,
              key_len: u32,
@@ -146,7 +146,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_insert",
         })?
         .func_wrap("env", "settings_map_get", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64, key_ptr: u32, key_len: u32| {
+            |mut caller: Caller<Context<T>>, settings_map: u64, key_ptr: u32, key_len: u32| {
                 let (memory, context) = memory_and_context(&mut caller);
 
                 let settings_map = context
@@ -167,7 +167,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_get",
         })?
         .func_wrap("env", "settings_map_len", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64| {
                 let ctx = caller.data_mut();
 
                 let len = ctx
@@ -186,7 +186,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_len",
         })?
         .func_wrap("env", "settings_map_get_key_by_index", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              settings_map: u64,
              index: u64,
              buf_ptr: u32,
@@ -225,7 +225,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "settings_map_get_key_by_index",
         })?
         .func_wrap("env", "settings_map_get_value_by_index", {
-            |mut caller: Caller<'_, Context<T>>, settings_map: u64, index: u64| {
+            |mut caller: Caller<Context<T>>, settings_map: u64, index: u64| {
                 let ctx = caller.data_mut();
 
                 let maybe_slot = if let Ok(index) = index.try_into() {

--- a/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
@@ -8,14 +8,14 @@ use super::{get_str, memory_and_context};
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "timer_get_state", {
-            |caller: Caller<'_, Context<T>>| caller.data().timer.state() as u32
+            |caller: Caller<Context<T>>| caller.data().timer.state() as u32
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_get_state",
         })?
         .func_wrap("env", "timer_current_split_index", {
-            |caller: Caller<'_, Context<T>>| {
+            |caller: Caller<Context<T>>| {
                 caller
                     .data()
                     .timer
@@ -28,7 +28,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "timer_current_split_index",
         })?
         .func_wrap("env", "timer_segment_splitted", {
-            |caller: Caller<'_, Context<T>>, index: u64| {
+            |caller: Caller<Context<T>>, index: u64| {
                 Ok(caller
                     .data()
                     .timer
@@ -40,24 +40,16 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "timer_segment_splitted",
         })?
-        .func_wrap(
-            "env",
-            "timer_start",
-            |mut caller: Caller<'_, Context<T>>| {
-                caller.data_mut().timer.start();
-            },
-        )
+        .func_wrap("env", "timer_start", |mut caller: Caller<Context<T>>| {
+            caller.data_mut().timer.start();
+        })
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_start",
         })?
-        .func_wrap(
-            "env",
-            "timer_split",
-            |mut caller: Caller<'_, Context<T>>| {
-                caller.data_mut().timer.split();
-            },
-        )
+        .func_wrap("env", "timer_split", |mut caller: Caller<Context<T>>| {
+            caller.data_mut().timer.split();
+        })
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_split",
@@ -65,7 +57,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .func_wrap(
             "env",
             "timer_skip_split",
-            |mut caller: Caller<'_, Context<T>>| {
+            |mut caller: Caller<Context<T>>| {
                 caller.data_mut().timer.skip_split();
             },
         )
@@ -76,7 +68,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .func_wrap(
             "env",
             "timer_undo_split",
-            |mut caller: Caller<'_, Context<T>>| {
+            |mut caller: Caller<Context<T>>| {
                 caller.data_mut().timer.undo_split();
             },
         )
@@ -84,19 +76,15 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "timer_undo_split",
         })?
-        .func_wrap(
-            "env",
-            "timer_reset",
-            |mut caller: Caller<'_, Context<T>>| {
-                caller.data_mut().timer.reset();
-            },
-        )
+        .func_wrap("env", "timer_reset", |mut caller: Caller<Context<T>>| {
+            caller.data_mut().timer.reset();
+        })
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_reset",
         })?
         .func_wrap("env", "timer_set_variable", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              name_ptr: u32,
              name_len: u32,
              value_ptr: u32,
@@ -114,7 +102,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "timer_set_variable",
         })?
         .func_wrap("env", "timer_set_game_time", {
-            |mut caller: Caller<'_, Context<T>>, secs: i64, nanos: i32| {
+            |mut caller: Caller<Context<T>>, secs: i64, nanos: i32| {
                 caller
                     .data_mut()
                     .timer
@@ -126,14 +114,14 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "timer_set_game_time",
         })?
         .func_wrap("env", "timer_pause_game_time", {
-            |mut caller: Caller<'_, Context<T>>| caller.data_mut().timer.pause_game_time()
+            |mut caller: Caller<Context<T>>| caller.data_mut().timer.pause_game_time()
         })
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_pause_game_time",
         })?
         .func_wrap("env", "timer_resume_game_time", {
-            |mut caller: Caller<'_, Context<T>>| caller.data_mut().timer.resume_game_time()
+            |mut caller: Caller<Context<T>>| caller.data_mut().timer.resume_game_time()
         })
         .map_err(|source| CreationError::LinkFunction {
             source,

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use wasmtime::{Caller, Linker};
 
-use crate::{runtime::Context, settings, CreationError, Timer};
+use crate::{CreationError, Timer, runtime::Context, settings};
 
 use super::{get_str, memory_and_context};
 
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
         .func_wrap("env", "user_settings_add_bool", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
@@ -38,7 +38,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_bool",
         })?
         .func_wrap("env", "user_settings_add_title", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
@@ -61,7 +61,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_title",
         })?
         .func_wrap("env", "user_settings_add_choice", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
@@ -90,7 +90,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_choice",
         })?
         .func_wrap("env", "user_settings_add_choice_option", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              option_key_ptr: u32,
@@ -125,7 +125,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_choice_option",
         })?
         .func_wrap("env", "user_settings_add_file_select", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
@@ -149,7 +149,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_file_select",
         })?
         .func_wrap("env", "user_settings_add_file_select_name_filter", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              description_ptr: u32,
@@ -183,7 +183,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_file_select_name_filter",
         })?
         .func_wrap("env", "user_settings_add_file_select_mime_filter", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              mime_ptr: u32,
@@ -207,7 +207,7 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             name: "user_settings_add_file_select_mime_filter",
         })?
         .func_wrap("env", "user_settings_set_tooltip", {
-            |mut caller: Caller<'_, Context<T>>,
+            |mut caller: Caller<Context<T>>,
              key_ptr: u32,
              key_len: u32,
              tooltip_ptr: u32,

--- a/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/wasi.rs
@@ -2,18 +2,18 @@ use std::{
     collections::VecDeque,
     path::Path,
     sync::{
-        atomic::{self, AtomicUsize},
         Arc, Mutex,
+        atomic::{self, AtomicUsize},
     },
 };
 
 use bstr::ByteSlice;
 use wasmtime_wasi::{
-    preview1::WasiP1Ctx, DirPerms, FilePerms, OutputStream, Pollable, StdoutStream, StreamError,
-    WasiCtxBuilder,
+    DirPerms, FilePerms, OutputStream, Pollable, StdoutStream, StreamError, WasiCtxBuilder,
+    preview1::WasiP1Ctx,
 };
 
-use crate::{wasi_path, Timer};
+use crate::{Timer, wasi_path};
 
 const ERR_CAPACITY: usize = 1 << 20;
 
@@ -103,10 +103,10 @@ pub fn build(script_path: Option<&Path>) -> (WasiP1Ctx, StdErr) {
     let stderr = StdErr::new();
     wasi.stderr(stderr.clone());
 
-    if let Some(script_path) = script_path {
-        if let Some(path) = wasi_path::from_native(script_path) {
-            wasi.env("SCRIPT_PATH", &path);
-        }
+    if let Some(script_path) = script_path
+        && let Some(path) = wasi_path::from_native(script_path)
+    {
+        wasi.env("SCRIPT_PATH", &path);
     }
 
     #[cfg(windows)]

--- a/crates/livesplit-auto-splitting/src/settings/list.rs
+++ b/crates/livesplit-auto-splitting/src/settings/list.rs
@@ -12,7 +12,7 @@ pub struct List {
 
 impl fmt::Debug for List {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.list, f)
     }
 }

--- a/crates/livesplit-auto-splitting/src/settings/map.rs
+++ b/crates/livesplit-auto-splitting/src/settings/map.rs
@@ -16,7 +16,7 @@ pub struct Map {
 
 impl fmt::Debug for Map {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.values, f)
     }
 }

--- a/crates/livesplit-auto-splitting/src/settings/value.rs
+++ b/crates/livesplit-auto-splitting/src/settings/value.rs
@@ -104,7 +104,7 @@ impl Value {
 }
 
 impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Map(v) => fmt::Debug::fmt(v, f),
             Self::List(v) => fmt::Debug::fmt(v, f),

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -70,7 +70,7 @@ pub trait Timer: Send {
     /// auto splitter wants to provide for visualization.
     fn set_variable(&mut self, key: &str, value: &str);
     /// Logs a message from the auto splitter.
-    fn log_auto_splitter(&mut self, message: fmt::Arguments<'_>);
+    fn log_auto_splitter(&mut self, message: fmt::Arguments);
     /// Logs a message from the runtime.
-    fn log_runtime(&mut self, message: fmt::Arguments<'_>, log_level: LogLevel);
+    fn log_runtime(&mut self, message: fmt::Arguments, log_level: LogLevel);
 }

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -29,8 +29,8 @@ impl Timer for DummyTimer {
     fn pause_game_time(&mut self) {}
     fn resume_game_time(&mut self) {}
     fn set_variable(&mut self, _key: &str, _value: &str) {}
-    fn log_auto_splitter(&mut self, _message: fmt::Arguments<'_>) {}
-    fn log_runtime(&mut self, _message: fmt::Arguments<'_>, _log_level: LogLevel) {}
+    fn log_auto_splitter(&mut self, _message: fmt::Arguments) {}
+    fn log_runtime(&mut self, _message: fmt::Arguments, _log_level: LogLevel) {}
 }
 
 #[track_caller]

--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "livesplit-hotkey provides cross-platform global hotkey hooks."
 keywords = ["speedrun", "timer", "livesplit", "hotkey", "keyboard"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = [

--- a/crates/livesplit-hotkey/src/hotkey.rs
+++ b/crates/livesplit-hotkey/src/hotkey.rs
@@ -14,13 +14,13 @@ pub struct Hotkey {
 }
 
 impl fmt::Debug for Hotkey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Display for Hotkey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.modifiers.is_empty() {
             f.write_str(self.key_code.name())
         } else {
@@ -77,7 +77,7 @@ struct HotkeyVisitor;
 impl serde::de::Visitor<'_> for HotkeyVisitor {
     type Value = Hotkey;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a valid hotkey")
     }
 

--- a/crates/livesplit-hotkey/src/key_code.rs
+++ b/crates/livesplit-hotkey/src/key_code.rs
@@ -1160,7 +1160,7 @@ pub enum KeyCode {
 }
 
 impl fmt::Debug for KeyCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.name())
     }
 }
@@ -1188,7 +1188,7 @@ struct KeyCodeVisitor;
 impl serde::de::Visitor<'_> for KeyCodeVisitor {
     type Value = KeyCode;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a valid key code")
     }
 
@@ -1308,7 +1308,7 @@ struct KeyCodeClassVisitor;
 impl serde::de::Visitor<'_> for KeyCodeClassVisitor {
     type Value = KeyCodeClass;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a valid key code class")
     }
 
@@ -1844,17 +1844,18 @@ impl KeyCode {
     /// Resolves the key according to the current keyboard layout.
     pub fn resolve(self, hook: &Hook) -> Cow<'static, str> {
         let class = self.classify();
-        if class == KeyCodeClass::WritingSystem {
-            if let Some(resolved) = hook.0.try_resolve(self) {
-                let uppercase = if resolved != "ß" {
-                    resolved.to_uppercase()
-                } else {
-                    resolved
-                };
-                return uppercase.into();
-            }
+        if class == KeyCodeClass::WritingSystem
+            && let Some(resolved) = hook.0.try_resolve(self)
+        {
+            let uppercase = if resolved != "ß" {
+                resolved.to_uppercase()
+            } else {
+                resolved
+            };
+            uppercase.into()
+        } else {
+            self.resolve_en_us().into()
         }
-        self.resolve_en_us().into()
     }
 }
 

--- a/crates/livesplit-hotkey/src/lib.rs
+++ b/crates/livesplit-hotkey/src/lib.rs
@@ -3,8 +3,7 @@
     clippy::correctness,
     clippy::perf,
     clippy::style,
-    missing_docs,
-    rust_2018_idioms
+    missing_docs
 )]
 #![forbid(clippy::incompatible_msrv)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -124,7 +123,7 @@ pub enum Error {
 impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::UnmatchedPreference => {
                 "The consume preference could not be met on the current platform."
@@ -138,7 +137,6 @@ impl fmt::Display for Error {
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown", feature = "wasm-web")))]
 const _: () = {
-    #[allow(unused)]
     const fn assert_thread_safe<T: Send + Sync>() {}
     assert_thread_safe::<Hook>();
 };

--- a/crates/livesplit-hotkey/src/linux/evdev_impl.rs
+++ b/crates/livesplit-hotkey/src/linux/evdev_impl.rs
@@ -1,10 +1,10 @@
 use std::{collections::hash_map::HashMap, os::unix::prelude::AsRawFd, ptr, thread};
 
 use evdev::{Device, EventType, InputEventKind, Key};
-use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
-use x11_dl::xlib::{Xlib, _XDisplay};
+use mio::{Events, Interest, Poll, Token, Waker, unix::SourceFd};
+use x11_dl::xlib::{_XDisplay, Xlib};
 
-use super::{x11_impl, Error, Hook, Message};
+use super::{Error, Hook, Message, x11_impl};
 use crate::{KeyCode, Modifiers, Result};
 
 // Low numbered tokens are allocated to devices.
@@ -344,7 +344,9 @@ pub fn new() -> Result<Hook> {
             }
         }
 
-        if let (Some(xlib), Some(display)) = (xlib, display) {
+        if let Some(xlib) = xlib
+            && let Some(display) = display
+        {
             unsafe { (xlib.XCloseDisplay)(display) };
         }
 

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -3,8 +3,8 @@ use std::{fmt, thread::JoinHandle};
 use crate::{ConsumePreference, Hotkey, KeyCode, Result};
 use crossbeam_channel::Sender;
 use mio::Waker;
-use nix::unistd::{getgroups, Group};
-use promising_future::{future_promise, Promise};
+use nix::unistd::{Group, getgroups};
+use promising_future::{Promise, future_promise};
 
 mod evdev_impl;
 mod x11_impl;
@@ -26,7 +26,7 @@ impl From<Error> for crate::Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::EvDev => "Failed fetching events from evdev.",
             Self::EPoll => "Failed polling the event file descriptors.",
@@ -72,10 +72,10 @@ fn can_use_evdev() -> Option<()> {
 
 impl Hook {
     pub fn new(consume: ConsumePreference) -> Result<Self> {
-        if matches!(consume, ConsumePreference::PreferConsume) {
-            if let Ok(x11) = x11_impl::new() {
-                return Ok(x11);
-            }
+        if matches!(consume, ConsumePreference::PreferConsume)
+            && let Ok(x11) = x11_impl::new()
+        {
+            return Ok(x11);
         }
 
         if !matches!(consume, ConsumePreference::MustConsume) && can_use_evdev().is_some() {

--- a/crates/livesplit-hotkey/src/macos/cg.rs
+++ b/crates/livesplit-hotkey/src/macos/cg.rs
@@ -188,7 +188,7 @@ pub type EventTapCallBack = Option<
         proxy: EventTapProxy,
         ty: EventType,
         event: EventRef,
-        userInfo: *mut c_void,
+        user_info: *mut c_void,
     ) -> EventRef,
 >;
 
@@ -217,7 +217,7 @@ unsafe extern "C" {
         options: EventTapOptions,
         events_of_interest: EventMask,
         callback: EventTapCallBack,
-        userInfo: *mut c_void,
+        user_info: *mut c_void,
     ) -> MachPortRef;
 
     pub fn CGEventTapEnable(tap: MachPortRef, enable: bool);

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -46,7 +46,7 @@ impl From<Error> for crate::Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::CouldntCreateEventTap => "Failed creating the event tap.",
             Self::CouldntCreateRunLoopSource => "Failed creating the run loop source.",

--- a/crates/livesplit-hotkey/src/modifiers.rs
+++ b/crates/livesplit-hotkey/src/modifiers.rs
@@ -18,7 +18,7 @@ bitflags::bitflags! {
 }
 
 impl fmt::Display for Modifiers {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut first = true;
         if self.contains(Modifiers::CONTROL) {
             first = false;
@@ -89,7 +89,7 @@ struct ModifiersVisitor;
 impl serde::de::Visitor<'_> for ModifiersVisitor {
     type Value = Modifiers;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("valid modifiers")
     }
 

--- a/crates/livesplit-hotkey/src/other/mod.rs
+++ b/crates/livesplit-hotkey/src/other/mod.rs
@@ -7,7 +7,7 @@ pub enum Error {}
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
         Ok(())
     }
 }

--- a/crates/livesplit-hotkey/src/wasm_web/mod.rs
+++ b/crates/livesplit-hotkey/src/wasm_web/mod.rs
@@ -18,7 +18,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::FailedToCreateHook => "Failed creating the hook.",
         })
@@ -162,10 +162,10 @@ impl Hook {
             let keyboard_layout_resolver = keyboard_layout_resolver.clone();
 
             let closure = Closure::wrap(Box::new(move |layout_map| {
-                if let Ok(get_fn) = Reflect::get(&layout_map, &JsValue::from_str("get")) {
-                    if let Ok(get_fn) = get_fn.dyn_into::<Function>() {
-                        *keyboard_layout_resolver.borrow_mut() = Some((layout_map, get_fn));
-                    }
+                if let Ok(get_fn) = Reflect::get(&layout_map, &JsValue::from_str("get"))
+                    && let Ok(get_fn) = get_fn.dyn_into::<Function>()
+                {
+                    *keyboard_layout_resolver.borrow_mut() = Some((layout_map, get_fn));
                 }
             }) as Box<dyn FnMut(JsValue)>);
 
@@ -190,12 +190,12 @@ impl Hook {
                         {
                             if let Ok(button) = button.dyn_into::<GamepadButton>() {
                                 let pressed = button.pressed();
-                                if pressed && !*state {
-                                    if let Some(callback) =
+                                if pressed
+                                    && !*state
+                                    && let Some(callback) =
                                         hotkey_map.lock().unwrap().get_mut(&code.into())
-                                    {
-                                        callback();
-                                    }
+                                {
+                                    callback();
                                 }
                                 *state = pressed;
                             }

--- a/crates/livesplit-hotkey/src/windows/mod.rs
+++ b/crates/livesplit-hotkey/src/windows/mod.rs
@@ -36,7 +36,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::WindowsHook => "An error occurred in the Windows API.",
             Self::ThreadStopped => "The background thread stopped unexpectedly.",

--- a/crates/livesplit-title-abbreviations/Cargo.toml
+++ b/crates/livesplit-title-abbreviations/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT OR Apache-2.0"
 description = "livesplit-title-abbreviations encapsulates the algorithm that LiveSplit uses to abbreviate game titles."
 keywords = ["speedrun", "timer", "livesplit", "title", "abbreviation"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"

--- a/crates/livesplit-title-abbreviations/src/lib.rs
+++ b/crates/livesplit-title-abbreviations/src/lib.rs
@@ -7,7 +7,6 @@
     clippy::undocumented_unsafe_blocks,
     // TODO: Write documentation
     // missing_docs,
-    rust_2018_idioms
 )]
 #![forbid(clippy::incompatible_msrv)]
 #![no_std]
@@ -223,39 +222,39 @@ pub fn abbreviate(name: &str) -> Vec<Box<str>> {
 pub fn abbreviate_category(category: &str) -> Vec<Box<str>> {
     let mut abbrevs = Vec::new();
 
-    if let Some((before, rest)) = category.split_once('(') {
-        if let Some((inside, after)) = rest.split_once(')') {
-            let before = before.trim();
-            let after = after.trim_end();
+    if let Some((before, rest)) = category.split_once('(')
+        && let Some((inside, after)) = rest.split_once(')')
+    {
+        let before = before.trim();
+        let after = after.trim_end();
 
-            let mut buf = String::with_capacity(category.len());
-            buf.push_str(before);
-            buf.push_str(" (");
+        let mut buf = String::with_capacity(category.len());
+        buf.push_str(before);
+        buf.push_str(" (");
 
-            let mut splits = inside.split(',');
-            let mut variable = splits.next().unwrap();
-            for next_variable in splits {
-                buf.push_str(variable);
-                let old_len = buf.len();
+        let mut splits = inside.split(',');
+        let mut variable = splits.next().unwrap();
+        for next_variable in splits {
+            buf.push_str(variable);
+            let old_len = buf.len();
 
-                buf.push(')');
-                buf.push_str(after);
-                abbrevs.push(buf.as_str().into());
+            buf.push(')');
+            buf.push_str(after);
+            abbrevs.push(buf.as_str().into());
 
-                buf.drain(old_len..);
-                buf.push(',');
-                variable = next_variable;
-            }
-
-            if after.trim_start().is_empty() {
-                buf.drain(before.len()..);
-            } else {
-                buf.drain(before.len() + 1..);
-                buf.push_str(after);
-            }
-
-            abbrevs.push(buf.into());
+            buf.drain(old_len..);
+            buf.push(',');
+            variable = next_variable;
         }
+
+        if after.trim_start().is_empty() {
+            buf.drain(before.len()..);
+        } else {
+            buf.drain(before.len() + 1..);
+            buf.push_str(after);
+        }
+
+        abbrevs.push(buf.into());
     }
 
     abbrevs.push(category.into());

--- a/src/analysis/current_pace.rs
+++ b/src/analysis/current_pace.rs
@@ -2,12 +2,12 @@
 //! provided. If there's no active attempt, the final time of the comparison is
 //! returned instead.
 
-use crate::{analysis, timing::Snapshot, TimeSpan, TimerPhase};
+use crate::{TimeSpan, TimerPhase, analysis, timing::Snapshot};
 
 /// Calculates the current pace of the active attempt based on the comparison
 /// provided. If there's no active attempt, the final time of the comparison is
 /// returned instead.
-pub fn calculate(timer: &Snapshot<'_>, comparison: &str) -> (Option<TimeSpan>, bool) {
+pub fn calculate(timer: &Snapshot, comparison: &str) -> (Option<TimeSpan>, bool) {
     let timing_method = timer.current_timing_method();
     let last_segment = timer.run().segments().last().unwrap();
     let phase = timer.current_phase();

--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -4,14 +4,14 @@
 //! the moment. This may be the case when the current attempt is slower than the
 //! comparison at the current split.
 
-use crate::{analysis, timing::Snapshot, TimeSpan, TimerPhase};
+use crate::{TimeSpan, TimerPhase, analysis, timing::Snapshot};
 
 /// Calculates the delta of the current attempt to the comparison provided.
 /// Additionally a value is returned that indicates whether the delta value is a
 /// live delta. A live delta indicates that the value is actively changing at
 /// the moment. This may be the case when the current attempt is slower than the
 /// comparison at the current split.
-pub fn calculate(timer: &Snapshot<'_>, comparison: &str) -> (Option<TimeSpan>, bool) {
+pub fn calculate(timer: &Snapshot, comparison: &str) -> (Option<TimeSpan>, bool) {
     let timing_method = timer.current_timing_method();
     let last_segment = timer.run().segments().last().unwrap();
 

--- a/src/analysis/pb_chance/mod.rs
+++ b/src/analysis/pb_chance/mod.rs
@@ -12,7 +12,7 @@
 //! source its split times.
 
 use super::SkillCurve;
-use crate::{comparison, timing::Snapshot, Run, Segment, TimeSpan, TimingMethod};
+use crate::{Run, Segment, TimeSpan, TimingMethod, comparison, timing::Snapshot};
 
 #[cfg(test)]
 mod tests;
@@ -44,7 +44,7 @@ pub fn for_run(run: &Run, method: TimingMethod) -> f64 {
 /// The value is being reported as a floating point number in the range
 /// from 0 (0%) to 1 (100%). Additionally a boolean is returned that
 /// indicates if the value is currently actively changing as time is being lost.
-pub fn for_timer(timer: &Snapshot<'_>) -> (f64, bool) {
+pub fn for_timer(timer: &Snapshot) -> (f64, bool) {
     let method = timer.current_timing_method();
     let all_segments = timer.run().segments();
 
@@ -81,11 +81,7 @@ pub fn for_timer(timer: &Snapshot<'_>) -> (f64, bool) {
             .last()
             .and_then(|s| s.personal_best_split_time()[method])
             .is_none_or(|pb| current_time < pb);
-        if beat_pb {
-            1.0
-        } else {
-            0.0
-        }
+        if beat_pb { 1.0 } else { 0.0 }
     } else {
         calculate(segments, method, current_time)
     };

--- a/src/analysis/skill_curve.rs
+++ b/src/analysis/skill_curve.rs
@@ -1,4 +1,4 @@
-use crate::{platform::prelude::*, Segment, TimeSpan, TimingMethod};
+use crate::{Segment, TimeSpan, TimingMethod, platform::prelude::*};
 use core::cmp::Ordering;
 
 const WEIGHT: f64 = 0.75;
@@ -35,12 +35,12 @@ impl SkillCurve {
     }
 
     /// Returns the number of segments this skill curve is comprised of.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.all_weighted_segment_times.len()
     }
 
     /// Returns `true` if there are no segments in this skill curve.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.all_weighted_segment_times.is_empty()
     }
 

--- a/src/analysis/state_helper.rs
+++ b/src/analysis/state_helper.rs
@@ -188,7 +188,7 @@ pub fn previous_segment_time(
 /// Returns the length of the segment leading up to `segment_index`, returning
 /// the live segment time if the split is not completed yet.
 pub fn live_segment_time(
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     segment_index: usize,
     method: TimingMethod,
 ) -> Option<TimeSpan> {
@@ -236,7 +236,7 @@ pub fn previous_segment_delta(
 /// Returns the segment delta for a certain split, returning the live segment
 /// delta if the split is not completed yet.
 pub fn live_segment_delta(
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     segment_index: usize,
     comparison: &str,
     method: TimingMethod,
@@ -260,7 +260,7 @@ pub fn live_segment_delta(
 ///
 /// Returns the current live delta.
 pub fn check_live_delta(
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     split_delta: bool,
     comparison: &str,
     method: TimingMethod,

--- a/src/analysis/sum_of_segments/best.rs
+++ b/src/analysis/sum_of_segments/best.rs
@@ -7,7 +7,7 @@
 //! the actual sum of their best segment times. The name is therefore a bit
 //! misleading, but sticks around for historical reasons.
 
-use super::{track_branch, track_current_run, track_personal_best_run, Prediction};
+use super::{Prediction, track_branch, track_current_run, track_personal_best_run};
 use crate::{Segment, TimeSpan, TimingMethod};
 
 fn populate_prediction(
@@ -15,13 +15,13 @@ fn populate_prediction(
     target_prediction: &mut Option<Prediction>,
     predicted_time: Option<TimeSpan>,
 ) {
-    if let Some(predicted_time) = predicted_time {
-        if target_prediction.is_none_or(|p| predicted_time < p.time) {
-            *target_prediction = Some(Prediction {
-                time: predicted_time,
-                predecessor,
-            });
-        }
+    if let Some(predicted_time) = predicted_time
+        && target_prediction.is_none_or(|p| predicted_time < p.time)
+    {
+        *target_prediction = Some(Prediction {
+            time: predicted_time,
+            predecessor,
+        });
     }
 }
 
@@ -102,7 +102,6 @@ fn populate_predictions(
 /// means that the predictions buffer needs to have one more element than the
 /// list of segments provided, so that you can properly query the total Sum of
 /// Best Segments. This value is also the value that is being returned.
-#[allow(clippy::needless_range_loop)]
 pub fn calculate(
     segments: &[Segment],
     predictions: &mut [Option<Prediction>],

--- a/src/analysis/sum_of_segments/worst.rs
+++ b/src/analysis/sum_of_segments/worst.rs
@@ -4,7 +4,7 @@
 //! collected from all the previous attempts. This obviously isn't really the worst
 //! possible time, but may be useful information regardless.
 
-use super::{track_branch, track_current_run, track_personal_best_run, Prediction};
+use super::{Prediction, track_branch, track_current_run, track_personal_best_run};
 use crate::{Segment, TimeSpan, TimingMethod};
 
 fn populate_prediction(
@@ -12,13 +12,13 @@ fn populate_prediction(
     target_prediction: &mut Option<Prediction>,
     predicted_time: Option<TimeSpan>,
 ) {
-    if let Some(predicted_time) = predicted_time {
-        if target_prediction.is_none_or(|p| predicted_time > p.time) {
-            *target_prediction = Some(Prediction {
-                time: predicted_time,
-                predecessor,
-            });
-        }
+    if let Some(predicted_time) = predicted_time
+        && target_prediction.is_none_or(|p| predicted_time > p.time)
+    {
+        *target_prediction = Some(Prediction {
+            time: predicted_time,
+            predecessor,
+        });
     }
 }
 
@@ -84,7 +84,6 @@ fn populate_predictions(
 /// it. This means that the predictions buffer needs to have one more element
 /// than the list of segments provided, so that you can properly query the total
 /// Sum of Worst Segments. This value is also the value that is being returned.
-#[allow(clippy::needless_range_loop)]
 pub fn calculate(
     segments: &[Segment],
     predictions: &mut [Option<Prediction>],

--- a/src/analysis/total_playtime.rs
+++ b/src/analysis/total_playtime.rs
@@ -25,10 +25,8 @@ impl TotalPlaytime for Run {
                 // Must be < 1.6.0 and a reset
                 // Calculate the sum of the segments for that run
                 for segment in self.segments() {
-                    if let Some(segment_time) = segment
-                        .segment_history()
-                        .get(attempt.index())
-                        .and_then(|s| s[TimingMethod::RealTime])
+                    if let Some(s) = segment.segment_history().get(attempt.index())
+                        && let Some(segment_time) = s[TimingMethod::RealTime]
                     {
                         total_playtime += segment_time;
                     }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -805,7 +805,7 @@ impl<E: event::CommandSink + TimerQuery + Send> AutoSplitTimer for Timer<E> {
 
     fn segment_splitted(&self, idx: usize) -> Option<bool> {
         let t = self.0.get_timer();
-        if !(idx < t.current_split_index()?) {
+        if idx >= t.current_split_index()? {
             return None;
         }
         Some(
@@ -854,11 +854,11 @@ impl<E: event::CommandSink + TimerQuery + Send> AutoSplitTimer for Timer<E> {
         drop(self.0.set_custom_variable(name.into(), value.into()));
     }
 
-    fn log_auto_splitter(&mut self, message: fmt::Arguments<'_>) {
+    fn log_auto_splitter(&mut self, message: fmt::Arguments) {
         log::info!(target: "Auto Splitter", "{message}");
     }
 
-    fn log_runtime(&mut self, message: fmt::Arguments<'_>, log_level: LogLevel) {
+    fn log_runtime(&mut self, message: fmt::Arguments, log_level: LogLevel) {
         let level = match log_level {
             LogLevel::Trace => log::Level::Trace,
             LogLevel::Debug => log::Level::Debug,

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -103,7 +103,7 @@ impl Component {
     }
 
     /// Updates the component's state based on the timer provided.
-    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot<'_>) {
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot) {
         let comparison = comparison::resolve(&self.settings.comparison_override, timer);
         let comparison = comparison::or_current(comparison, timer);
         let key = self.text(Some(comparison));
@@ -161,7 +161,7 @@ impl Component {
     }
 
     /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, timer: &Snapshot<'_>) -> key_value::State {
+    pub fn state(&self, timer: &Snapshot) -> key_value::State {
         let mut state = Default::default();
         self.update_state(&mut state, timer);
         state

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -98,7 +98,7 @@ impl Component {
     pub fn update_state(
         &self,
         state: &mut key_value::State,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         let comparison = comparison::resolve(&self.settings.comparison_override, timer);
@@ -155,7 +155,7 @@ impl Component {
     /// settings provided.
     pub fn state(
         &self,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) -> key_value::State {
         let mut state = Default::default();

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -6,15 +6,15 @@
 
 use super::timer;
 use crate::{
+    GeneralLayoutSettings, TimeSpan, TimerPhase,
     analysis::comparison_single_segment_time,
     comparison::{self, best_segments, none},
     platform::prelude::*,
     settings::{Color, Field, Gradient, Image, ImageCache, ImageId, SettingsDescription, Value},
     timing::{
-        formatter::{Accuracy, DigitsFormat, SegmentTime, TimeFormatter},
         Snapshot,
+        formatter::{Accuracy, DigitsFormat, SegmentTime, TimeFormatter},
     },
-    GeneralLayoutSettings, TimeSpan, TimerPhase,
 };
 use core::fmt::Write;
 use serde_derive::{Deserialize, Serialize};
@@ -217,7 +217,7 @@ impl Component {
         &self,
         state: &mut State,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         let current_phase = timer.current_phase();
@@ -342,7 +342,7 @@ impl Component {
     pub fn state(
         &self,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) -> State {
         let mut state = Default::default();

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -232,7 +232,7 @@ impl Component {
     pub fn update_state(
         &self,
         state: &mut State,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         let mut draw_info = DrawInfo {
@@ -266,7 +266,7 @@ impl Component {
 
     /// Calculates the component's state based on the timer and layout settings
     /// provided.
-    pub fn state(&self, timer: &Snapshot<'_>, layout_settings: &GeneralLayoutSettings) -> State {
+    pub fn state(&self, timer: &Snapshot, layout_settings: &GeneralLayoutSettings) -> State {
         let mut state = State::default();
         self.update_state(&mut state, timer, layout_settings);
         state
@@ -358,7 +358,7 @@ impl Component {
         }
     }
 
-    fn calculate_graph(&self, timer: &Snapshot<'_>, draw_info: &mut DrawInfo) -> Option<f32> {
+    fn calculate_graph(&self, timer: &Snapshot, draw_info: &mut DrawInfo) -> Option<f32> {
         let settings = &self.settings;
         draw_info.split_index = timer.current_split_index()?;
         let comparison = comparison::resolve(&self.settings.comparison_override, timer);
@@ -410,7 +410,7 @@ impl Component {
     }
 }
 
-fn calculate_horizontal_scaling(timer: &Snapshot<'_>, draw_info: &mut DrawInfo, live_graph: bool) {
+fn calculate_horizontal_scaling(timer: &Snapshot, draw_info: &mut DrawInfo, live_graph: bool) {
     let timing_method = timer.current_timing_method();
 
     // final_split is the split time of a theoretical point on the right edge of
@@ -479,7 +479,7 @@ fn calculate_split_points(
     }
 }
 
-fn calculate_live_delta_point(timer: &Snapshot<'_>, draw_info: &mut DrawInfo, comparison: &str) {
+fn calculate_live_delta_point(timer: &Snapshot, draw_info: &mut DrawInfo, comparison: &str) {
     if timer.current_phase() == TimerPhase::Ended {
         return;
     }
@@ -492,8 +492,9 @@ fn calculate_live_delta_point(timer: &Snapshot<'_>, draw_info: &mut DrawInfo, co
         .segment(draw_info.split_index)
         .comparison(comparison)[timing_method];
 
-    if let (Some(current_time), Some(current_split_comparison), None) =
-        (current_time, current_split_comparison, live_delta)
+    if let Some(current_time) = current_time
+        && let Some(current_split_comparison) = current_split_comparison
+        && let None = live_delta
     {
         // Live delta should be shown despite what analysis::check_live_delta says.
         let delta = current_time - current_split_comparison;

--- a/src/component/pb_chance.rs
+++ b/src/component/pb_chance.rs
@@ -78,7 +78,7 @@ impl Component {
     }
 
     /// Updates the component's state based on the timer provided.
-    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot<'_>) {
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot) {
         let (chance, is_live) = pb_chance::for_timer(timer);
 
         state.background = self.settings.background;
@@ -98,7 +98,7 @@ impl Component {
     }
 
     /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, timer: &Snapshot<'_>) -> key_value::State {
+    pub fn state(&self, timer: &Snapshot) -> key_value::State {
         let mut state = Default::default();
         self.update_state(&mut state, timer);
         state

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -114,7 +114,7 @@ impl Component {
     }
 
     /// Updates the component's state based on the timer provided.
-    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot<'_>) {
+    pub fn update_state(&self, state: &mut key_value::State, timer: &Snapshot) {
         let segment_index = timer.current_split_index();
         let current_phase = timer.current_phase();
         let comparison = comparison::resolve(&self.settings.comparison_override, timer);
@@ -161,7 +161,7 @@ impl Component {
     }
 
     /// Calculates the component's state based on the timer provided.
-    pub fn state(&self, timer: &Snapshot<'_>) -> key_value::State {
+    pub fn state(&self, timer: &Snapshot) -> key_value::State {
         let mut state = Default::default();
         self.update_state(&mut state, timer);
         state

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -120,7 +120,7 @@ impl Component {
     pub fn update_state(
         &self,
         state: &mut key_value::State,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         let mut time_change = None;
@@ -245,7 +245,7 @@ impl Component {
     /// settings provided.
     pub fn state(
         &self,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) -> key_value::State {
         let mut state = Default::default();

--- a/src/component/separator.rs
+++ b/src/component/separator.rs
@@ -58,6 +58,5 @@ impl Component {
     /// This panics if the type of the value to be set is not compatible with
     /// the type of the setting's value. A panic can also occur if the index of
     /// the setting provided is out of bounds.
-    #[allow(clippy::needless_pass_by_value, clippy::needless_pass_by_ref_mut)]
     pub fn set_value(&mut self, _index: usize, _value: Value) {}
 }

--- a/src/component/splits/column.rs
+++ b/src/component/splits/column.rs
@@ -1,15 +1,15 @@
 use crate::{
+    GeneralLayoutSettings, Segment, TimeSpan, TimingMethod,
     analysis::{self, possible_time_save, split_color},
     comparison,
     component::splits::Settings as SplitsSettings,
     platform::prelude::*,
     settings::{Color, SemanticColor},
     timing::{
-        formatter::{Delta, Regular, SegmentTime, TimeFormatter},
         Snapshot,
+        formatter::{Delta, Regular, SegmentTime, TimeFormatter},
     },
     util::Clear,
-    GeneralLayoutSettings, Segment, TimeSpan, TimingMethod,
 };
 use core::fmt::Write;
 use serde_derive::{Deserialize, Serialize};
@@ -180,7 +180,7 @@ enum ColumnFormatter {
 pub fn update_state(
     state: &mut ColumnState,
     column_settings: &ColumnSettings,
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     splits_settings: &SplitsSettings,
     layout_settings: &GeneralLayoutSettings,
     segment: &Segment,
@@ -193,20 +193,19 @@ pub fn update_state(
             state.value.clear();
             if let Some(value) = segment.variables().get(column.variable_name.as_str()) {
                 state.value.push_str(value);
-            } else if Some(segment_index) == current_split {
-                if let Some(value) = timer
+            } else if Some(segment_index) == current_split
+                && let Some(value) = timer
                     .run()
                     .metadata()
                     .custom_variable_value(column.variable_name.as_str())
-                {
-                    // FIXME: We show the live value of the variable, which means it
-                    // might update frequently. So we possibly should mark it as
-                    // such. However it's currently impossible to tell if it
-                    // actually does update frequently. On top of that, the text
-                    // component would need to support this as well, as it also
-                    // shows the live value of the variable.
-                    state.value.push_str(value);
-                }
+            {
+                // FIXME: We show the live value of the variable, which means it
+                // might update frequently. So we possibly should mark it as
+                // such. However it's currently impossible to tell if it
+                // actually does update frequently. On top of that, the text
+                // component would need to support this as well, as it also
+                // shows the live value of the variable.
+                state.value.push_str(value);
             }
             state.semantic_color = SemanticColor::Default;
             state.visual_color = layout_settings.text_color;
@@ -231,7 +230,7 @@ pub fn update_state(
 fn update_time_column(
     state: &mut ColumnState,
     column_settings: &TimeColumn,
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     splits_settings: &SplitsSettings,
     layout_settings: &GeneralLayoutSettings,
     segment: &Segment,
@@ -320,7 +319,7 @@ fn update_time_column(
 
 fn time_column_update_value(
     column: &TimeColumn,
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     segment: &Segment,
     segment_index: usize,
     current_split: Option<usize>,

--- a/src/component/splits/mod.rs
+++ b/src/component/splits/mod.rs
@@ -272,7 +272,7 @@ impl Component {
         &mut self,
         state: &mut State,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         // Reset Scroll Offset when any movement of the split index is observed.
@@ -413,7 +413,7 @@ impl Component {
     pub fn state(
         &mut self,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) -> State {
         let mut state = Default::default();

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -376,10 +376,10 @@ impl Component {
     /// the type of the setting's value. A panic can also occur if the index of
     /// the setting provided is out of bounds.
     pub fn set_value(&mut self, mut index: usize, value: Value) {
-        if index >= 5 {
-            if let Text::Variable(_, _) = &self.settings.text {
-                index += 1;
-            }
+        if index >= 5
+            && let Text::Variable(_, _) = &self.settings.text
+        {
+            index += 1;
         }
 
         match index {

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -192,7 +192,7 @@ impl Component {
     pub fn update_state(
         &self,
         state: &mut State,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralLayoutSettings,
     ) {
         let method = self
@@ -303,7 +303,7 @@ impl Component {
 
     /// Calculates the component's state based on the timer and the layout
     /// settings provided.
-    pub fn state(&self, timer: &Snapshot<'_>, layout_settings: &GeneralLayoutSettings) -> State {
+    pub fn state(&self, timer: &Snapshot, layout_settings: &GeneralLayoutSettings) -> State {
         let mut state = Default::default();
         self.update_state(&mut state, timer, layout_settings);
         state
@@ -390,7 +390,7 @@ pub fn top_and_bottom_color(color: Color) -> (Color, Color) {
 }
 
 fn calculate_live_segment_time(
-    timer: &Snapshot<'_>,
+    timer: &Snapshot,
     timing_method: TimingMethod,
     last_split_index: usize,
 ) -> Option<TimeSpan> {
@@ -417,7 +417,7 @@ mod serialize {
     }
 
     #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
-    #[allow(clippy::enum_variant_names)]
+    #[expect(clippy::enum_variant_names)]
     pub enum Delta {
         DeltaPlain,
         DeltaVertical,

--- a/src/event.rs
+++ b/src/event.rs
@@ -241,7 +241,7 @@ pub trait CommandSink {
     /// comparison doesn't exist an error is returned.
     fn set_current_comparison(
         &self,
-        comparison: Cow<'_, str>,
+        comparison: Cow<str>,
     ) -> impl Future<Output = Result> + 'static;
     /// Toggles between the `Real Time` and `Game Time` timing methods.
     fn toggle_timing_method(&self) -> impl Future<Output = Result> + 'static;
@@ -273,8 +273,8 @@ pub trait CommandSink {
     /// be stored in the splits file.
     fn set_custom_variable(
         &self,
-        name: Cow<'_, str>,
-        value: Cow<'_, str>,
+        name: Cow<str>,
+        value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static;
 }
 
@@ -353,7 +353,7 @@ impl CommandSink for crate::SharedTimer {
 
     fn set_current_comparison(
         &self,
-        comparison: Cow<'_, str>,
+        comparison: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         let result = self.write().unwrap().set_current_comparison(comparison);
         async move { result }
@@ -399,8 +399,8 @@ impl CommandSink for crate::SharedTimer {
 
     fn set_custom_variable(
         &self,
-        name: Cow<'_, str>,
-        value: Cow<'_, str>,
+        name: Cow<str>,
+        value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         self.write().unwrap().set_custom_variable(name, value);
         async { Ok(Event::CustomVariableSet) }
@@ -466,7 +466,7 @@ impl<T: CommandSink + ?Sized> CommandSink for Arc<T> {
 
     fn set_current_comparison(
         &self,
-        comparison: Cow<'_, str>,
+        comparison: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         CommandSink::set_current_comparison(&**self, comparison)
     }
@@ -504,15 +504,18 @@ impl<T: CommandSink + ?Sized> CommandSink for Arc<T> {
 
     fn set_custom_variable(
         &self,
-        name: Cow<'_, str>,
-        value: Cow<'_, str>,
+        name: Cow<str>,
+        value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         CommandSink::set_custom_variable(&**self, name, value)
     }
 }
 
 impl<T: TimerQuery + ?Sized> TimerQuery for Arc<T> {
-    type Guard<'a> = T::Guard<'a> where T: 'a;
+    type Guard<'a>
+        = T::Guard<'a>
+    where
+        T: 'a;
     fn get_timer(&self) -> Self::Guard<'_> {
         TimerQuery::get_timer(&**self)
     }

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -165,7 +165,7 @@ impl Component {
         &mut self,
         state: &mut ComponentState,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralSettings,
     ) {
         match (state, self) {
@@ -235,7 +235,7 @@ impl Component {
     pub fn state(
         &mut self,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
         layout_settings: &GeneralSettings,
     ) -> ComponentState {
         match self {

--- a/src/layout/editor/mod.rs
+++ b/src/layout/editor/mod.rs
@@ -63,11 +63,7 @@ impl Editor {
     /// visited in the [`ImageCache`]. You still need to manually run
     /// [`ImageCache::collect`] to ensure unused images are removed from the
     /// cache.
-    pub fn layout_state(
-        &mut self,
-        image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
-    ) -> LayoutState {
+    pub fn layout_state(&mut self, image_cache: &mut ImageCache, timer: &Snapshot) -> LayoutState {
         self.layout.state(image_cache, timer)
     }
 
@@ -82,7 +78,7 @@ impl Editor {
         &mut self,
         state: &mut LayoutState,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
     ) {
         self.layout.update_state(state, image_cache, timer)
     }
@@ -90,7 +86,7 @@ impl Editor {
     /// Selects the component with the given index in order to modify its
     /// settings. Only a single component is selected at any given time. You may
     /// not provide an invalid index.
-    pub fn select(&mut self, index: usize) {
+    pub const fn select(&mut self, index: usize) {
         if index < self.layout.components.len() {
             self.selected_component = index;
         }
@@ -105,7 +101,7 @@ impl Editor {
 
     /// Checks if the currently selected component can be removed. If there's
     /// only one component in the layout, it can't be removed.
-    pub fn can_remove_component(&self) -> bool {
+    pub const fn can_remove_component(&self) -> bool {
         // We need to ensure there's always at least one component.
         self.layout.components.len() > 1
     }
@@ -130,7 +126,6 @@ impl Editor {
     }
 
     /// Moves the selected component up, unless the first component is selected.
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn move_component_up(&mut self) {
         if self.can_move_component_up() {
             self.layout
@@ -142,7 +137,7 @@ impl Editor {
 
     /// Checks if the currently selected component can be moved down. If the
     /// last component is selected, it can't be moved down.
-    pub fn can_move_component_down(&self) -> bool {
+    pub const fn can_move_component_down(&self) -> bool {
         self.selected_component < self.layout.components.len() - 1
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -95,7 +95,7 @@ impl Layout {
         &mut self,
         state: &mut LayoutState,
         image_cache: &mut ImageCache,
-        timer: &Snapshot<'_>,
+        timer: &Snapshot,
     ) {
         let settings = &self.settings;
 
@@ -128,7 +128,7 @@ impl Layout {
     /// are marked as visited in the [`ImageCache`]. You still need to manually
     /// run [`ImageCache::collect`] to ensure unused images are removed from the
     /// cache.
-    pub fn state(&mut self, image_cache: &mut ImageCache, timer: &Snapshot<'_>) -> LayoutState {
+    pub fn state(&mut self, image_cache: &mut ImageCache, timer: &Snapshot) -> LayoutState {
         let mut state = Default::default();
         self.update_state(&mut state, image_cache, timer);
         state

--- a/src/layout/parser/blank_space.rs
+++ b/src/layout/parser/blank_space.rs
@@ -1,12 +1,12 @@
-use super::{translate_size, Error, GradientBuilder, Result};
+use super::{Error, GradientBuilder, Result, translate_size};
 use crate::util::xml::{
-    helper::{end_tag, parse_children, text_parsed},
     Reader,
+    helper::{end_tag, parse_children, text_parsed},
 };
 
 pub use crate::component::blank_space::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
 

--- a/src/layout/parser/current_comparison.rs
+++ b/src/layout/parser/current_comparison.rs
@@ -1,12 +1,12 @@
-use super::{color, parse_bool, GradientBuilder, Result};
+use super::{GradientBuilder, Result, color, parse_bool};
 use crate::util::xml::{
-    helper::{end_tag, parse_children},
     Reader,
+    helper::{end_tag, parse_children},
 };
 
 pub use crate::component::current_comparison::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/layout/parser/current_pace.rs
+++ b/src/layout/parser/current_pace.rs
@@ -1,12 +1,12 @@
-use super::{accuracy, color, comparison_override, parse_bool, GradientBuilder, Result};
+use super::{GradientBuilder, Result, accuracy, color, comparison_override, parse_bool};
 use crate::util::xml::{
-    helper::{end_tag, parse_children},
     Reader,
+    helper::{end_tag, parse_children},
 };
 
 pub use crate::component::current_pace::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/layout/parser/delta.rs
+++ b/src/layout/parser/delta.rs
@@ -1,12 +1,12 @@
-use super::{accuracy, color, comparison_override, parse_bool, GradientBuilder, Result};
+use super::{GradientBuilder, Result, accuracy, color, comparison_override, parse_bool};
 use crate::util::xml::{
-    helper::{end_tag, parse_children},
     Reader,
+    helper::{end_tag, parse_children},
 };
 
 pub use crate::component::delta::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let mut override_label = false;

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -1,13 +1,12 @@
 use super::{
-    accuracy, color, comparison_override, end_tag, parse_bool, parse_children, text_parsed,
-    timer_format, timing_method_override, translate_size, DeltaGradientKind, GradientBuilder,
-    Result,
+    DeltaGradientKind, GradientBuilder, Result, accuracy, color, comparison_override, end_tag,
+    parse_bool, parse_children, text_parsed, timer_format, timing_method_override, translate_size,
 };
 use crate::{timing::formatter::DigitsFormat, util::xml::Reader};
 
 pub use crate::component::detailed_timer::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let mut settings = component.settings().clone();
     let mut background_builder = GradientBuilder::<DeltaGradientKind>::new_gradient_type();
     let mut timer_override_color = false;

--- a/src/layout/parser/graph.rs
+++ b/src/layout/parser/graph.rs
@@ -1,12 +1,12 @@
 use super::{
-    color, comparison_override, end_tag, parse_bool, parse_children, text_parsed, translate_size,
-    Result,
+    Result, color, comparison_override, end_tag, parse_bool, parse_children, text_parsed,
+    translate_size,
 };
 
 pub use crate::component::graph::Component;
 use crate::util::xml::Reader;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
 
     parse_children(reader, |reader, tag, _| {

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -280,7 +280,7 @@ impl<T: GradientType> GradientBuilder<T> {
         }
     }
 
-    fn parse_background(&mut self, reader: &mut Reader<'_>, tag_name: &str) -> Result<bool> {
+    fn parse_background(&mut self, reader: &mut Reader, tag_name: &str) -> Result<bool> {
         if tag_name == self.tag_color1 {
             color(reader, |c| self.first = c)?;
         } else if tag_name == self.tag_color2 {
@@ -301,7 +301,7 @@ impl<T: GradientType> GradientBuilder<T> {
     }
 }
 
-fn color<F>(reader: &mut Reader<'_>, func: F) -> Result<()>
+fn color<F>(reader: &mut Reader, func: F) -> Result<()>
 where
     F: FnOnce(Color),
 {
@@ -329,7 +329,7 @@ where
     })
 }
 
-fn percentage<F>(reader: &mut Reader<'_>, func: F) -> Result<()>
+fn percentage<F>(reader: &mut Reader, func: F) -> Result<()>
 where
     F: FnOnce(f32),
 {
@@ -344,7 +344,7 @@ where
     })
 }
 
-fn font<F>(reader: &mut Reader<'_>, font_buf: &mut Vec<MaybeUninit<u8>>, f: F) -> Result<()>
+fn font<F>(reader: &mut Reader, font_buf: &mut Vec<MaybeUninit<u8>>, f: F) -> Result<()>
 where
     F: FnOnce(Font),
 {
@@ -541,7 +541,7 @@ where
     })
 }
 
-fn parse_bool<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn parse_bool<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(bool),
 {
@@ -558,7 +558,7 @@ where
     })
 }
 
-fn comparison_override<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn comparison_override<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(Option<String>),
 {
@@ -571,7 +571,7 @@ where
     })
 }
 
-fn timing_method_override<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn timing_method_override<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(Option<TimingMethod>),
 {
@@ -586,7 +586,7 @@ where
     })
 }
 
-fn accuracy<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn accuracy<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(Accuracy),
 {
@@ -601,7 +601,7 @@ where
     })
 }
 
-fn timer_format<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn timer_format<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(DigitsFormat, Accuracy),
 {
@@ -625,7 +625,7 @@ where
     })
 }
 
-fn component<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn component<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(Component),
 {
@@ -699,7 +699,7 @@ where
     Ok(())
 }
 
-fn parse_general_settings(layout: &mut Layout, reader: &mut Reader<'_>) -> Result<()> {
+fn parse_general_settings(layout: &mut Layout, reader: &mut Reader) -> Result<()> {
     let settings = layout.general_settings_mut();
     let mut background_builder = GradientBuilder::<LayoutBackgroundKind>::new_gradient_type();
 

--- a/src/layout/parser/pb_chance.rs
+++ b/src/layout/parser/pb_chance.rs
@@ -1,9 +1,9 @@
-use super::{end_tag, parse_children, Result};
+use super::{Result, end_tag, parse_children};
 
 pub use crate::component::pb_chance::Component;
 use crate::util::xml::Reader;
 
-pub fn settings(reader: &mut Reader<'_>, _: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, _: &mut Component) -> Result<()> {
     parse_children(reader, |reader, _, _| -> Result<()> {
         // Unused:
         // AttemptCount

--- a/src/layout/parser/possible_time_save.rs
+++ b/src/layout/parser/possible_time_save.rs
@@ -1,12 +1,12 @@
 use super::{
-    accuracy, color, comparison_override, end_tag, parse_bool, parse_children, GradientBuilder,
-    Result,
+    GradientBuilder, Result, accuracy, color, comparison_override, end_tag, parse_bool,
+    parse_children,
 };
 use crate::util::xml::Reader;
 
 pub use crate::component::possible_time_save::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/layout/parser/previous_segment.rs
+++ b/src/layout/parser/previous_segment.rs
@@ -1,12 +1,12 @@
 use super::{
-    accuracy, color, comparison_override, end_tag, parse_bool, parse_children, GradientBuilder,
-    Result,
+    GradientBuilder, Result, accuracy, color, comparison_override, end_tag, parse_bool,
+    parse_children,
 };
 use crate::util::xml::Reader;
 
 pub use crate::component::previous_segment::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let mut override_label = false;

--- a/src/layout/parser/splits.rs
+++ b/src/layout/parser/splits.rs
@@ -13,7 +13,7 @@ use crate::{
 
 pub use crate::component::splits::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut split_gradient_builder = GradientBuilder::<GradientKind>::with_tags(
         "CurrentSplitTopColor",

--- a/src/layout/parser/sum_of_best.rs
+++ b/src/layout/parser/sum_of_best.rs
@@ -1,9 +1,9 @@
-use super::{accuracy, color, end_tag, parse_bool, parse_children, GradientBuilder, Result};
+use super::{GradientBuilder, Result, accuracy, color, end_tag, parse_bool, parse_children};
 use crate::util::xml::Reader;
 
 pub use crate::component::sum_of_best::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/layout/parser/text.rs
+++ b/src/layout/parser/text.rs
@@ -3,7 +3,7 @@ use crate::{component::text::Text, platform::prelude::*, util::xml::Reader};
 
 pub use crate::component::text::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/layout/parser/timer.rs
+++ b/src/layout/parser/timer.rs
@@ -1,12 +1,12 @@
 use super::{
-    accuracy, color, end_tag, parse_bool, parse_children, text_parsed, timer_format,
-    timing_method_override, translate_size, DeltaGradientKind, GradientBuilder, Result,
+    DeltaGradientKind, GradientBuilder, Result, accuracy, color, end_tag, parse_bool,
+    parse_children, text_parsed, timer_format, timing_method_override, translate_size,
 };
 use crate::util::xml::Reader;
 
 pub use crate::component::timer::Component;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::<DeltaGradientKind>::new_gradient_type();
     let mut override_color = false;

--- a/src/layout/parser/title.rs
+++ b/src/layout/parser/title.rs
@@ -1,12 +1,12 @@
 use super::{
-    color, end_tag, parse_bool, parse_children, text_as_escaped_string_err, Alignment, Error,
-    GradientBuilder, Result,
+    Alignment, Error, GradientBuilder, Result, color, end_tag, parse_bool, parse_children,
+    text_as_escaped_string_err,
 };
 
 pub use crate::component::title::Component;
 use crate::util::xml::Reader;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let mut override_title_color = false;

--- a/src/layout/parser/total_playtime.rs
+++ b/src/layout/parser/total_playtime.rs
@@ -1,9 +1,9 @@
-use super::{color, end_tag, parse_bool, parse_children, GradientBuilder, Result};
+use super::{GradientBuilder, Result, color, end_tag, parse_bool, parse_children};
 
 pub use crate::component::total_playtime::Component;
 use crate::util::xml::Reader;
 
-pub fn settings(reader: &mut Reader<'_>, component: &mut Component) -> Result<()> {
+pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
     let settings = component.settings_mut();
     let mut background_builder = GradientBuilder::new();
     let (mut override_label, mut override_value) = (false, false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
     clippy::missing_const_for_fn,
     clippy::undocumented_unsafe_blocks,
     clippy::needless_pass_by_ref_mut,
-    missing_docs,
-    rust_2018_idioms
+    missing_docs
 )]
 #![forbid(clippy::incompatible_msrv)]
 // Clippy false positives
@@ -92,7 +91,7 @@ pub use crate::{
 pub use livesplit_hotkey as hotkey;
 
 #[cfg(not(feature = "std"))]
-pub use crate::platform::{register_clock, Clock, Duration};
+pub use crate::platform::{Clock, Duration, register_clock};
 
 #[cfg(feature = "std")]
 pub use crate::{hotkey_config::HotkeyConfig, hotkey_system::HotkeySystem, timing::SharedTimer};

--- a/src/networking/server_protocol.rs
+++ b/src/networking/server_protocol.rs
@@ -53,9 +53,9 @@ use alloc::borrow::Cow;
 use serde::Serializer;
 
 use crate::{
-    event::{self, Event},
-    timing::formatter::{self, TimeFormatter, ASCII_MINUS},
     TimeSpan, Timer, TimerPhase, TimingMethod,
+    event::{self, Event},
+    timing::formatter::{self, ASCII_MINUS, TimeFormatter},
 };
 
 /// Handles an incoming command and returns the response to be sent.
@@ -63,7 +63,7 @@ pub async fn handle_command<S: event::CommandSink + event::TimerQuery>(
     command: &str,
     command_sink: &S,
 ) -> String {
-    let response = match serde_json::from_str::<Command<'_>>(command) {
+    let response = match serde_json::from_str::<Command>(command) {
         Ok(command) => command.handle(command_sink).await.into(),
         Err(e) => CommandResult::Error(Error::InvalidCommand {
             message: e.to_string(),

--- a/src/platform/math.rs
+++ b/src/platform/math.rs
@@ -2,7 +2,7 @@ pub mod f32 {
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "std"))] {
             #[inline(always)]
-            #[allow(clippy::missing_const_for_fn)] // Can't do this for the libm counterpart.
+            #[expect(clippy::missing_const_for_fn)] // Can't do this for the libm counterpart.
             pub fn abs(x: f32) -> f32 {
                 x.abs()
             }
@@ -26,7 +26,6 @@ mod f64 {
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "std"))] {
             #[inline(always)]
-            #[allow(clippy::missing_const_for_fn)] // Can't do this for the libm counterpart.
             pub fn powf(x: f64, y: f64) -> f64 {
                 x.powf(y)
             }

--- a/src/platform/no_std/mod.rs
+++ b/src/platform/no_std/mod.rs
@@ -1,8 +1,10 @@
 mod time;
 pub use self::time::*;
 
+#[allow(unused)]
 pub struct RwLock<T>(core::cell::RefCell<T>);
 
+#[allow(unused)]
 impl<T> RwLock<T> {
     pub fn new(value: T) -> Self {
         Self(core::cell::RefCell::new(value))

--- a/src/rendering/component/blank_space.rs
+++ b/src/rendering/component/blank_space.rs
@@ -1,10 +1,10 @@
 use crate::{
     component::blank_space::State,
-    rendering::{resource::ResourceAllocator, RenderContext},
+    rendering::{RenderContext, resource::ResourceAllocator},
 };
 
 pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+    context: &mut RenderContext<impl ResourceAllocator>,
     dim: [f32; 2],
     component: &State,
 ) {

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -38,7 +38,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,

--- a/src/rendering/component/graph.rs
+++ b/src/rendering/component/graph.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+    context: &mut RenderContext<impl ResourceAllocator>,
     [width, height]: [f32; 2],
     component: &State,
     _layout_state: &LayoutState,

--- a/src/rendering/component/key_value.rs
+++ b/src/rendering/component/key_value.rs
@@ -24,7 +24,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     dim: [f32; 2],
     component: &State,
     layout_state: &LayoutState,

--- a/src/rendering/component/mod.rs
+++ b/src/rendering/component/mod.rs
@@ -1,9 +1,9 @@
 use crate::layout::{ComponentState, LayoutState};
 
 use super::{
+    RenderContext,
     consts::{DEFAULT_COMPONENT_HEIGHT, PSEUDO_PIXELS, SEPARATOR_THICKNESS, TWO_ROW_HEIGHT},
     resource::ResourceAllocator,
-    RenderContext,
 };
 
 pub mod blank_space;
@@ -138,7 +138,7 @@ pub fn height(component: &ComponentState) -> f32 {
 
 pub(super) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     component: &ComponentState,
     state: &LayoutState,
     dim: [f32; 2],

--- a/src/rendering/component/separator.rs
+++ b/src/rendering/component/separator.rs
@@ -1,12 +1,12 @@
 use crate::{
     component::separator::State,
     layout::LayoutState,
-    rendering::{resource::ResourceAllocator, RenderContext},
+    rendering::{RenderContext, resource::ResourceAllocator},
     settings::Gradient,
 };
 
 pub(in crate::rendering) fn render(
-    context: &mut RenderContext<'_, impl ResourceAllocator>,
+    context: &mut RenderContext<impl ResourceAllocator>,
     dim: [f32; 2],
     _component: &State,
     layout_state: &LayoutState,

--- a/src/rendering/component/splits.rs
+++ b/src/rendering/component/splits.rs
@@ -86,7 +86,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,
@@ -185,40 +185,40 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
     let transform = context.transform;
     let text_color = solid(&layout_state.text_color);
 
-    if let Some(column_labels) = &component.column_labels {
-        if layout_state.direction == LayoutDirection::Vertical {
-            cache
-                .column_labels
-                .resize_with(column_labels.len(), CachedLabel::new);
+    if let Some(column_labels) = &component.column_labels
+        && layout_state.direction == LayoutDirection::Vertical
+    {
+        cache
+            .column_labels
+            .resize_with(column_labels.len(), CachedLabel::new);
 
-            let mut right_x = width - PADDING;
-            for ((label, column_cache), (max_width, _)) in column_labels
-                .iter()
-                .zip(&mut cache.column_labels)
-                .zip(&mut cache.column_width_labels)
-            {
-                let left_x = context.render_text_right_align(
-                    label,
-                    column_cache,
-                    Layer::Bottom,
-                    [right_x, TEXT_ALIGN_TOP],
-                    DEFAULT_TEXT_SIZE,
-                    text_color,
-                );
-                let label_width = right_x - left_x;
-                if label_width > *max_width {
-                    *max_width = label_width;
-                }
-                right_x -= *max_width + PADDING;
-            }
-
-            context.translate(0.0, DEFAULT_COMPONENT_HEIGHT);
-            context.render_rectangle(
-                [0.0, -THIN_SEPARATOR_THICKNESS],
-                [width, THIN_SEPARATOR_THICKNESS],
-                &Gradient::Plain(layout_state.separators_color),
+        let mut right_x = width - PADDING;
+        for ((label, column_cache), (max_width, _)) in column_labels
+            .iter()
+            .zip(&mut cache.column_labels)
+            .zip(&mut cache.column_width_labels)
+        {
+            let left_x = context.render_text_right_align(
+                label,
+                column_cache,
+                Layer::Bottom,
+                [right_x, TEXT_ALIGN_TOP],
+                DEFAULT_TEXT_SIZE,
+                text_color,
             );
+            let label_width = right_x - left_x;
+            if label_width > *max_width {
+                *max_width = label_width;
+            }
+            right_x -= *max_width + PADDING;
         }
+
+        context.translate(0.0, DEFAULT_COMPONENT_HEIGHT);
+        context.render_rectangle(
+            [0.0, -THIN_SEPARATOR_THICKNESS],
+            [width, THIN_SEPARATOR_THICKNESS],
+            &Gradient::Plain(layout_state.separators_color),
+        );
     }
 
     let icon_size = split_height - 2.0 * vertical_padding;

--- a/src/rendering/component/text.rs
+++ b/src/rendering/component/text.rs
@@ -26,7 +26,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,

--- a/src/rendering/component/timer.rs
+++ b/src/rendering/component/timer.rs
@@ -22,7 +22,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     [width, height]: [f32; 2],
     component: &State,
 ) -> f32 {

--- a/src/rendering/component/title.rs
+++ b/src/rendering/component/title.rs
@@ -36,7 +36,7 @@ impl<L> Cache<L> {
 
 pub(in crate::rendering) fn render<A: ResourceAllocator>(
     cache: &mut Cache<A::Label>,
-    context: &mut RenderContext<'_, A>,
+    context: &mut RenderContext<A>,
     [width, height]: [f32; 2],
     component: &State,
     layout_state: &LayoutState,

--- a/src/rendering/default_text_engine/color_font/mod.rs
+++ b/src/rendering/default_text_engine/color_font/mod.rs
@@ -42,14 +42,13 @@ impl<'f> ColorTables<'f> {
 }
 
 pub fn iter_colored_glyphs(
-    color_tables: &Option<ColorTables<'_>>,
+    color_tables: &Option<ColorTables>,
     palette: usize,
     glyph: GlyphId,
     mut f: impl FnMut(GlyphId, Option<Color>),
 ) {
-    if let Some(iter) = color_tables
-        .as_ref()
-        .and_then(|c| c.look_up(palette, glyph.0))
+    if let Some(c) = color_tables
+        && let Some(iter) = c.look_up(palette, glyph.0)
     {
         for (glyph, color) in iter {
             f(GlyphId(glyph), color);

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -556,7 +556,7 @@ impl<A: ResourceAllocator> RenderContext<'_, A> {
     fn render_key_value_component(
         &mut self,
         key: &str,
-        abbreviations: &[Cow<'_, str>],
+        abbreviations: &[Cow<str>],
         key_label: &mut AbbreviatedLabel<A::Label>,
         value: &str,
         value_label: &mut CachedLabel<A::Label>,

--- a/src/rendering/resource/handles.rs
+++ b/src/rendering/resource/handles.rs
@@ -17,7 +17,7 @@ impl<A> Handles<A> {
         Self { next_id, allocator }
     }
 
-    pub fn next<T>(&mut self, element: T) -> Handle<T> {
+    pub const fn next<T>(&mut self, element: T) -> Handle<T> {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
         Handle { id, inner: element }

--- a/src/rendering/scene.rs
+++ b/src/rendering/scene.rs
@@ -1,7 +1,7 @@
 use super::{
-    entity::{calculate_hash, Entity},
-    resource::{Handle, SharedOwnership},
     Background,
+    entity::{Entity, calculate_hash},
+    resource::{Handle, SharedOwnership},
 };
 use crate::platform::prelude::*;
 
@@ -96,12 +96,12 @@ impl<P: SharedOwnership, I: SharedOwnership, L: SharedOwnership> Scene<P, I, L> 
     }
 
     /// Get a mutable reference to the scene's bottom [`Layer`].
-    pub fn bottom_layer_mut(&mut self) -> &mut Vec<Entity<P, I, L>> {
+    pub const fn bottom_layer_mut(&mut self) -> &mut Vec<Entity<P, I, L>> {
         &mut self.bottom_layer
     }
 
     /// Get a mutable reference to the scene's top [`Layer`].
-    pub fn top_layer_mut(&mut self) -> &mut Vec<Entity<P, I, L>> {
+    pub const fn top_layer_mut(&mut self) -> &mut Vec<Entity<P, I, L>> {
         &mut self.top_layer
     }
 
@@ -122,7 +122,7 @@ impl<P: SharedOwnership, I: SharedOwnership, L: SharedOwnership> Scene<P, I, L> 
     }
 
     /// Accesses the [`Layer`] specified mutably.
-    pub fn layer_mut(&mut self, layer: Layer) -> &mut Vec<Entity<P, I, L>> {
+    pub const fn layer_mut(&mut self, layer: Layer) -> &mut Vec<Entity<P, I, L>> {
         match layer {
             Layer::Bottom => &mut self.bottom_layer,
             Layer::Top => &mut self.top_layer,

--- a/src/rendering/software.rs
+++ b/src/rendering/software.rs
@@ -417,7 +417,7 @@ impl Renderer {
 }
 
 fn render_layer(
-    canvas: &mut PixmapMut<'_>,
+    canvas: &mut PixmapMut,
     layer: &[Entity<SkiaPath, SkiaImage, SkiaLabel>],
     rectangle: &Path,
 ) {
@@ -635,7 +635,7 @@ fn fill_background(
         BackgroundImage<usize>,
         Pixmap,
     )>,
-    background_layer: &mut PixmapMut<'_>,
+    background_layer: &mut PixmapMut,
     width: u32,
     height: u32,
     rectangle: &Path,

--- a/src/rendering/web/mod.rs
+++ b/src/rendering/web/mod.rs
@@ -384,21 +384,21 @@ impl ResourceAllocator for CanvasAllocator {
         label.shape = shape;
 
         // FIXME: Pop from the existing shape instead.
-        if let Some(max_width) = max_width {
-            if label.width > max_width {
-                let mut text = text.to_owned();
-                while let Some((drain_index, _)) = text.char_indices().next_back() {
-                    text.drain(drain_index..);
-                    text.push('…');
-                    let (shape, width) = font.font_handling.shape(&text, &self.ctx_top);
-                    label.shape = shape;
-                    label.width = width;
-                    if label.width <= max_width {
-                        break;
-                    } else {
-                        const ELLIPSIS_LEN: usize = '…'.len_utf8();
-                        text.drain(text.len() - ELLIPSIS_LEN..);
-                    }
+        if let Some(max_width) = max_width
+            && label.width > max_width
+        {
+            let mut text = text.to_owned();
+            while let Some((drain_index, _)) = text.char_indices().next_back() {
+                text.drain(drain_index..);
+                text.push('…');
+                let (shape, width) = font.font_handling.shape(&text, &self.ctx_top);
+                label.shape = shape;
+                label.width = width;
+                if label.width <= max_width {
+                    break;
+                } else {
+                    const ELLIPSIS_LEN: usize = '…'.len_utf8();
+                    text.drain(text.len() - ELLIPSIS_LEN..);
                 }
             }
         }

--- a/src/run/editor/state.rs
+++ b/src/run/editor/state.rs
@@ -4,7 +4,7 @@ use crate::{
     platform::prelude::*,
     run::RunMetadata,
     settings::{ImageCache, ImageId},
-    timing::formatter::{none_wrapper::EmptyWrapper, Accuracy, SegmentTime, TimeFormatter},
+    timing::formatter::{Accuracy, SegmentTime, TimeFormatter, none_wrapper::EmptyWrapper},
 };
 use serde_derive::{Deserialize, Serialize};
 
@@ -59,7 +59,7 @@ pub struct Buttons {
 }
 
 /// Describes the current state of a segment.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Segment {
     /// The icon of the segment. The associated image can be looked up in the
     /// image cache. The image may be the empty image. This indicates that there
@@ -82,7 +82,7 @@ pub struct Segment {
 }
 
 /// Describes a segment's selection state.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SelectionState {
     /// The segment is not selected.
     NotSelected,

--- a/src/run/parser/face_split.rs
+++ b/src/run/parser/face_split.rs
@@ -1,6 +1,6 @@
 //! Provides the parser for FaceSplit splits files.
 
-use crate::{timing, RealTime, Run, Segment, Time, TimeSpan};
+use crate::{RealTime, Run, Segment, Time, TimeSpan, timing};
 use alloc::borrow::Cow;
 use core::{num::ParseIntError, result::Result as StdResult};
 use snafu::{OptionExt, ResultExt};
@@ -108,18 +108,16 @@ pub fn parse(source: &str, #[allow(unused)] load_icons: bool) -> Result<Run> {
         splits.next(); // Skip Segment Time
 
         #[cfg(feature = "std")]
-        if load_icons {
-            if let Some(icon_path) = splits.next() {
-                if !icon_path.is_empty() {
-                    if let Ok(image) = crate::settings::Image::from_file(
-                        icon_path,
-                        &mut icon_buf,
-                        crate::settings::Image::ICON,
-                    ) {
-                        segment.set_icon(image);
-                    }
-                }
-            }
+        if load_icons
+            && let Some(icon_path) = splits.next()
+            && !icon_path.is_empty()
+            && let Ok(image) = crate::settings::Image::from_file(
+                icon_path,
+                &mut icon_buf,
+                crate::settings::Image::ICON,
+            )
+        {
+            segment.set_icon(image);
         }
 
         run.push_segment(segment);

--- a/src/run/parser/llanfair_gered.rs
+++ b/src/run/parser/llanfair_gered.rs
@@ -7,15 +7,15 @@ use crate::util::byte_parsing::big_endian::strip_u32;
 #[cfg(feature = "std")]
 use crate::util::xml::helper::text_as_str_err;
 use crate::{
+    RealTime, Run, Segment, Time, TimeSpan,
     platform::prelude::*,
     util::xml::{
-        helper::{
-            end_tag, optional_attribute_escaped_err, parse_base, parse_children, single_child,
-            text, text_err, text_parsed, Error as XmlError,
-        },
         Reader,
+        helper::{
+            Error as XmlError, end_tag, optional_attribute_escaped_err, parse_base, parse_children,
+            single_child, text, text_err, text_parsed,
+        },
     },
-    RealTime, Run, Segment, Time, TimeSpan,
 };
 #[cfg(feature = "std")]
 use image::{ExtendedColorType, ImageEncoder};
@@ -64,7 +64,7 @@ const fn type_hint<T>(v: Result<T>) -> Result<T> {
     v
 }
 
-fn time_span<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn time_span<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(TimeSpan),
 {
@@ -75,7 +75,7 @@ where
     })
 }
 
-fn time<F>(reader: &mut Reader<'_>, f: F) -> Result<()>
+fn time<F>(reader: &mut Reader, f: F) -> Result<()>
 where
     F: FnOnce(Time),
 {
@@ -84,7 +84,7 @@ where
 
 #[cfg(feature = "std")]
 fn image<F>(
-    reader: &mut Reader<'_>,
+    reader: &mut Reader,
     raw_buf: &mut Vec<MaybeUninit<u8>>,
     png_buf: &mut Vec<u8>,
     mut f: F,
@@ -135,7 +135,7 @@ where
 
 fn parse_segment(
     total_time: &mut TimeSpan,
-    reader: &mut Reader<'_>,
+    reader: &mut Reader,
     _raw_buf: &mut Vec<MaybeUninit<u8>>,
     _png_buf: &mut Vec<u8>,
 ) -> Result<Segment> {

--- a/src/run/parser/source_live_timer.rs
+++ b/src/run/parser/source_live_timer.rs
@@ -22,7 +22,7 @@ pub enum Error {
 /// The Result type for the SourceLiveTimer parser.
 pub type Result<T> = StdResult<T, Error>;
 
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Deserialize)]
 struct Splits<'a> {
     #[serde(borrow)]
@@ -32,7 +32,7 @@ struct Splits<'a> {
     Splits: Option<Vec<Split<'a>>>,
 }
 
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Deserialize)]
 struct Split<'a> {
     #[serde(borrow)]

--- a/src/run/parser/splitterino.rs
+++ b/src/run/parser/splitterino.rs
@@ -1,6 +1,6 @@
 //! Provides the parser for Splitterino splits files.
 
-use crate::{platform::prelude::*, Run, Segment, Time, TimeSpan};
+use crate::{Run, Segment, Time, TimeSpan, platform::prelude::*};
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
 use serde_derive::Deserialize;
@@ -184,14 +184,14 @@ pub fn parse(source: &str) -> Result<Run> {
         .extend(splits.segments.into_iter().map(|split| {
             let mut segment = Segment::new(split.name);
 
-            if !split.skipped {
-                if let Some(personal_best) = split.personal_best {
-                    segment.set_personal_best_split_time(parse_split_time(
-                        &mut total_rta,
-                        &mut total_igt,
-                        personal_best,
-                    ));
-                }
+            if !split.skipped
+                && let Some(personal_best) = split.personal_best
+            {
+                segment.set_personal_best_split_time(parse_split_time(
+                    &mut total_rta,
+                    &mut total_igt,
+                    personal_best,
+                ));
             }
 
             if let Some(overall_best) = split.overall_best {

--- a/src/run/parser/splitterz.rs
+++ b/src/run/parser/splitterz.rs
@@ -1,6 +1,6 @@
 //! Provides the parser for SplitterZ splits files.
 
-use crate::{timing, RealTime, Run, Segment, TimeSpan};
+use crate::{RealTime, Run, Segment, TimeSpan, timing};
 use alloc::borrow::Cow;
 use core::{num::ParseIntError, result::Result as StdResult};
 use snafu::ResultExt;
@@ -101,18 +101,16 @@ pub fn parse(source: &str, #[allow(unused)] load_icons: bool) -> Result<Run> {
         }
 
         #[cfg(feature = "std")]
-        if load_icons {
-            if let Some(icon_path) = splits.next() {
-                if !icon_path.is_empty() {
-                    if let Ok(image) = crate::settings::Image::from_file(
-                        unescape(icon_path).as_ref(),
-                        &mut icon_buf,
-                        crate::settings::Image::ICON,
-                    ) {
-                        segment.set_icon(image);
-                    }
-                }
-            }
+        if load_icons
+            && let Some(icon_path) = splits.next()
+            && !icon_path.is_empty()
+            && let Ok(image) = crate::settings::Image::from_file(
+                unescape(icon_path).as_ref(),
+                &mut icon_buf,
+                crate::settings::Image::ICON,
+            )
+        {
+            segment.set_icon(image);
         }
 
         run.push_segment(segment);

--- a/src/run/parser/time_split_tracker.rs
+++ b/src/run/parser/time_split_tracker.rs
@@ -1,13 +1,14 @@
 //! Provides the parser for Time Split Tracker splits files.
 
 use super::super::AddComparisonError;
+#[cfg(feature = "std")]
+use crate::{AtomicDateTime, settings::Image};
 use crate::{
+    RealTime, Run, Segment, Time, TimeSpan,
     comparison::RACE_COMPARISON_PREFIX,
     platform::{path::Path, prelude::*},
-    timing, RealTime, Run, Segment, Time, TimeSpan,
+    timing,
 };
-#[cfg(feature = "std")]
-use crate::{settings::Image, AtomicDateTime};
 use alloc::borrow::Cow;
 use core::{fmt::Write, num::ParseIntError, result::Result as StdResult};
 use snafu::{OptionExt, ResultExt};

--- a/src/run/parser/timer_kind.rs
+++ b/src/run/parser/timer_kind.rs
@@ -65,7 +65,7 @@ impl TimerKind<'_> {
 }
 
 impl fmt::Display for TimerKind<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             TimerKind::LiveSplit => "LiveSplit",
             TimerKind::WSplit => "WSplit",

--- a/src/run/run_metadata.rs
+++ b/src/run/run_metadata.rs
@@ -91,7 +91,6 @@ impl RunMetadata {
     /// changed once the Personal Best doesn't match up with that record
     /// anymore. This may be empty if there's no association.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn run_id(&self) -> &str {
         &self.run_id
     }
@@ -110,7 +109,6 @@ impl RunMetadata {
     /// Accesses the name of the platform this game is run on. This may be empty
     /// if it's not specified.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn platform_name(&self) -> &str {
         &self.platform_name
     }
@@ -142,7 +140,6 @@ impl RunMetadata {
     /// Accesses the name of the region this game is from. This may be empty if
     /// it's not specified.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn region_name(&self) -> &str {
         &self.region_name
     }

--- a/src/run/saver/livesplit.rs
+++ b/src/run/saver/livesplit.rs
@@ -25,12 +25,12 @@
 //! ```
 
 use crate::{
+    DateTime, Run, Time, Timer, TimerPhase,
     platform::prelude::*,
     run::LinkedLayout,
     settings::Image,
     timing::formatter::{Complete, TimeFormatter},
-    util::xml::{AttributeWriter, DisplayAlreadyEscaped, Text, Writer, NO_ATTRIBUTES},
-    DateTime, Run, Time, Timer, TimerPhase,
+    util::xml::{AttributeWriter, DisplayAlreadyEscaped, NO_ATTRIBUTES, Text, Writer},
 };
 use alloc::borrow::Cow;
 use core::{fmt, mem::MaybeUninit};
@@ -67,7 +67,7 @@ fn image<W: fmt::Write>(
     tag: &str,
     image: &Image,
     base64_buf: &mut Vec<MaybeUninit<u8>>,
-    image_buf: &mut Cow<'_, [u8]>,
+    image_buf: &mut Cow<[u8]>,
 ) -> fmt::Result {
     writer.tag(tag, |tag| {
         let image_data = image.data();
@@ -96,11 +96,7 @@ fn image<W: fmt::Write>(
     })
 }
 
-fn date<W: fmt::Write>(
-    writer: &mut AttributeWriter<'_, W>,
-    key: &str,
-    date: DateTime,
-) -> fmt::Result {
+fn date<W: fmt::Write>(writer: &mut AttributeWriter<W>, key: &str, date: DateTime) -> fmt::Result {
     let date = date.to_offset(UtcOffset::UTC);
     let (year, month, day) = date.to_calendar_date();
     let month = month as u8;
@@ -134,7 +130,7 @@ fn time_inner<W: fmt::Write>(writer: &mut Writer<W>, time: Time) -> fmt::Result 
     Ok(())
 }
 
-fn time<W: fmt::Write>(writer: AttributeWriter<'_, W>, time: Time) -> fmt::Result {
+fn time<W: fmt::Write>(writer: AttributeWriter<W>, time: Time) -> fmt::Result {
     if time.real_time.is_some() || time.game_time.is_some() {
         writer.content(|writer| time_inner(writer, time))
     } else {

--- a/src/run/segment.rs
+++ b/src/run/segment.rs
@@ -45,7 +45,6 @@ impl Segment {
 
     /// Accesses the name of the segment.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/settings/color.rs
+++ b/src/settings/color.rs
@@ -231,7 +231,7 @@ impl<'de> Deserialize<'de> for Color {
 mod tests {
     use super::*;
 
-    #[allow(clippy::float_cmp)]
+    #[expect(clippy::float_cmp)]
     #[test]
     fn to_hsva() {
         assert_eq!(

--- a/src/settings/image/image_id.rs
+++ b/src/settings/image/image_id.rs
@@ -10,13 +10,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 pub struct ImageId(pub(crate) [u8; 32]);
 
 impl fmt::Display for ImageId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self.format_str(&mut [0; 64]), f)
     }
 }
 
 impl fmt::Debug for ImageId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.format_str(&mut [0; 64]), f)
     }
 }
@@ -119,7 +119,7 @@ impl serde::de::Visitor<'_> for ImageIdVisitor {
         ImageId::from_str(v).map_err(|_| E::custom("invalid 64 char hex string"))
     }
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a SHA-256 hash")
     }
 }

--- a/src/settings/image/mod.rs
+++ b/src/settings/image/mod.rs
@@ -27,7 +27,7 @@ pub struct Image {
 }
 
 impl fmt::Debug for Image {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Image")
             .field("is_empty", &self.is_empty())
             .field("id", &self.id)
@@ -79,7 +79,7 @@ struct ImageVisitor;
 impl Visitor<'_> for ImageVisitor {
     type Value = Image;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a base64 encoded image or its bytes")
     }
 
@@ -177,7 +177,6 @@ impl Image {
     /// Accesses the image's data. If the image's data is empty, this returns an
     /// empty slice.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn data(&self) -> &[u8] {
         self
     }

--- a/src/settings/layout_background.rs
+++ b/src/settings/layout_background.rs
@@ -2,7 +2,7 @@ use super::{Gradient, Image, ImageCache, ImageId};
 use serde_derive::{Deserialize, Serialize};
 
 /// The background of a layout.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum LayoutBackground<I = Image> {
     /// A gradient that describes the background coloration.
@@ -15,7 +15,7 @@ pub enum LayoutBackground<I = Image> {
 
 /// An image that is stretched to fill the background. The stretch is meant to
 /// preserve the aspect ratio of the image, but always fill the full background.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BackgroundImage<I> {
     /// The image itself.
     pub image: I,
@@ -36,6 +36,17 @@ pub struct BackgroundImage<I> {
     /// sigma = BLUR_FACTOR * blur * max(width, height)
     /// ```
     pub blur: f32,
+}
+
+impl<I: Default> Default for BackgroundImage<I> {
+    fn default() -> Self {
+        Self {
+            image: I::default(),
+            brightness: 1.0,
+            opacity: 1.0,
+            blur: 0.0,
+        }
+    }
 }
 
 /// A constant that is part of the formula to calculate the sigma of a gaussian

--- a/src/timing/formatter/accuracy.rs
+++ b/src/timing/formatter/accuracy.rs
@@ -1,4 +1,4 @@
-use super::{format_padded, NANOS_PER_HUNDREDTH, NANOS_PER_MILLI, NANOS_PER_TENTH};
+use super::{NANOS_PER_HUNDREDTH, NANOS_PER_MILLI, NANOS_PER_TENTH, format_padded};
 use core::{
     fmt::{Display, Formatter, Result},
     str,
@@ -36,7 +36,7 @@ pub struct FractionalPart {
 }
 
 impl Display for FractionalPart {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         match self.accuracy {
             Accuracy::Seconds => Ok(()),
             Accuracy::Tenths => {

--- a/src/timing/formatter/complete.rs
+++ b/src/timing/formatter/complete.rs
@@ -1,6 +1,6 @@
 use super::{
-    format_padded, TimeFormatter, ASCII_MINUS, SECONDS_PER_DAY, SECONDS_PER_HOUR,
-    SECONDS_PER_MINUTE,
+    ASCII_MINUS, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter,
+    format_padded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -45,7 +45,7 @@ impl TimeFormatter<'_> for Complete {
 }
 
 impl Display for Inner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.0 {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {

--- a/src/timing/formatter/days.rs
+++ b/src/timing/formatter/days.rs
@@ -1,5 +1,5 @@
 use super::{
-    format_padded, TimeFormatter, MINUS, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE,
+    MINUS, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter, format_padded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -43,7 +43,7 @@ impl TimeFormatter<'_> for Days {
 }
 
 impl Display for Inner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let total_seconds = if (total_seconds | nanoseconds as i64) < 0 {

--- a/src/timing/formatter/delta.rs
+++ b/src/timing/formatter/delta.rs
@@ -1,5 +1,5 @@
 use super::{
-    format_padded, Accuracy, TimeFormatter, DASH, MINUS, PLUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE,
+    Accuracy, DASH, MINUS, PLUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter, format_padded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -78,7 +78,7 @@ impl TimeFormatter<'_> for Delta {
 }
 
 impl Display for Inner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let bit_or = total_seconds | nanoseconds as i64;

--- a/src/timing/formatter/none_wrapper.rs
+++ b/src/timing/formatter/none_wrapper.rs
@@ -2,7 +2,7 @@
 //! allows you to create a new Time Formatter by wrapping another one and
 //! changing its behavior when formatting empty times.
 
-use super::{TimeFormatter, DASH};
+use super::{DASH, TimeFormatter};
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
 
@@ -63,7 +63,7 @@ impl<'a, F: 'a + TimeFormatter<'a>, S: 'a + AsRef<str>> TimeFormatter<'a> for No
 }
 
 impl<'a, F: TimeFormatter<'a>, S: 'a + AsRef<str>> Display for Inner<'a, F, S> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if self.time.is_none() {
             self.wrapper.1.as_ref().fmt(f)
         } else {

--- a/src/timing/formatter/regular.rs
+++ b/src/timing/formatter/regular.rs
@@ -1,5 +1,5 @@
 use super::{
-    format_padded, Accuracy, TimeFormatter, DASH, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE,
+    Accuracy, DASH, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter, format_padded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -65,7 +65,7 @@ impl TimeFormatter<'_> for Regular {
 }
 
 impl Display for Inner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {

--- a/src/timing/formatter/segment_time.rs
+++ b/src/timing/formatter/segment_time.rs
@@ -1,5 +1,5 @@
 use super::{
-    format_padded, Accuracy, TimeFormatter, DASH, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE,
+    Accuracy, DASH, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter, format_padded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -66,7 +66,7 @@ impl TimeFormatter<'_> for SegmentTime {
 }
 
 impl Display for Inner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let (total_seconds, nanoseconds) = if (total_seconds | nanoseconds as i64) < 0 {

--- a/src/timing/formatter/timer.rs
+++ b/src/timing/formatter/timer.rs
@@ -3,8 +3,8 @@
 //! is the Time Formatter pair used by the Timer Component.
 
 use super::{
-    format_padded, format_unpadded, Accuracy, DigitsFormat, TimeFormatter, DASH, MINUS,
-    SECONDS_PER_HOUR, SECONDS_PER_MINUTE,
+    Accuracy, DASH, DigitsFormat, MINUS, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, TimeFormatter,
+    format_padded, format_unpadded,
 };
 use crate::TimeSpan;
 use core::fmt::{Display, Formatter, Result};
@@ -67,7 +67,7 @@ impl TimeFormatter<'_> for Time {
 }
 
 impl Display for TimeInner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let (total_seconds, nanoseconds) = time.to_seconds_and_subsec_nanoseconds();
             let total_seconds = if (total_seconds | nanoseconds as i64) < 0 {
@@ -179,7 +179,7 @@ impl TimeFormatter<'_> for Fraction {
 }
 
 impl Display for FractionInner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         if let Some(time) = self.time {
             let nanoseconds = time.to_duration().subsec_nanoseconds().unsigned_abs();
             self.accuracy.format_nanoseconds(nanoseconds).fmt(f)

--- a/src/timing/time_span.rs
+++ b/src/timing/time_span.rs
@@ -1,5 +1,5 @@
 use crate::{
-    platform::{prelude::*, Duration},
+    platform::{Duration, prelude::*},
     util::ascii_char::AsciiChar,
 };
 use core::{
@@ -103,7 +103,6 @@ impl CustomParser for DefaultParser {}
 pub(crate) fn parse_custom<T: CustomParser>(mut text: &str) -> Result<TimeSpan, ParseError> {
     // It's faster to use `strip_prefix` with char literals if it's an ASCII
     // char, otherwise prefer using string literals.
-    #[allow(clippy::single_char_pattern)]
     let negate = if T::ALLOW_NEGATIVE {
         if let Some(remainder) = text.strip_prefix('-').or_else(|| {
             if T::ASCII_ONLY {
@@ -136,13 +135,7 @@ pub(crate) fn parse_custom<T: CustomParser>(mut text: &str) -> Result<TimeSpan, 
     let mut seconds = 0u64;
 
     let mut factor = 1;
-    let max_pieces = const {
-        if T::WITH_DAYS {
-            4
-        } else {
-            3
-        }
-    };
+    let max_pieces = const { if T::WITH_DAYS { 4 } else { 3 } };
     for i in 0.. {
         if i == max_pieces {
             return Err(ParseError::TooManyColons);
@@ -264,7 +257,7 @@ struct TimeSpanVisitor;
 impl Visitor<'_> for TimeSpanVisitor {
     type Value = TimeSpan;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a string containing a time")
     }
 

--- a/src/timing/timer/active_attempt.rs
+++ b/src/timing/timer/active_attempt.rs
@@ -159,7 +159,7 @@ impl ActiveAttempt {
         }
     }
 
-    pub fn current_split_index_overflowing(&self, run: &Run) -> usize {
+    pub const fn current_split_index_overflowing(&self, run: &Run) -> usize {
         match self.state {
             State::NotEnded {
                 current_split_index,

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -136,7 +136,7 @@ impl Timer {
     /// that was in use by the Timer is being returned. Before the Run is
     /// returned, the current attempt is reset and the splits are being updated
     /// depending on the `update_splits` parameter.
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn replace_run(&mut self, mut run: Run, update_splits: bool) -> Result<Run, Run> {
         if run.is_empty() {
             return Err(run);
@@ -157,7 +157,7 @@ impl Timer {
     /// the Run provided contains no segments, it can't be used for timing and
     /// is returned as the Err case of the Result. The Run object in use by the
     /// Timer is dropped by this method.
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn set_run(&mut self, run: Run) -> Result<(), Run> {
         self.replace_run(run, false).map(drop)
     }
@@ -236,7 +236,6 @@ impl Timer {
     /// Returns the current comparison that is being compared against. This may
     /// be a custom comparison or one of the Comparison Generators.
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // FIXME: Can't reason about Deref
     pub fn current_comparison(&self) -> &str {
         &self.current_comparison
     }
@@ -404,12 +403,11 @@ impl Timer {
 
         let last_segment = self.run.segments().last().unwrap();
 
-        if let Some(final_time) = last_segment.split_time()[timing_method] {
-            if last_segment.personal_best_split_time()[timing_method]
+        if let Some(final_time) = last_segment.split_time()[timing_method]
+            && last_segment.personal_best_split_time()[timing_method]
                 .is_none_or(|pb| final_time < pb)
-            {
-                return true;
-            }
+        {
+            return true;
         }
 
         false

--- a/src/util/byte_parsing.rs
+++ b/src/util/byte_parsing.rs
@@ -12,7 +12,7 @@ pub mod big_endian {
     pub struct U16(pub [u8; 2]);
 
     impl fmt::Debug for U16 {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             fmt::Debug::fmt(&self.get(), f)
         }
     }
@@ -33,7 +33,7 @@ pub mod big_endian {
     pub struct U32(pub [u8; 4]);
 
     impl fmt::Debug for U32 {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             fmt::Debug::fmt(&self.get(), f)
         }
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod ascii_char;
 pub(crate) mod ascii_set;
+#[allow(unused)]
 pub(crate) mod byte_parsing;
 pub(crate) mod caseless;
 mod clear_vec;

--- a/src/util/ordered_map.rs
+++ b/src/util/ordered_map.rs
@@ -152,7 +152,7 @@ where
 {
     type Value = Map<V>;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a map")
     }
 

--- a/src/util/populate_string.rs
+++ b/src/util/populate_string.rs
@@ -31,7 +31,7 @@ impl PopulateString for &str {
     // allocate a new buffer instead of forcing it to reallocate, which would
     // mean copying all the bytes of the previous buffer, which we don't care
     // about.
-    #[allow(clippy::assigning_clones)]
+    #[expect(clippy::assigning_clones)]
     fn populate(self, buf: &mut String) {
         if self.len() <= buf.capacity() {
             buf.clear();

--- a/src/util/xml/helper.rs
+++ b/src/util/xml/helper.rs
@@ -21,7 +21,7 @@ pub enum Error {
     ElementNotFound,
 }
 
-pub fn text_parsed<F, T, E>(reader: &mut Reader<'_>, f: F) -> Result<(), E>
+pub fn text_parsed<F, T, E>(reader: &mut Reader, f: F) -> Result<(), E>
 where
     F: FnOnce(T),
     T: str::FromStr,
@@ -52,7 +52,7 @@ where
     text_as_str_err(reader, f)
 }
 
-pub fn text_as_escaped_string_err<F, T, E>(reader: &mut Reader<'_>, f: F) -> Result<T, E>
+pub fn text_as_escaped_string_err<F, T, E>(reader: &mut Reader, f: F) -> Result<T, E>
 where
     F: FnOnce(&str) -> Result<T, E>,
     E: From<Error>,
@@ -103,7 +103,7 @@ where
     }
 }
 
-fn end_tag_immediately<E>(reader: &mut Reader<'_>) -> Result<(), E>
+fn end_tag_immediately<E>(reader: &mut Reader) -> Result<(), E>
 where
     E: From<Error>,
 {
@@ -117,7 +117,7 @@ where
     }
 }
 
-pub fn reencode_children(reader: &mut Reader<'_>, target_buf: &mut String) -> Result<(), Error> {
+pub fn reencode_children(reader: &mut Reader, target_buf: &mut String) -> Result<(), Error> {
     let mut writer = Writer::new_skip_header(target_buf);
     let mut depth = 0usize;
     loop {
@@ -166,7 +166,7 @@ pub fn reencode_children(reader: &mut Reader<'_>, target_buf: &mut String) -> Re
     }
 }
 
-pub fn end_tag<E>(reader: &mut Reader<'_>) -> Result<(), E>
+pub fn end_tag<E>(reader: &mut Reader) -> Result<(), E>
 where
     E: From<Error>,
 {
@@ -188,9 +188,9 @@ where
     }
 }
 
-pub fn single_child<F, T, E>(reader: &mut Reader<'_>, tag: &str, mut f: F) -> Result<T, E>
+pub fn single_child<F, T, E>(reader: &mut Reader, tag: &str, mut f: F) -> Result<T, E>
 where
-    F: FnMut(&mut Reader<'_>, Attributes<'_>) -> Result<T, E>,
+    F: FnMut(&mut Reader, Attributes) -> Result<T, E>,
     E: From<Error>,
 {
     let mut val = None;
@@ -205,9 +205,9 @@ where
     val.ok_or(Error::ElementNotFound.into())
 }
 
-pub fn parse_children<F, E>(reader: &mut Reader<'_>, mut f: F) -> Result<(), E>
+pub fn parse_children<F, E>(reader: &mut Reader, mut f: F) -> Result<(), E>
 where
-    F: FnMut(&mut Reader<'_>, TagName<'_>, Attributes<'_>) -> Result<(), E>,
+    F: FnMut(&mut Reader, TagName, Attributes) -> Result<(), E>,
     E: From<Error>,
 {
     loop {
@@ -223,9 +223,9 @@ where
     }
 }
 
-pub fn parse_base<F, E>(reader: &mut Reader<'_>, tag: &str, mut f: F) -> Result<(), E>
+pub fn parse_base<F, E>(reader: &mut Reader, tag: &str, mut f: F) -> Result<(), E>
 where
-    F: FnMut(&mut Reader<'_>, Attributes<'_>) -> Result<(), E>,
+    F: FnMut(&mut Reader, Attributes) -> Result<(), E>,
     E: From<Error>,
 {
     loop {
@@ -258,7 +258,7 @@ where
 }
 
 pub fn optional_attribute_escaped_err<F, E>(
-    attributes: Attributes<'_>,
+    attributes: Attributes,
     key: &str,
     mut f: F,
 ) -> Result<(), E>
@@ -276,7 +276,7 @@ where
     })
 }
 
-pub fn attribute_escaped_err<F, E>(attributes: Attributes<'_>, key: &str, mut f: F) -> Result<(), E>
+pub fn attribute_escaped_err<F, E>(attributes: Attributes, key: &str, mut f: F) -> Result<(), E>
 where
     F: FnMut(&str) -> Result<(), E>,
     E: From<Error>,
@@ -331,11 +331,7 @@ where
     })
 }
 
-pub fn image<F, E>(
-    reader: &mut Reader<'_>,
-    image_buf: &mut Vec<MaybeUninit<u8>>,
-    f: F,
-) -> Result<(), E>
+pub fn image<F, E>(reader: &mut Reader, image_buf: &mut Vec<MaybeUninit<u8>>, f: F) -> Result<(), E>
 where
     F: FnOnce(&[u8]),
     E: From<Error>,

--- a/src/util/xml/mod.rs
+++ b/src/util/xml/mod.rs
@@ -11,7 +11,7 @@ mod writer;
 
 pub use self::{
     reader::{Event, Reader},
-    writer::{AttributeWriter, DisplayAlreadyEscaped, Value, Writer, NO_ATTRIBUTES},
+    writer::{AttributeWriter, DisplayAlreadyEscaped, NO_ATTRIBUTES, Value, Writer},
 };
 
 use super::{ascii_char::AsciiChar, ascii_set::AsciiSet};
@@ -20,7 +20,7 @@ use super::{ascii_char::AsciiChar, ascii_set::AsciiSet};
 pub struct Tag<'a>(&'a str);
 
 impl Debug for Tag<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("<")?;
         Display::fmt(self.0, f)?;
         f.write_str(" />")
@@ -46,7 +46,7 @@ impl<'a> TagName<'a> {
 }
 
 impl Debug for TagName<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("<")?;
         Display::fmt(self.0, f)?;
         f.write_str("/>")
@@ -95,13 +95,13 @@ impl<'a> Attributes<'a> {
 pub struct Text<'a>(&'a str);
 
 impl Display for Text<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.try_unescape_with_fn(|chunk| Display::fmt(chunk, f))
     }
 }
 
 impl Debug for Text<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(self.0, f)
     }
 }

--- a/src/util/xml/writer.rs
+++ b/src/util/xml/writer.rs
@@ -22,7 +22,7 @@ impl<T: fmt::Write> Writer<T> {
         text.write_escaped(&mut self.sink)
     }
 
-    pub fn tag<O, E: From<fmt::Error>, F: FnOnce(AttributeWriter<'_, T>) -> Result<O, E>>(
+    pub fn tag<O, E: From<fmt::Error>, F: FnOnce(AttributeWriter<T>) -> Result<O, E>>(
         &mut self,
         tag: &str,
         f: F,
@@ -112,7 +112,7 @@ impl<T: fmt::Write> Writer<T> {
     pub fn just_start_tag<
         O,
         E: From<fmt::Error>,
-        F: FnOnce(&mut AttributeWriter<'_, T>) -> Result<O, E>,
+        F: FnOnce(&mut AttributeWriter<T>) -> Result<O, E>,
     >(
         &mut self,
         tag: &str,

--- a/tests/layout_parsing.rs
+++ b/tests/layout_parsing.rs
@@ -81,17 +81,20 @@ mod parse {
                 panic!("expected Text::Variable");
             };
             assert_eq!(variable_name, "hits");
-            assert_eq!(is_split, true);
+            assert!(is_split);
         }
         {
             let text::Text::Variable(ref variable_name, is_split) = texts[1].settings().text else {
                 panic!("expected Text::Variable");
             };
             assert_eq!(variable_name, "pb hits");
-            assert_eq!(is_split, true);
+            assert!(is_split);
         }
         let l1 = ls1l(layout_files::CUSTOM_VARIABLE_LS1L);
-        assert_eq!(serde_json::to_string(&l.settings()).ok(), serde_json::to_string(&l1.settings()).ok());
+        assert_eq!(
+            serde_json::to_string(&l.settings()).ok(),
+            serde_json::to_string(&l1.settings()).ok()
+        );
     }
 
     #[test]
@@ -132,17 +135,20 @@ mod parse {
                 panic!("expected Text::Variable");
             };
             assert_eq!(variable_name, "hits");
-            assert_eq!(is_split, true);
+            assert!(is_split);
         }
         {
             let text::Text::Variable(ref variable_name, is_split) = texts[1].settings().text else {
                 panic!("expected Text::Variable");
             };
             assert_eq!(variable_name, "pb hits");
-            assert_eq!(is_split, true);
+            assert!(is_split);
         }
         let l1 = ls1l(layout_files::CUSTOM_VARIABLE_LS1L);
-        assert_eq!(serde_json::to_string(&l.settings()).ok(), serde_json::to_string(&l1.settings()).ok());
+        assert_eq!(
+            serde_json::to_string(&l.settings()).ok(),
+            serde_json::to_string(&l1.settings()).ok()
+        );
     }
 
     #[test]

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -72,8 +72,8 @@ fn font_fallback() {
     let build_number: u64 = build_number.parse().unwrap();
     let revision: u32 = cur_ver.get_value("UBR").unwrap();
 
-    if (build_number, revision) < (26100, 2605) {
-        // The hash is different before Windows 11 24H2.
+    if (build_number, revision) < (26100, 5074) {
+        // The hash is different before that Windows 11 version.
         println!(
             "Skipping font fallback test on Windows with build number {build_number}.{revision}.",
         );
@@ -171,8 +171,8 @@ fn font_fallback() {
         &state,
         &image_cache,
         [320, 750],
-        "d21ee9034ca0baed",
-        "e339132ee6cf8e94",
+        "80a81fbbfbb53fa3",
+        "a72544f5514c086b",
         "font_fallback",
     );
 }
@@ -362,7 +362,7 @@ fn background_image() {
         &layout.state(&mut image_cache, &timer.snapshot()),
         &image_cache,
         [300, 300],
-        "ffcfc4aa51a13d69",
+        "84ec75e9cb50bab5",
         "721485d08ac431f5",
         "background_image",
     );


### PR DESCRIPTION
- Replaced nested if / if let with let chains.
- With the new lifetime warning rules, it became possible to remove some unnecessary explicit `'_` lifetimes.
- Resolved some clippy lints (mostly missing const fns).
- Switched `#[allow]` to `#[expect]` for most lints. This should catch situations where the warning no longer applies. It already caught a few of those.
- Updated test snapshot hashes that seem to have changed again (the fonts on Windows got updated).