### PR TITLE
Add Hints to Settings Fields

### DIFF
--- a/benches/layout_state.rs
+++ b/benches/layout_state.rs
@@ -22,7 +22,11 @@ fn artificial() -> (Timer, Layout, ImageCache) {
     let mut timer = Timer::new(run).unwrap();
     timer.start().unwrap();
 
-    (timer, Layout::default_layout(), ImageCache::new())
+    (
+        timer,
+        Layout::default_layout(Lang::English),
+        ImageCache::new(),
+    )
 }
 
 fn real() -> (Timer, Layout, ImageCache) {
@@ -32,7 +36,11 @@ fn real() -> (Timer, Layout, ImageCache) {
     let mut timer = Timer::new(run).unwrap();
     timer.start().unwrap();
 
-    (timer, Layout::default_layout(), ImageCache::new())
+    (
+        timer,
+        Layout::default_layout(Lang::English),
+        ImageCache::new(),
+    )
 }
 
 fn no_reuse_real(c: &mut Criterion) {

--- a/benches/scene_management.rs
+++ b/benches/scene_management.rs
@@ -87,7 +87,7 @@ cfg_if::cfg_if! {
             run.set_category_name("Some Category Name");
             run.set_attempt_count(1337);
             let mut timer = Timer::new(run).unwrap();
-            let mut layout = Layout::default_layout();
+            let mut layout = Layout::default_layout(Lang::English);
             let mut image_cache = ImageCache::new();
 
             start_run(&mut timer);

--- a/benches/software_rendering.rs
+++ b/benches/software_rendering.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
             run.set_category_name("Some Category Name");
             run.set_attempt_count(1337);
             let mut timer = Timer::new(run).unwrap();
-            let mut layout = Layout::default_layout();
+            let mut layout = Layout::default_layout(Lang::English);
             let mut image_cache = ImageCache::new();
 
             start_run(&mut timer);

--- a/benches/svg_rendering.rs
+++ b/benches/svg_rendering.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
             run.set_category_name("Some Category Name");
             run.set_attempt_count(1337);
             let mut timer = Timer::new(run).unwrap();
-            let mut layout = Layout::default_layout();
+            let mut layout = Layout::default_layout(Lang::English);
             let mut image_cache = ImageCache::new();
 
             start_run(&mut timer);

--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -727,6 +727,8 @@ export interface SettingsDescriptionFieldJson {
     text: string,
     /** The tooltip to show for the setting. */
     tooltip: string,
+    /** An optional hint about how to display the setting. */
+    hint?: "Comparison" | "CustomVariable",
     /** The current value of the setting. */
     value: SettingsDescriptionValueJson,
 }

--- a/capi/src/layout.rs
+++ b/capi/src/layout.rs
@@ -26,8 +26,8 @@ pub extern "C" fn Layout_new() -> OwnedLayout {
 /// are provided by this and how they are configured may change in the
 /// future.
 #[unsafe(no_mangle)]
-pub extern "C" fn Layout_default_layout() -> OwnedLayout {
-    Box::new(Layout::default_layout())
+pub extern "C" fn Layout_default_layout(lang: Lang) -> OwnedLayout {
+    Box::new(Layout::default_layout(lang))
 }
 
 /// drop

--- a/capi/src/splits_component.rs
+++ b/capi/src/splits_component.rs
@@ -16,8 +16,8 @@ pub type OwnedSplitsComponent = Box<SplitsComponent>;
 
 /// Creates a new Splits Component.
 #[unsafe(no_mangle)]
-pub extern "C" fn SplitsComponent_new() -> OwnedSplitsComponent {
-    Box::new(SplitsComponent::new())
+pub extern "C" fn SplitsComponent_new(lang: Lang) -> OwnedSplitsComponent {
+    Box::new(SplitsComponent::new(lang))
 }
 
 /// drop

--- a/capi/src/title_component.rs
+++ b/capi/src/title_component.rs
@@ -4,7 +4,9 @@
 
 use super::{Json, output_vec};
 use crate::{component::OwnedComponent, title_component_state::OwnedTitleComponentState};
-use livesplit_core::{Timer, component::title::Component as TitleComponent, settings::ImageCache};
+use livesplit_core::{
+    Lang, Timer, component::title::Component as TitleComponent, settings::ImageCache,
+};
 
 /// type
 pub type OwnedTitleComponent = Box<TitleComponent>;
@@ -34,9 +36,10 @@ pub extern "C" fn TitleComponent_state_as_json(
     this: &mut TitleComponent,
     image_cache: &mut ImageCache,
     timer: &Timer,
+    lang: Lang,
 ) -> Json {
     output_vec(|o| {
-        this.state(image_cache, timer).write_json(o).unwrap();
+        this.state(image_cache, timer, lang).write_json(o).unwrap();
     })
 }
 
@@ -46,6 +49,7 @@ pub extern "C" fn TitleComponent_state(
     this: &mut TitleComponent,
     image_cache: &mut ImageCache,
     timer: &Timer,
+    lang: Lang,
 ) -> OwnedTitleComponentState {
-    Box::new(this.state(image_cache, timer))
+    Box::new(this.state(image_cache, timer, lang))
 }

--- a/src/component/current_pace.rs
+++ b/src/component/current_pace.rs
@@ -10,7 +10,7 @@ use crate::{
     comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SettingsDescription, Value},
     timing::{
         Snapshot,
         formatter::{Accuracy, Regular, TimeFormatter},
@@ -208,7 +208,8 @@ impl Component {
                 Text::CurrentPaceComparison.resolve(lang).into(),
                 Text::CurrentPaceComparisonDescription.resolve(lang).into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::CurrentPaceDisplayTwoRows.resolve(lang).into(),
                 Text::CurrentPaceDisplayTwoRowsDescription

--- a/src/component/delta/mod.rs
+++ b/src/component/delta/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SemanticColor, SettingsDescription, Value},
     timing::{
         Snapshot,
         formatter::{Accuracy, Delta, TimeFormatter},
@@ -184,7 +184,8 @@ impl Component {
                 Text::DeltaComparison.resolve(lang).into(),
                 Text::DeltaComparisonDescription.resolve(lang).into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::DeltaDisplayTwoRows.resolve(lang).into(),
                 Text::DeltaDisplayTwoRowsDescription.resolve(lang).into(),

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -11,7 +11,9 @@ use crate::{
     comparison::{self, best_segments, none},
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, Image, ImageCache, ImageId, SettingsDescription, Value},
+    settings::{
+        Color, Field, FieldHint, Gradient, Image, ImageCache, ImageId, SettingsDescription, Value,
+    },
     timing::{
         Snapshot,
         formatter::{Accuracy, DigitsFormat, SegmentTime, TimeFormatter},
@@ -380,14 +382,16 @@ impl Component {
                     .resolve(lang)
                     .into(),
                 self.settings.comparison1.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::DetailedTimerComparison2.resolve(lang).into(),
                 Text::DetailedTimerComparison2Description
                     .resolve(lang)
                     .into(),
                 self.settings.comparison2.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::DetailedTimerHideSecondComparison.resolve(lang).into(),
                 Text::DetailedTimerHideSecondComparisonDescription

--- a/src/component/graph.rs
+++ b/src/component/graph.rs
@@ -14,7 +14,7 @@ use crate::{
     GeneralLayoutSettings, TimeSpan, Timer, TimerPhase, analysis, comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, SettingsDescription, Value},
     timing::Snapshot,
 };
 use alloc::borrow::Cow;
@@ -287,7 +287,8 @@ impl Component {
                 Text::GraphComparison.resolve(lang).into(),
                 Text::GraphComparisonDescription.resolve(lang).into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::GraphHeight.resolve(lang).into(),
                 Text::GraphHeightDescription.resolve(lang).into(),

--- a/src/component/possible_time_save.rs
+++ b/src/component/possible_time_save.rs
@@ -11,7 +11,7 @@ use crate::{
     comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SettingsDescription, Value},
     timing::{
         Snapshot,
         formatter::{Accuracy, SegmentTime, TimeFormatter},
@@ -192,7 +192,8 @@ impl Component {
                     .resolve(lang)
                     .into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::PossibleTimeSaveDisplayTwoRows.resolve(lang).into(),
                 Text::PossibleTimeSaveDisplayTwoRowsDescription

--- a/src/component/previous_segment.rs
+++ b/src/component/previous_segment.rs
@@ -11,7 +11,7 @@ use crate::{
     GeneralLayoutSettings, TimerPhase, analysis, comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SemanticColor, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SemanticColor, SettingsDescription, Value},
     timing::{
         Snapshot,
         formatter::{Accuracy, Delta, SegmentTime, TimeFormatter},
@@ -290,7 +290,8 @@ impl Component {
                     .resolve(lang)
                     .into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::PreviousSegmentDisplayTwoRows.resolve(lang).into(),
                 Text::PreviousSegmentDisplayTwoRowsDescription

--- a/src/component/segment_time/mod.rs
+++ b/src/component/segment_time/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     comparison,
     localization::{Lang, Text},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SettingsDescription, Value},
     timing::formatter::{Accuracy, SegmentTime, TimeFormatter},
 };
 use alloc::borrow::Cow;
@@ -233,7 +233,8 @@ impl Component {
                 Text::SegmentTimeComparison.resolve(lang).into(),
                 Text::SegmentTimeComparisonDescription.resolve(lang).into(),
                 self.settings.comparison_override.clone().into(),
-            ),
+            )
+            .with_hint(FieldHint::Comparison),
             Field::new(
                 Text::SegmentTimeDisplayTwoRows.resolve(lang).into(),
                 Text::SegmentTimeDisplayTwoRowsDescription

--- a/src/component/splits/tests/column.rs
+++ b/src/component/splits/tests/column.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     Lang, Run, Segment, TimeSpan, Timer,
-    component::splits::{ColumnKind, TimeColumn},
+    component::splits::{ColumnKind, TimeColumn, english_settings},
     settings::{
         ImageCache,
         SemanticColor::{
@@ -502,7 +502,7 @@ fn check_columns(
             ..Default::default()
         }],
         fill_with_blank_space: false,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();
@@ -1132,7 +1132,7 @@ fn check_columns_update_trigger(
             ..Default::default()
         }],
         fill_with_blank_space: false,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();
@@ -1254,7 +1254,7 @@ fn column_delta_best_segment_colors() {
             ..Default::default()
         }],
         fill_with_blank_space: false,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();
@@ -1396,7 +1396,7 @@ fn delta_or_split_time() {
             ..Default::default()
         }],
         fill_with_blank_space: false,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();

--- a/src/component/splits/tests/mod.rs
+++ b/src/component/splits/tests/mod.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     Lang, Run, Segment, TimeSpan, Timer, TimingMethod,
-    component::splits::{ColumnKind, TimeColumn},
+    component::splits::{ColumnKind, TimeColumn, english_settings},
     settings::ImageCache,
 };
 
@@ -20,7 +20,7 @@ fn zero_visual_split_count_always_shows_all_splits() {
     let layout_settings = Default::default();
     let mut component = Component::with_settings(Settings {
         visual_split_count: 0,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();
@@ -75,7 +75,7 @@ fn one_visual_split() {
         always_show_last_split: false,
         split_preview_count: 0,
         visual_split_count: 1,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();
@@ -146,7 +146,7 @@ fn negative_segment_times() {
             }),
             ..Default::default()
         }],
-        ..Default::default()
+        ..english_settings()
     });
 
     timer.start().unwrap();
@@ -179,7 +179,7 @@ fn unique_split_indices() {
     let mut component = Component::with_settings(Settings {
         visual_split_count: 20,
         fill_with_blank_space: true,
-        ..Default::default()
+        ..english_settings()
     });
 
     let mut image_cache = ImageCache::new();

--- a/src/component/text/mod.rs
+++ b/src/component/text/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     Timer,
     localization::{Lang, Text as LText},
     platform::prelude::*,
-    settings::{Color, Field, Gradient, SettingsDescription, Value},
+    settings::{Color, Field, FieldHint, Gradient, SettingsDescription, Value},
     timing::formatter,
     util::PopulateString,
 };
@@ -321,7 +321,8 @@ impl Component {
                     LText::TextComponentVariable.resolve(lang).into(),
                     LText::TextComponentVariableDescription.resolve(lang).into(),
                     var_name.to_string().into(),
-                ),
+                )
+                .with_hint(FieldHint::CustomVariable),
                 None,
                 true,
                 *is_split,

--- a/src/component/title/mod.rs
+++ b/src/component/title/mod.rs
@@ -167,7 +167,13 @@ impl Component {
     /// state. The images are marked as visited in the [`ImageCache`]. You still
     /// need to manually run [`ImageCache::collect`] to ensure unused images are
     /// removed from the cache.
-    pub fn update_state(&self, state: &mut State, image_cache: &mut ImageCache, timer: &Timer) {
+    pub fn update_state(
+        &self,
+        state: &mut State,
+        image_cache: &mut ImageCache,
+        timer: &Timer,
+        lang: Lang,
+    ) {
         let run = timer.run();
 
         let finished_runs = if self.settings.show_finished_runs_count {
@@ -328,7 +334,7 @@ impl Component {
             }
             (false, false) => {
                 state.line1.clear();
-                state.line1.push("Untitled".into());
+                state.line1.push(Text::Untitled.resolve(lang).into());
                 state.line2.clear();
             }
         }
@@ -345,9 +351,9 @@ impl Component {
     /// state. The images are marked as visited in the [`ImageCache`]. You still
     /// need to manually run [`ImageCache::collect`] to ensure unused images are
     /// removed from the cache.
-    pub fn state(&self, image_cache: &mut ImageCache, timer: &Timer) -> State {
+    pub fn state(&self, image_cache: &mut ImageCache, timer: &Timer, lang: Lang) -> State {
         let mut state = Default::default();
-        self.update_state(&mut state, image_cache, timer);
+        self.update_state(&mut state, image_cache, timer, lang);
         state
     }
 

--- a/src/component/title/tests.rs
+++ b/src/component/title/tests.rs
@@ -1,5 +1,5 @@
 use super::{Component, Settings};
-use crate::{Run, Segment, Timer, settings::ImageCache};
+use crate::{Lang, Run, Segment, Timer, settings::ImageCache};
 
 #[test]
 fn finished_runs_and_attempt_count() {
@@ -16,29 +16,57 @@ fn finished_runs_and_attempt_count() {
     let mut image_cache = ImageCache::new();
 
     assert_eq!(
-        component.state(&mut image_cache, &timer).finished_runs,
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .finished_runs,
         Some(0)
     );
-    assert_eq!(component.state(&mut image_cache, &timer).attempts, Some(0));
+    assert_eq!(
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .attempts,
+        Some(0)
+    );
 
     timer.start().unwrap();
     assert_eq!(
-        component.state(&mut image_cache, &timer).finished_runs,
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .finished_runs,
         Some(0)
     );
-    assert_eq!(component.state(&mut image_cache, &timer).attempts, Some(1));
+    assert_eq!(
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .attempts,
+        Some(1)
+    );
 
     timer.split().unwrap();
     assert_eq!(
-        component.state(&mut image_cache, &timer).finished_runs,
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .finished_runs,
         Some(1)
     );
-    assert_eq!(component.state(&mut image_cache, &timer).attempts, Some(1));
+    assert_eq!(
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .attempts,
+        Some(1)
+    );
 
     timer.reset(true).unwrap();
     assert_eq!(
-        component.state(&mut image_cache, &timer).finished_runs,
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .finished_runs,
         Some(1)
     );
-    assert_eq!(component.state(&mut image_cache, &timer).attempts, Some(1));
+    assert_eq!(
+        component
+            .state(&mut image_cache, &timer, Lang::English)
+            .attempts,
+        Some(1)
+    );
 }

--- a/src/layout/component.rs
+++ b/src/layout/component.rs
@@ -217,7 +217,7 @@ impl Component {
                 component.update_state(state, timer, layout_settings, lang)
             }
             (ComponentState::Title(state), Component::Title(component)) => {
-                component.update_state(state, image_cache, timer)
+                component.update_state(state, image_cache, timer, lang)
             }
             (ComponentState::KeyValue(state), Component::TotalPlaytime(component)) => {
                 component.update_state(state, timer, lang)
@@ -284,7 +284,7 @@ impl Component {
                 ComponentState::Timer(component.state(timer, layout_settings, lang))
             }
             Component::Title(component) => {
-                ComponentState::Title(component.state(image_cache, timer))
+                ComponentState::Title(component.state(image_cache, timer, lang))
             }
             Component::TotalPlaytime(component) => {
                 ComponentState::KeyValue(component.state(timer, lang))

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -45,11 +45,11 @@ impl Layout {
     /// in order to provide a good default layout for runners. Which components
     /// are provided by this and how they are configured may change in the
     /// future.
-    pub fn default_layout() -> Self {
+    pub fn default_layout(lang: Lang) -> Self {
         Self {
             components: vec![
                 title::Component::new().into(),
-                splits::Component::new().into(),
+                splits::Component::new(lang).into(),
                 timer::Component::new().into(),
                 previous_segment::Component::new().into(),
             ],

--- a/src/layout/parser/mod.rs
+++ b/src/layout/parser/mod.rs
@@ -2,6 +2,7 @@
 
 use super::{Component, Layout, LayoutDirection};
 use crate::{
+    Lang,
     component::{separator, timer::DeltaGradient},
     platform::{math::f32::stable_powf, prelude::*},
     settings::{
@@ -650,7 +651,7 @@ where
                     "LiveSplit.PreviousSegment.dll" => previous_segment::Component::new().into(),
                     "" => separator::Component::new().into(),
                     "LiveSplit.Splits.dll" | "LiveSplit.Subsplits.dll" => {
-                        splits::Component::new().into()
+                        splits::Component::new(Lang::English).into()
                     }
                     "LiveSplit.SumOfBest.dll" => sum_of_best::Component::new().into(),
                     "LiveSplit.Text.dll" => text::Component::new().into(),

--- a/src/localization/brazilian_portuguese.rs
+++ b/src/localization/brazilian_portuguese.rs
@@ -635,11 +635,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Últ. t. seg.",
         Text::LatestSegmentShort => "Último segmento",
         Text::SegmentTimeShort => "T. seg.",
+        Text::SplitTime => "Tempo",
         Text::PossibleTimeSaveShort => "Tempo possível a poupar",
         Text::PossibleTimeSaveAbbreviation => "T. poss. a poupar",
         Text::TimeSaveShort => "Tempo a poupar",
         Text::RealTime => "Tempo real",
         Text::GameTime => "Tempo de jogo",
+        Text::Untitled => "Sem título",
         Text::SumOfBestCleanerStartOfRun => "o início da corrida",
         Text::SumOfBestCleanerShouldRemove => {
             ". Você acha que este tempo de segmento é impreciso e deve ser removido?"

--- a/src/localization/chinese_simplified.rs
+++ b/src/localization/chinese_simplified.rs
@@ -473,11 +473,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "最新分段时间",
         Text::LatestSegmentShort => "最新分段",
         Text::SegmentTimeShort => "分段时间",
+        Text::SplitTime => "分段时间",
         Text::PossibleTimeSaveShort => "可节省时间",
         Text::PossibleTimeSaveAbbreviation => "可节省",
         Text::TimeSaveShort => "节省时间",
         Text::RealTime => "实时时间",
         Text::GameTime => "游戏时间",
+        Text::Untitled => "未命名",
         Text::SumOfBestCleanerStartOfRun => "本次跑开始",
         Text::SumOfBestCleanerShouldRemove => "你觉得这个分段时间不准确、需要删除吗？",
     }

--- a/src/localization/chinese_traditional.rs
+++ b/src/localization/chinese_traditional.rs
@@ -78,6 +78,7 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::BlankSpaceBackgroundDescription => "空白元件背景。",
         Text::BlankSpaceSize => "空白大小",
         Text::BlankSpaceSizeDescription => "空白元件大小。",
+        Text::SplitTime => "分段時間",
         _ => super::chinese_simplified::resolve(text),
     }
 }

--- a/src/localization/dutch.rs
+++ b/src/localization/dutch.rs
@@ -641,11 +641,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Laatste seg. tijd",
         Text::LatestSegmentShort => "Laatste segment",
         Text::SegmentTimeShort => "Seg. tijd",
+        Text::SplitTime => "Tijd",
         Text::PossibleTimeSaveShort => "Mogelijke tijdswinst",
         Text::PossibleTimeSaveAbbreviation => "Mogl. tijdswinst",
         Text::TimeSaveShort => "Tijdswinst",
         Text::RealTime => "Echte tijd",
         Text::GameTime => "Speltijd",
+        Text::Untitled => "Naamloos",
         Text::SumOfBestCleanerStartOfRun => "het begin van de run",
         Text::SumOfBestCleanerShouldRemove => {
             ". Denk je dat deze segmenttijd onnauwkeurig is en verwijderd moet worden?"

--- a/src/localization/english.rs
+++ b/src/localization/english.rs
@@ -633,11 +633,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Latest Seg. Time",
         Text::LatestSegmentShort => "Latest Segment",
         Text::SegmentTimeShort => "Seg. Time",
+        Text::SplitTime => "Time",
         Text::PossibleTimeSaveShort => "Possible Time Save",
         Text::PossibleTimeSaveAbbreviation => "Poss. Time Save",
         Text::TimeSaveShort => "Time Save",
         Text::RealTime => "Real Time",
         Text::GameTime => "Game Time",
+        Text::Untitled => "Untitled",
         Text::SumOfBestCleanerStartOfRun => "the start of the run",
         Text::SumOfBestCleanerShouldRemove => {
             ". Do you think that this segment time is inaccurate and should be removed?"

--- a/src/localization/french.rs
+++ b/src/localization/french.rs
@@ -651,11 +651,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Dern. tps seg.",
         Text::LatestSegmentShort => "Dernier segment",
         Text::SegmentTimeShort => "Tps seg.",
+        Text::SplitTime => "Temps",
         Text::PossibleTimeSaveShort => "Temps potentiellement gagné",
         Text::PossibleTimeSaveAbbreviation => "Tps pot. gagné",
         Text::TimeSaveShort => "Temps gagné",
         Text::RealTime => "Temps réel",
         Text::GameTime => "Temps de jeu",
+        Text::Untitled => "Sans titre",
         Text::SumOfBestCleanerStartOfRun => "le début du run",
         Text::SumOfBestCleanerShouldRemove => {
             ". Pensez-vous que ce temps de segment est inexact et devrait être supprimé ?"

--- a/src/localization/german.rs
+++ b/src/localization/german.rs
@@ -669,11 +669,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Letzte Seg.-Zeit",
         Text::LatestSegmentShort => "Letztes Segment",
         Text::SegmentTimeShort => "Seg.-Zeit",
+        Text::SplitTime => "Zeit",
         Text::PossibleTimeSaveShort => "Mögliche Zeitersparnis",
         Text::PossibleTimeSaveAbbreviation => "Mögl. Zeitersp.",
         Text::TimeSaveShort => "Zeitersparnis",
         Text::RealTime => "Echtzeit",
         Text::GameTime => "Spielzeit",
+        Text::Untitled => "Unbenannt",
         Text::SumOfBestCleanerStartOfRun => "dem Start des Runs",
         Text::SumOfBestCleanerShouldRemove => {
             ". Glaubst du, dass diese Segmentzeit ungenau ist und entfernt werden sollte?"

--- a/src/localization/italian.rs
+++ b/src/localization/italian.rs
@@ -4,33 +4,39 @@ pub const fn resolve(text: Text) -> &'static str {
     match text {
         Text::StartSplit => "Avvia / Split",
         Text::StartSplitDescription => {
-            "Il tasto rapido da usare per splittare e avviare un nuovo tentativo."
+            "Il tasto ad azione rapida da usare per splittare e avviare un nuovo tentativo."
         }
         Text::Reset => "Reimposta",
-        Text::ResetDescription => "Il tasto rapido da usare per reimpostare il tentativo corrente.",
+        Text::ResetDescription => {
+            "Il tasto ad azione rapida da usare per reimpostare il tentativo corrente."
+        }
         Text::UndoSplit => "Annulla split",
-        Text::UndoSplitDescription => "Il tasto rapido da usare per annullare l’ultimo split.",
+        Text::UndoSplitDescription => {
+            "Il tasto ad azione rapida da usare per annullare l’ultimo split."
+        }
         Text::SkipSplit => "Salta split",
-        Text::SkipSplitDescription => "Il tasto rapido da usare per saltare lo split corrente.",
+        Text::SkipSplitDescription => {
+            "Il tasto ad azione rapida da usare per saltare lo split corrente."
+        }
         Text::Pause => "Pausa",
         Text::PauseDescription => {
-            "Il tasto rapido da usare per mettere in pausa il tentativo corrente. Può anche essere usato per avviare un nuovo tentativo."
+            "Il tasto ad azione rapida da usare per mettere in pausa il tentativo corrente. Può anche essere usato per avviare un nuovo tentativo."
         }
         Text::UndoAllPauses => "Annulla tutte le pause",
         Text::UndoAllPausesDescription => {
-            "Il tasto rapido da usare per rimuovere tutti i tempi di pausa dal tempo corrente. Utile se hai messo in pausa per errore."
+            "Il tasto ad azione rapida da usare per rimuovere tutti i tempi di pausa dal tempo corrente. Utile se hai messo in pausa per errore."
         }
         Text::PreviousComparison => "Confronto precedente",
         Text::PreviousComparisonDescription => {
-            "Il tasto rapido da usare per passare al confronto precedente."
+            "Il tasto ad azione rapida da usare per passare al confronto precedente."
         }
         Text::NextComparison => "Confronto successivo",
         Text::NextComparisonDescription => {
-            "Il tasto rapido da usare per passare al confronto successivo."
+            "Il tasto ad azione rapida da usare per passare al confronto successivo."
         }
         Text::ToggleTimingMethod => "Cambia metodo di cronometraggio",
         Text::ToggleTimingMethodDescription => {
-            "Il tasto rapido da usare per alternare tra «Tempo reale» e «Tempo di gioco»."
+            "Il tasto ad azione rapida da usare per alternare tra «Tempo reale» e «Tempo di gioco»."
         }
         Text::TimerBackground => "Sfondo",
         Text::TimerBackgroundDescription => {
@@ -633,11 +639,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Ult. t. seg.",
         Text::LatestSegmentShort => "Ultimo segmento",
         Text::SegmentTimeShort => "T. seg.",
+        Text::SplitTime => "Tempo",
         Text::PossibleTimeSaveShort => "Tempo possibile da risparmiare",
         Text::PossibleTimeSaveAbbreviation => "T. poss. da risp.",
         Text::TimeSaveShort => "Tempo da risp.",
         Text::RealTime => "Tempo reale",
         Text::GameTime => "Tempo di gioco",
+        Text::Untitled => "Senza titolo",
         Text::SumOfBestCleanerStartOfRun => "l'inizio della run",
         Text::SumOfBestCleanerShouldRemove => {
             ". Pensi che questo tempo di segmento sia impreciso e debba essere rimosso?"

--- a/src/localization/japanese.rs
+++ b/src/localization/japanese.rs
@@ -575,11 +575,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "最新セグ時間",
         Text::LatestSegmentShort => "最新セグ",
         Text::SegmentTimeShort => "セグ時間",
+        Text::SplitTime => "時間",
         Text::PossibleTimeSaveShort => "短縮可能時間",
         Text::PossibleTimeSaveAbbreviation => "短縮可能",
         Text::TimeSaveShort => "短縮",
         Text::RealTime => "リアルタイム",
         Text::GameTime => "ゲームタイム",
+        Text::Untitled => "無題",
         Text::SumOfBestCleanerStartOfRun => "ラン開始",
         Text::SumOfBestCleanerShouldRemove => {
             " この区間タイムは不正確だと思いますか？ もしそうなら、削除したほうがいいでしょうか？"

--- a/src/localization/korean.rs
+++ b/src/localization/korean.rs
@@ -583,11 +583,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "최신 세그 시간",
         Text::LatestSegmentShort => "최신 세그먼트",
         Text::SegmentTimeShort => "세그 시간",
+        Text::SplitTime => "시간",
         Text::PossibleTimeSaveShort => "절약 가능 시간",
         Text::PossibleTimeSaveAbbreviation => "절약 가능",
         Text::TimeSaveShort => "절약",
         Text::RealTime => "실시간",
         Text::GameTime => "게임 시간",
+        Text::Untitled => "제목 없음",
         Text::SumOfBestCleanerStartOfRun => "런 시작",
         Text::SumOfBestCleanerShouldRemove => {
             " 이 세그먼트 시간이 부정확하다고 보시나요? 그렇다면 삭제하는 게 좋을까요?"

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -982,11 +982,13 @@ pub(crate) enum Text {
     LatestSegmentTimeShort,
     LatestSegmentShort,
     SegmentTimeShort,
+    SplitTime,
     PossibleTimeSaveShort,
     PossibleTimeSaveAbbreviation,
     TimeSaveShort,
     RealTime,
     GameTime,
+    Untitled,
     SumOfBestCleanerStartOfRun,
     SumOfBestCleanerShouldRemove,
 }

--- a/src/localization/polish.rs
+++ b/src/localization/polish.rs
@@ -2,17 +2,17 @@ use super::{Piece, PlaceholderText, Text};
 
 pub const fn resolve(text: Text) -> &'static str {
     match text {
-        Text::StartSplit => "Start / Podział",
-        Text::StartSplitDescription => "Skrót klawiszowy do dzielenia i rozpoczęcia nowej próby.",
+        Text::StartSplit => "Start / Split",
+        Text::StartSplitDescription => "Skrót klawiszowy do dzielenia i rozpoczęcia nowego biegu.",
         Text::Reset => "Reset",
-        Text::ResetDescription => "Skrót klawiszowy do resetowania bieżącej próby.",
+        Text::ResetDescription => "Skrót klawiszowy do resetowania bieżącego biegu.",
         Text::UndoSplit => "Cofnij split",
         Text::UndoSplitDescription => "Skrót klawiszowy do cofnięcia ostatniego splitu.",
         Text::SkipSplit => "Pomiń split",
         Text::SkipSplitDescription => "Skrót klawiszowy do pominięcia bieżącego splitu.",
         Text::Pause => "Pauza",
         Text::PauseDescription => {
-            "Skrót klawiszowy do wstrzymania bieżącej próby. Może też służyć do rozpoczęcia nowej próby."
+            "Skrót klawiszowy do wstrzymania bieżącego biegu. Może też służyć do rozpoczęcia nowego biegu."
         }
         Text::UndoAllPauses => "Cofnij wszystkie pauzy",
         Text::UndoAllPausesDescription => {
@@ -36,7 +36,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::SegmentTimer => "Timer segmentu",
         Text::SegmentTimerDescription => {
-            "Określa, czy wyświetlać czas od rozpoczęcia bieżącego segmentu zamiast czasu od rozpoczęcia bieżącej próby."
+            "Określa, czy wyświetlać czas od rozpoczęcia bieżącego segmentu zamiast czasu od rozpoczęcia bieżącego biegu."
         }
         Text::TimingMethod => "Metoda pomiaru czasu",
         Text::TimingMethodDescription => {
@@ -46,7 +46,7 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::HeightDescription => "Wysokość timera.",
         Text::TimerTextColor => "Kolor tekstu",
         Text::TimerTextColorDescription => {
-            "Kolor wyświetlanego czasu. Jeśli nie określono, kolor jest automatycznie dobierany na podstawie tego, jak dobrze idzie bieżąca próba. Te kolory można ustawić w ogólnych ustawieniach układu."
+            "Kolor wyświetlanego czasu. Jeśli nie określono, kolor jest automatycznie dobierany na podstawie tego, jak dobrze idzie bieżący bieg. Te kolory można ustawić w ogólnych ustawieniach układu."
         }
         Text::ShowGradient => "Pokaż gradient",
         Text::ShowGradientDescription => {
@@ -72,9 +72,9 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::ShowCategoryNameDescription => {
             "Określa, czy nazwa kategorii ma być częścią wyświetlanego tytułu."
         }
-        Text::ShowFinishedRunsCount => "Pokaż liczbę ukończonych prób",
+        Text::ShowFinishedRunsCount => "Pokaż liczbę ukończonych biegów",
         Text::ShowFinishedRunsCountDescription => {
-            "Określa, czy ma być wyświetlana liczba pomyślnie ukończonych prób."
+            "Określa, czy ma być wyświetlana liczba pomyślnie ukończonych biegów."
         }
         Text::ShowAttemptCount => "Pokaż liczbę prób",
         Text::ShowAttemptCountDescription => "Określa, czy ma być wyświetlana łączna liczba prób.",
@@ -160,7 +160,7 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::DeltaBackgroundDescription => "Tło wyświetlane za komponentem.",
         Text::DeltaComparison => "Porównanie",
         Text::DeltaComparisonDescription => {
-            "Porównanie używane do obliczania, o ile bieżąca próba jest do przodu lub do tyłu. Jeśli nie określono, używane jest bieżące porównanie."
+            "Porównanie używane do obliczania, o ile bieżący bieg jest do przodu lub do tyłu. Jeśli nie określono, używane jest bieżące porównanie."
         }
         Text::DeltaDisplayTwoRows => "Wyświetl 2 wiersze",
         Text::DeltaDisplayTwoRowsDescription => {
@@ -218,7 +218,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::PossibleTimeSaveShowTotal => "Pokaż łączną możliwą oszczędność czasu",
         Text::PossibleTimeSaveShowTotalDescription => {
-            "Określa, czy wyświetlać łączną możliwą oszczędność czasu dla reszty bieżącej próby zamiast możliwej oszczędności czasu dla bieżącego segmentu."
+            "Określa, czy wyświetlać łączną możliwą oszczędność czasu dla reszty bieżącego biegu zamiast możliwej oszczędności czasu dla bieżącego segmentu."
         }
         Text::PossibleTimeSaveLabelColor => "Kolor etykiety",
         Text::PossibleTimeSaveLabelColorDescription => {
@@ -338,7 +338,7 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::DetailedTimerSegmentTimerHeightDescription => "Wysokość timera segmentu.",
         Text::DetailedTimerTimerColor => "Kolor timera",
         Text::DetailedTimerTimerColorDescription => {
-            "Zamiast automatycznie dobierać kolor głównego timera na podstawie tego, jak dobrze idzie bieżąca próba, można podać stały kolor."
+            "Zamiast automatycznie dobierać kolor głównego timera na podstawie tego, jak dobrze idzie bieżący bieg, można podać stały kolor."
         }
         Text::DetailedTimerShowTimerGradient => "Pokaż gradient timera",
         Text::DetailedTimerShowTimerGradientDescription => {
@@ -484,7 +484,7 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::TextComponentUseVariableDescription => {
             "Określa, czy używać niestandardowej zmiennej do wyświetlania dynamicznej wartości. Zmienne niestandardowe można określić w edytorze splitów i mogą być dostarczane automatycznie przez auto splittery."
         }
-        Text::TextComponentSplit => "Podział",
+        Text::TextComponentSplit => "Split",
         Text::TextComponentSplitDescription => {
             "Określa, czy podzielić tekst na lewą i prawą część. W przeciwnym razie wyświetlany jest tylko jeden wyśrodkowany tekst."
         }
@@ -549,7 +549,7 @@ pub const fn resolve(text: Text) -> &'static str {
             "Kolor używany, gdy jesteś za porównaniem i tracisz jeszcze więcej czasu."
         }
         Text::NotRunning => "Nie uruchomiono",
-        Text::NotRunningDescription => "Kolor używany, gdy nie ma aktywnej próby.",
+        Text::NotRunningDescription => "Kolor używany, gdy nie ma aktywnego biegu.",
         Text::PersonalBest => "Rekord osobisty",
         Text::PersonalBestDescription => "Kolor używany po uzyskaniu nowego rekordu osobistego.",
         Text::Paused => "Wstrzymano",
@@ -619,11 +619,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Ost. czas seg.",
         Text::LatestSegmentShort => "Ostatni segment",
         Text::SegmentTimeShort => "Czas seg.",
+        Text::SplitTime => "Czas",
         Text::PossibleTimeSaveShort => "Możl. oszcz. czasu",
         Text::PossibleTimeSaveAbbreviation => "Możl. oszcz.",
         Text::TimeSaveShort => "Oszczędność",
         Text::RealTime => "Czas rzeczywisty",
         Text::GameTime => "Czas gry",
+        Text::Untitled => "Bez tytułu",
         Text::SumOfBestCleanerStartOfRun => "początek biegu",
         Text::SumOfBestCleanerShouldRemove => {
             ". Czy uważasz, że ten czas segmentu jest nieprawidłowy i powinien zostać usunięty?"

--- a/src/localization/portuguese.rs
+++ b/src/localization/portuguese.rs
@@ -635,11 +635,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Últ. t. seg.",
         Text::LatestSegmentShort => "Último segmento",
         Text::SegmentTimeShort => "T. seg.",
+        Text::SplitTime => "Tempo",
         Text::PossibleTimeSaveShort => "Tempo possível a poupar",
         Text::PossibleTimeSaveAbbreviation => "T. poss. a poupar",
         Text::TimeSaveShort => "Tempo a poupar",
         Text::RealTime => "Tempo real",
         Text::GameTime => "Tempo de jogo",
+        Text::Untitled => "Sem título",
         Text::SumOfBestCleanerStartOfRun => "o início da corrida",
         Text::SumOfBestCleanerShouldRemove => {
             ". Achas que este tempo de segmento é impreciso e deve ser removido?"

--- a/src/localization/russian.rs
+++ b/src/localization/russian.rs
@@ -615,11 +615,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Последн. вр. сег.",
         Text::LatestSegmentShort => "Последний сегмент",
         Text::SegmentTimeShort => "Вр. сег.",
+        Text::SplitTime => "Время",
         Text::PossibleTimeSaveShort => "Возможная экономия времени",
         Text::PossibleTimeSaveAbbreviation => "Возможн. экономия",
         Text::TimeSaveShort => "Экономия времени",
         Text::RealTime => "Реальное время",
         Text::GameTime => "Игровое время",
+        Text::Untitled => "Без названия",
         Text::SumOfBestCleanerStartOfRun => "началом забега",
         Text::SumOfBestCleanerShouldRemove => {
             ". Считаете ли вы, что это время сегмента неточно и должно быть удалено?"

--- a/src/localization/spanish.rs
+++ b/src/localization/spanish.rs
@@ -637,11 +637,13 @@ pub const fn resolve(text: Text) -> &'static str {
         Text::LatestSegmentTimeShort => "Últ. t. seg.",
         Text::LatestSegmentShort => "Último segmento",
         Text::SegmentTimeShort => "T. seg.",
+        Text::SplitTime => "Tiempo",
         Text::PossibleTimeSaveShort => "Tiempo posible a ahorrar",
         Text::PossibleTimeSaveAbbreviation => "T. posible a ahorrar",
         Text::TimeSaveShort => "Tiempo a ahorrar",
         Text::RealTime => "Tiempo real",
         Text::GameTime => "Tiempo de juego",
+        Text::Untitled => "Sin título",
         Text::SumOfBestCleanerStartOfRun => "el inicio de la run",
         Text::SumOfBestCleanerShouldRemove => {
             ". ¿Crees que este tiempo de segmento es inexacto y debería eliminarse?"

--- a/src/settings/field.rs
+++ b/src/settings/field.rs
@@ -9,8 +9,20 @@ pub struct Field {
     pub text: Cow<'static, str>,
     /// The tooltip to show for the setting.
     pub tooltip: Cow<'static, str>,
+    /// An optional hint about how to display the setting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<Hint>,
     /// The current value of the setting.
     pub value: Value,
+}
+
+/// A hint about how to display the setting.
+#[derive(Serialize, Deserialize)]
+pub enum Hint {
+    /// Display the setting as a selection of a comparison.
+    Comparison,
+    /// Display the setting as a selection of a custom variable.
+    CustomVariable,
 }
 
 impl Field {
@@ -19,7 +31,16 @@ impl Field {
         Self {
             text,
             tooltip,
+            hint: None,
             value,
+        }
+    }
+
+    /// Sets a hint for the field.
+    pub fn with_hint(self, hint: Hint) -> Self {
+        Self {
+            hint: Some(hint),
+            ..self
         }
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -15,7 +15,7 @@ mod value;
 pub use self::{
     alignment::Alignment,
     color::Color,
-    field::Field,
+    field::{Field, Hint as FieldHint},
     font::{Font, Stretch as FontStretch, Style as FontStyle, Weight as FontWeight},
     gradient::{Gradient, ListGradient},
     image::{HasImageId, Image, ImageCache, ImageId},

--- a/tests/layout_parsing.rs
+++ b/tests/layout_parsing.rs
@@ -3,7 +3,7 @@ mod layout_files;
 mod parse {
     use crate::layout_files;
     use livesplit_core::{
-        Component,
+        Component, Lang,
         component::{splits, text},
         layout::{Layout, parser::parse},
     };
@@ -157,7 +157,7 @@ mod parse {
 
         // The layout parser assumes that the order is from right to left. If it
         // changes, the layout parser needs to be adjusted as well.
-        let component = splits::Component::default();
+        let component = splits::Component::new(Lang::English);
         let columns = &component.settings().columns;
         assert_eq!(columns[0].name, "Time");
         assert_eq!(columns[1].name, "+/−");

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -37,7 +37,7 @@ fn default() {
     run.set_category_name("Some Category Name");
     run.set_attempt_count(1337);
     let mut timer = Timer::new(run).unwrap();
-    let mut layout = Layout::default_layout();
+    let mut layout = Layout::default_layout(Lang::English);
 
     tests_helper::start_run(&mut timer);
     tests_helper::make_progress_run_with_splits_opt(&mut timer, &[Some(5.0), None, Some(10.0)]);
@@ -160,7 +160,7 @@ fn font_fallback() {
     ]);
     let timer = Timer::new(run).unwrap();
     let mut layout = Layout::new();
-    let mut splits = component::splits::Component::new();
+    let mut splits = component::splits::Component::new(Lang::English);
     splits.settings_mut().visual_split_count = 0;
     layout.push(splits);
 
@@ -181,7 +181,7 @@ fn font_fallback() {
 fn actual_split_file() {
     let run = lss(run_files::LIVESPLIT_1_0);
     let timer = Timer::new(run).unwrap();
-    let mut layout = Layout::default_layout();
+    let mut layout = Layout::default_layout(Lang::English);
 
     let mut image_cache = ImageCache::new();
     check(
@@ -279,7 +279,7 @@ fn all_components() {
 fn score_split() {
     let run = lss(run_files::LIVESPLIT_1_0);
     let timer = Timer::new(run).unwrap();
-    let mut layout = Layout::default_layout();
+    let mut layout = Layout::default_layout(Lang::English);
 
     let mut image_cache = ImageCache::new();
 
@@ -426,7 +426,7 @@ fn single_line_title() {
 fn horizontal() {
     let run = lss(run_files::CELESTE);
     let mut timer = Timer::new(run).unwrap();
-    let mut layout = Layout::default_layout();
+    let mut layout = Layout::default_layout(Lang::English);
     layout.general_settings_mut().direction = LayoutDirection::Horizontal;
     match &mut layout.components[1] {
         Component::Splits(splits) => splits.settings_mut().visual_split_count = 4,


### PR DESCRIPTION
Certain settings fields should despite their type be visualized differently. For example comparisons and custom variables are all (optional) strings, but they should be displayed as dropdowns or lists respectively. This adds a hinting system to the settings fields to allow for this. Previously the UI hardcoded detection based on the name of the fields, but this is no longer easily possible with the addition of localization.

Additionally, this improves some of the translations.