### PR TITLE
Expose Range Selection In C API

### DIFF
--- a/capi/src/run_editor.rs
+++ b/capi/src/run_editor.rs
@@ -75,6 +75,16 @@ pub extern "C" fn RunEditor_select_additionally(this: &mut RunEditor, index: usi
     this.select_additionally(index);
 }
 
+/// Selects all segments from the currently active segment to the segment with
+/// the given index. The segment with the given index becomes the new active
+/// segment.
+///
+/// This panics if the index of the segment provided is out of bounds.
+#[unsafe(no_mangle)]
+pub extern "C" fn RunEditor_select_range(this: &mut RunEditor, index: usize) {
+    this.select_range(index);
+}
+
 /// Selects the segment with the given index. All other segments are
 /// unselected. The segment chosen also becomes the active segment.
 ///

--- a/src/run/editor/mod.rs
+++ b/src/run/editor/mod.rs
@@ -176,6 +176,10 @@ impl Editor {
     ///
     /// This panics if the index of the segment provided is out of bounds.
     pub fn select_range(&mut self, index: usize) {
+        if index >= self.run.len() {
+            panic!("Index out of bounds for segment selection.");
+        }
+
         let active = self.active_segment_index();
         let range = if index < active {
             index + 1..active

--- a/src/run/editor/tests/mod.rs
+++ b/src/run/editor/tests/mod.rs
@@ -1,6 +1,7 @@
-use super::Editor;
+use super::{Editor, SelectionState};
 use crate::{
     Lang, Run, Segment, TimeSpan,
+    settings::ImageCache,
     util::tests_helper::{create_timer, run_with_splits},
 };
 
@@ -89,6 +90,60 @@ fn select_additionally_oob() {
     let mut editor = Editor::new(run).unwrap();
 
     editor.select_additionally(1);
+}
+
+#[test]
+#[should_panic(expected = "Index out of bounds for segment selection.")]
+fn select_range_oob() {
+    let mut run = Run::new();
+    run.push_segment(Segment::new(""));
+
+    let mut editor = Editor::new(run).unwrap();
+
+    editor.select_range(1);
+}
+
+#[test]
+fn select_range_keeps_existing_selection_and_updates_active_segment() {
+    let mut run = Run::new();
+    for name in ["A", "B", "C", "D"] {
+        run.push_segment(Segment::new(name));
+    }
+
+    let mut editor = Editor::new(run).unwrap();
+    editor.select_additionally(3);
+    editor.select_range(1);
+
+    let mut image_cache = ImageCache::new();
+    let state = editor.state(&mut image_cache, Lang::English);
+
+    assert_eq!(state.segments[0].selected, SelectionState::Selected);
+    assert_eq!(state.segments[1].selected, SelectionState::Active);
+    assert_eq!(state.segments[2].selected, SelectionState::Selected);
+    assert_eq!(state.segments[3].selected, SelectionState::Selected);
+}
+
+#[test]
+fn select_range_preserves_selected_segments_outside_of_the_range() {
+    let mut run = Run::new();
+    for name in ["A", "B", "C", "D", "E", "F"] {
+        run.push_segment(Segment::new(name));
+    }
+
+    let mut editor = Editor::new(run).unwrap();
+    editor.select_additionally(5);
+    editor.select_additionally(2);
+    editor.select_range(4);
+
+    let mut image_cache = ImageCache::new();
+    let state = editor.state(&mut image_cache, Lang::English);
+
+    assert_eq!(state.segments[0].selected, SelectionState::Selected);
+    assert_eq!(state.segments[1].selected, SelectionState::NotSelected);
+    assert_eq!(state.segments[2].selected, SelectionState::Selected);
+    assert_eq!(state.segments[3].selected, SelectionState::Selected);
+    assert_eq!(state.segments[4].selected, SelectionState::Active);
+    assert_eq!(state.segments[5].selected, SelectionState::Selected);
 }
 
 #[test]


### PR DESCRIPTION
This exposes `RunEditor_select_range` through the C API so native bindings can trigger the same contiguous segment selection behavior that the Rust editor already provides. That keeps range selection available across the exported editor surface instead of requiring platform-specific reimplementation.

This also makes `Editor::select_range` check its documented bounds explicitly and adds tests that pin down the panic and selection behavior the exported function now depends on.