### PR TITLE
Add "Merged Timeloss" comparison

### DIFF
--- a/src/comparison/merged_timeloss.rs
+++ b/src/comparison/merged_timeloss.rs
@@ -1,0 +1,53 @@
+//! Defines the Comparison Generator for calculating the Best Segments of a
+//! [`Run`](crate::Run).
+
+use super::ComparisonGenerator;
+use crate::{
+    Attempt, Segment, Time, TimeSpan, TimingMethod, analysis::sum_of_segments::calculate_best,
+};
+
+/// Defines the Comparison Generator for calculating the Best Segments of a
+/// [`Run`](crate::Run).
+#[derive(Copy, Clone, Debug)]
+pub struct MergedTimeloss;
+
+/// The short name of this comparison. Suitable for situations where not a lot
+/// of space for text is available.
+pub const SHORT_NAME: &str = "Merged";
+/// The name of this comparison.
+pub const NAME: &str = "Merged Timeloss";
+
+impl ComparisonGenerator for MergedTimeloss {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn generate(&mut self, segments: &mut [Segment], _: &[Attempt]) {
+        segments
+            .iter_mut()
+            .for_each(|s| *s.comparison_mut(NAME) = Time::new());
+
+        for method in TimingMethod::all() {
+            let mut split_time = calculate_timeloss(&segments, method);
+
+            for segment in &mut *segments {
+                let mut time = None;
+                if let Some(segment_best) = segment.best_segment_time()[method] {
+                    split_time = segment_best + split_time;
+                    time = Some(split_time)
+                }
+                segment.comparison_mut(NAME)[method] = time;
+            }
+        }
+    }
+}
+fn calculate_timeloss(segments: &[Segment], method: TimingMethod) -> TimeSpan {
+    if segments.len() == 0 { return TimeSpan::zero() }
+    let pb = segments[segments.len()-1].personal_best_split_time()[method];
+    let best = calculate_best(segments, false, false, method);
+
+    if pb.is_some() && best.is_some()
+    {
+        pb.unwrap() - best.unwrap()
+    } else { TimeSpan::zero() }
+}

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -15,11 +15,12 @@ pub mod latest_run;
 pub mod median_segments;
 pub mod none;
 pub mod worst_segments;
+pub mod merged_timeloss;
 
 pub use self::{
     average_segments::AverageSegments, balanced_pb::BalancedPB, best_segments::BestSegments,
     best_split_times::BestSplitTimes, latest_run::LatestRun, median_segments::MedianSegments,
-    none::None, worst_segments::WorstSegments,
+    none::None, worst_segments::WorstSegments, merged_timeloss::MergedTimeloss,
 };
 
 use crate::{Attempt, Segment, Timer, platform::prelude::*};
@@ -91,6 +92,7 @@ pub fn default_generators() -> Vec<Box<dyn ComparisonGenerator>> {
     vec![
         Box::new(BestSegments),
         Box::new(BestSplitTimes),
+        Box::new(MergedTimeloss),
         Box::new(AverageSegments),
         Box::new(MedianSegments),
         Box::new(WorstSegments),
@@ -115,6 +117,7 @@ pub fn try_shorten(comparison: &str) -> Option<&'static str> {
         latest_run::NAME => latest_run::SHORT_NAME,
         none::NAME => none::SHORT_NAME,
         worst_segments::NAME => worst_segments::SHORT_NAME,
+        merged_timeloss::NAME => merged_timeloss::SHORT_NAME,
         _ => return Option::None,
     })
 }


### PR DESCRIPTION
For this comparison, all timeloss is merged into the first split, with all other splits set to their best segment time.

My reason is just that I want to know how much time I can still lose in total, rather then see it split up over all segments.
