### PR TITLE
Update Urn Parser to LibreSplit Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bytemuck = { version = "1.9.1", default-features = false }
 bytemuck_derive = { version = "1.4.1", default-features = false }
 cfg-if = "1.0.0"
 itoa = { version = "1.0.3", default-features = false }
-time = { version = "0.3.46", default-features = false }
+time = { version = "0.3.47", default-features = false }
 hashbrown = "0.16.0"
 libm = "0.2.1"
 livesplit-hotkey = { path = "crates/livesplit-hotkey", version = "0.8.0", default-features = false }
@@ -76,11 +76,11 @@ cosmic-text = { version = "0.14.1", default-features = false, features = [
 # Currently doesn't require any additional dependencies.
 
 # Software Rendering
-tiny-skia = { version = "0.11.1", default-features = false, features = [
+tiny-skia = { version = "0.12.0", default-features = false, features = [
     "no-std-float",
     "simd",
 ], optional = true }
-tiny-skia-path = { version = "0.11.1", default-features = false, optional = true }
+tiny-skia-path = { version = "0.12.0", default-features = false, optional = true }
 
 # SVG Rendering
 foldhash = { version = "0.2.0", default-features = false, optional = true }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -25,16 +25,7 @@ pub use alloc::rc::Rc as Arc;
 pub use alloc::sync::Arc;
 
 pub mod math;
-
-#[cfg(feature = "std")]
-pub use std::path;
-
-#[cfg(not(feature = "std"))]
-#[allow(unused)]
-pub mod path {
-    pub use alloc::string::String as PathBuf;
-    pub use str as Path;
-}
+pub mod path;
 
 pub(crate) mod prelude {
     pub use alloc::{

--- a/src/platform/path.rs
+++ b/src/platform/path.rs
@@ -1,0 +1,161 @@
+#[cfg(feature = "std")]
+pub use std::path::{Path, PathBuf};
+
+#[cfg(not(feature = "std"))]
+pub use alloc::string::String as PathBuf;
+#[cfg(not(feature = "std"))]
+pub use str as Path;
+
+pub fn relative_to<'path>(
+    path_buf: &'path mut PathBuf,
+    source: &Path,
+    dest: &'path Path,
+) -> &'path Path {
+    if is_absolute(dest) {
+        return dest;
+    }
+    if let Some(parent) = parent(source) {
+        alloc::borrow::ToOwned::clone_into(parent, path_buf);
+        push(path_buf, dest);
+    } else {
+        alloc::borrow::ToOwned::clone_into(dest, path_buf);
+    }
+    path_buf
+}
+
+#[inline]
+fn parent(path: &Path) -> Option<&Path> {
+    #[cfg(feature = "std")]
+    {
+        path.parent()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        path.rsplit_once('/').map(|(parent, _)| parent)
+    }
+}
+
+#[inline]
+fn push(path_buf: &mut PathBuf, path: &Path) {
+    #[cfg(feature = "std")]
+    {
+        path_buf.push(path);
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        if is_absolute(path) {
+            alloc::borrow::ToOwned::clone_into(path, path_buf);
+            return;
+        }
+        if !path_buf.is_empty() && !path_buf.ends_with('/') {
+            path_buf.push('/');
+        }
+        path_buf.push_str(path);
+    }
+}
+
+#[inline]
+fn is_absolute(path: &Path) -> bool {
+    #[cfg(feature = "std")]
+    {
+        path.is_absolute()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        path.starts_with('/')
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::relative_to;
+    use std::path::{Path, PathBuf};
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_to_relative_path_windows() {
+        let mut buf = PathBuf::new();
+        let base = Path::new(r"C:\base\splits.lss");
+        let rel = Path::new(r"icons\icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new(r"C:\base\icons\icon.png"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn relative_to_relative_path_unix() {
+        let mut buf = PathBuf::new();
+        let base = Path::new("/base/splits.lss");
+        let rel = Path::new("icons/icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new("/base/icons/icon.png"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_to_relative_base_windows() {
+        let mut buf = PathBuf::new();
+        let base = Path::new(r"base\splits.lss");
+        let rel = Path::new(r"icons\icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new(r"base\icons\icon.png"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn relative_to_relative_base_unix() {
+        let mut buf = PathBuf::new();
+        let base = Path::new("base/splits.lss");
+        let rel = Path::new("icons/icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new("base/icons/icon.png"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_to_no_parent_windows() {
+        let mut buf = PathBuf::new();
+        let base = Path::new(r"splits.lss");
+        let rel = Path::new(r"icons\icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new(r"icons\icon.png"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn relative_to_no_parent_unix() {
+        let mut buf = PathBuf::new();
+        let base = Path::new("splits.lss");
+        let rel = Path::new("icons/icon.png");
+        let joined = relative_to(&mut buf, base, rel);
+
+        assert_eq!(joined, Path::new("icons/icon.png"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_to_absolute_path_windows() {
+        let mut buf = PathBuf::new();
+        let base = Path::new(r"C:\base\splits.lss");
+        let abs = Path::new(r"C:\other\icon.png");
+        let joined = relative_to(&mut buf, base, abs);
+
+        assert_eq!(joined, abs);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn relative_to_absolute_path_unix() {
+        let mut buf = PathBuf::new();
+        let base = Path::new("/base/splits.lss");
+        let abs = Path::new("/other/icon.png");
+        let joined = relative_to(&mut buf, base, abs);
+
+        assert_eq!(joined, abs);
+    }
+}

--- a/src/run/parser/composite.rs
+++ b/src/run/parser/composite.rs
@@ -28,9 +28,9 @@
 //! ```
 
 use super::{
-    TimerKind, face_split, flitter, livesplit, llanfair, llanfair_gered, opensplit,
+    TimerKind, face_split, flitter, libresplit, livesplit, llanfair, llanfair_gered, opensplit,
     portal2_live_timer, shit_split, source_live_timer, speedrun_igt, splitterino, splitterz,
-    splitty, time_split_tracker, urn, wsplit,
+    splitty, time_split_tracker, wsplit,
 };
 use crate::{Run, platform::path::Path};
 use core::{result::Result as StdResult, str};
@@ -74,7 +74,7 @@ const fn parsed(run: Run, kind: TimerKind<'_>) -> ParsedRun<'_> {
 /// Attempts to parse and fix a splits file by invoking the corresponding parser
 /// for the file format detected. Additionally you can provide the path of the
 /// splits file so additional files, like external images, can be loaded. If you
-/// are using livesplit-core in a server-like environment, set this to `None`.
+/// are using livesplit-core in a server-like environment, set this to [`None`].
 /// Only client-side applications should provide a path here. Unlike the normal
 /// parsing function, it also fixes problems in the Run, such as decreasing
 /// times and missing information.
@@ -90,8 +90,8 @@ pub fn parse_and_fix<'source>(
 /// Attempts to parse a splits file by invoking the corresponding parser for the
 /// file format detected. Additionally you can provide the path of the splits
 /// file so additional files, like external images, can be loaded. If you are
-/// using livesplit-core in a server-like environment, set this to `None`. Only
-/// client-side applications should provide a path here.
+/// using livesplit-core in a server-like environment, set this to [`None`].
+/// Only client-side applications should provide a path here.
 pub fn parse<'source>(
     source: &'source [u8],
     load_files_path: Option<&Path>,
@@ -101,11 +101,11 @@ pub fn parse<'source>(
             return Ok(parsed(run, TimerKind::LiveSplit));
         }
 
-        if let Ok(run) = wsplit::parse(source, load_files_path.is_some()) {
+        if let Ok(run) = wsplit::parse(source, load_files_path) {
             return Ok(parsed(run, TimerKind::WSplit));
         }
 
-        if let Ok(run) = splitterz::parse(source, load_files_path.is_some()) {
+        if let Ok(run) = splitterz::parse(source, load_files_path) {
             return Ok(parsed(run, TimerKind::SplitterZ));
         }
 
@@ -125,7 +125,7 @@ pub fn parse<'source>(
             return Ok(parsed(run, TimerKind::Portal2LiveTimer));
         }
 
-        if let Ok(run) = face_split::parse(source, load_files_path.is_some()) {
+        if let Ok(run) = face_split::parse(source, load_files_path) {
             return Ok(parsed(run, TimerKind::FaceSplit));
         }
 
@@ -136,7 +136,7 @@ pub fn parse<'source>(
         }
 
         // Splitterino, SourceLiveTimer, Flitter, and SpeedRunIGT need to be
-        // before Urn because of a false positive due to the nature of parsing
+        // before LibreSplit because of a false positive due to the nature of parsing
         // JSON files.
         if let Ok(run) = splitterino::parse(source) {
             return Ok(parsed(run, TimerKind::Splitterino));
@@ -158,9 +158,9 @@ pub fn parse<'source>(
             return Ok(parsed(run, TimerKind::OpenSplit));
         }
 
-        // Urn accepts entirely empty JSON files.
-        if let Ok(run) = urn::parse(source) {
-            return Ok(parsed(run, TimerKind::Urn));
+        // LibreSplit accepts entirely empty JSON files.
+        if let Ok(run) = libresplit::parse(source, load_files_path) {
+            return Ok(parsed(run, TimerKind::LibreSplit));
         }
     }
 

--- a/src/run/parser/mod.rs
+++ b/src/run/parser/mod.rs
@@ -31,6 +31,7 @@
 pub mod composite;
 pub mod face_split;
 pub mod flitter;
+pub mod libresplit;
 pub mod livesplit;
 pub mod llanfair;
 pub mod llanfair_gered;
@@ -43,7 +44,6 @@ pub mod splitterino;
 pub mod splitterz;
 pub mod splitty;
 pub mod time_split_tracker;
-pub mod urn;
 pub mod wsplit;
 
 mod timer_kind;

--- a/src/run/parser/timer_kind.rs
+++ b/src/run/parser/timer_kind.rs
@@ -29,8 +29,8 @@ pub enum TimerKind<'a> {
     LlanfairGered,
     /// OpenSplit
     OpenSplit,
-    /// Urn
-    Urn,
+    /// LibreSplit
+    LibreSplit,
     /// SourceLiveTimer
     SourceLiveTimer,
     /// Splitterino
@@ -58,7 +58,7 @@ impl TimerKind<'_> {
             TimerKind::Llanfair => TimerKind::Llanfair,
             TimerKind::LlanfairGered => TimerKind::LlanfairGered,
             TimerKind::OpenSplit => TimerKind::OpenSplit,
-            TimerKind::Urn => TimerKind::Urn,
+            TimerKind::LibreSplit => TimerKind::LibreSplit,
             TimerKind::SourceLiveTimer => TimerKind::SourceLiveTimer,
             TimerKind::Splitterino => TimerKind::Splitterino,
             TimerKind::SpeedRunIGT => TimerKind::SpeedRunIGT,
@@ -82,7 +82,7 @@ impl fmt::Display for TimerKind<'_> {
             TimerKind::Llanfair => "Llanfair",
             TimerKind::LlanfairGered => "Llanfair (Gered's fork)",
             TimerKind::OpenSplit => "OpenSplit",
-            TimerKind::Urn => "Urn",
+            TimerKind::LibreSplit => "LibreSplit",
             TimerKind::SourceLiveTimer => "SourceLiveTimer",
             TimerKind::Splitterino => "Splitterino",
             TimerKind::SpeedRunIGT => "SpeedRunIGT",

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -195,7 +195,7 @@ fn actual_split_file() {
 
 #[test]
 fn wsplit() {
-    let run = wsplit::parse(run_files::WSPLIT, false).unwrap();
+    let run = wsplit::parse(run_files::WSPLIT, None).unwrap();
     let timer = Timer::new(run).unwrap();
     let mut layout = lsl(layout_files::WSPLIT);
 

--- a/tests/run_files/libresplit.json
+++ b/tests/run_files/libresplit.json
@@ -2,27 +2,32 @@
     "title": "SotN Any% NSC",
     "attempt_count": 69,
     "start_delay": "2.800000",
+    "world_record": "23:42.151789",
     "splits": [
         {
             "title": "Mist",
+            "icon": "mist.png",
             "time": "11:41.299585",
             "best_time": "11:32.100735",
             "best_segment": "11:32.100735"
         },
         {
             "title": "Bat",
+            "icon": "bat.png",
             "time": "14:36.934210",
             "best_time": "14:16.933388",
             "best_segment": "2:35.819681"
         },
         {
             "title": "Reverse",
+            "icon": "reverse.png",
             "time": "17:51.600311",
             "best_time": "17:26.241850",
             "best_segment": "3:08.843658"
         },
         {
             "title": "Dracula",
+            "icon": "dracula.png",
             "time": "23:52.151789",
             "best_time": "23:52.151789",
             "best_segment": "5:54.446978"

--- a/tests/run_files/mod.rs
+++ b/tests/run_files/mod.rs
@@ -24,6 +24,6 @@ pub const SPLITTERINO: &str = include_str!("splitterino.splits");
 pub const SPLITTERZ: &str = include_str!("splitterz");
 pub const TIME_SPLIT_TRACKER_WITHOUT_ATTEMPT_COUNT: &str = include_str!("1734.timesplittracker");
 pub const TIME_SPLIT_TRACKER: &str = include_str!("timesplittracker.txt");
-pub const URN: &str = include_str!("urn.json");
+pub const LIBRESPLIT: &str = include_str!("libresplit.json");
 pub const WSPLIT: &str = include_str!("wsplit");
 pub const CLEAN_SUM_OF_BEST: &str = include_str!("clean_sum_of_best.lss");

--- a/tests/split_parsing.rs
+++ b/tests/split_parsing.rs
@@ -6,9 +6,9 @@ mod parse {
         Run, TimeSpan,
         analysis::total_playtime,
         run::parser::{
-            TimerKind, composite, flitter, livesplit, llanfair, llanfair_gered, opensplit,
-            portal2_live_timer, source_live_timer, speedrun_igt, splitterino, splitterz,
-            time_split_tracker, urn, wsplit,
+            TimerKind, composite, flitter, libresplit, livesplit, llanfair, llanfair_gered,
+            opensplit, portal2_live_timer, source_live_timer, speedrun_igt, splitterino, splitterz,
+            time_split_tracker, wsplit,
         },
     };
 
@@ -122,12 +122,12 @@ mod parse {
 
     #[test]
     fn splitterz() {
-        splitterz::parse(run_files::SPLITTERZ, false).unwrap();
+        splitterz::parse(run_files::SPLITTERZ, None).unwrap();
     }
 
     #[test]
     fn wsplit() {
-        wsplit::parse(run_files::WSPLIT, false).unwrap();
+        wsplit::parse(run_files::WSPLIT, None).unwrap();
     }
 
     #[test]
@@ -136,8 +136,8 @@ mod parse {
     }
 
     #[test]
-    fn urn() {
-        urn::parse(run_files::URN).unwrap();
+    fn libresplit() {
+        libresplit::parse(run_files::LIBRESPLIT, None).unwrap();
     }
 
     #[test]
@@ -194,9 +194,9 @@ mod parse {
     }
 
     #[test]
-    fn urn_prefers_parsing_as_itself() {
-        let run = composite::parse(run_files::URN.as_bytes(), None).unwrap();
-        assert_eq!(run.kind, TimerKind::Urn);
+    fn libresplit_prefers_parsing_as_itself() {
+        let run = composite::parse(run_files::LIBRESPLIT.as_bytes(), None).unwrap();
+        assert_eq!(run.kind, TimerKind::LibreSplit);
     }
 
     #[test]


### PR DESCRIPTION
Urn nowadays is maintained as a separate project called Libresplit. This updates the parser to reflect the changes in the file format, and renames it to match the name of the project.

Additionally, relative files are now parsed relative to the splits file, instead of relative to the current working directory. That's how it always should've been, but wasn't.