### PR TITLE
Support 'Option' key alias for Alt on MacOS

### DIFF
--- a/crates/livesplit-hotkey/src/modifiers.rs
+++ b/crates/livesplit-hotkey/src/modifiers.rs
@@ -57,6 +57,8 @@ impl FromStr for Modifiers {
             match modifier {
                 "Ctrl" => modifiers.insert(Modifiers::CONTROL),
                 "Alt" => modifiers.insert(Modifiers::ALT),
+                /// Option as alias for Alt used on MacOS
+                "Option" => modifiers.insert(Modifiers::ALT),
                 "Meta" => modifiers.insert(Modifiers::META),
                 "Shift" => modifiers.insert(Modifiers::SHIFT),
                 _ => return Err(()),


### PR DESCRIPTION
Add support for 'Option' as an alias for 'Alt' on MacOS.