### PR TITLE
fix(hotkey): support remapped Caps Lock (hyper key) on macOS

### DIFF
--- a/crates/livesplit-hotkey/src/macos/cg.rs
+++ b/crates/livesplit-hotkey/src/macos/cg.rs
@@ -196,6 +196,14 @@ bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct EventFlags: u64 {
+        const LEFT_CONTROL = 1 << 0;
+        const LEFT_SHIFT = 1 << 1;
+        const RIGHT_SHIFT = 1 << 2;
+        const LEFT_COMMAND = 1 << 3;
+        const RIGHT_COMMAND = 1 << 4;
+        const LEFT_OPTION = 1 << 5;
+        const RIGHT_OPTION = 1 << 6;
+        const RIGHT_CONTROL = 1 << 13;
         const CAPS_LOCK = 1 << 16;
         const SHIFT = 1 << 17;
         const CONTROL = 1 << 18;

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -456,25 +456,33 @@ unsafe extern "C" fn callback(
     let modifier_flags = unsafe { CGEventGetFlags(event) };
     let mut modifiers = Modifiers::empty();
 
-    if modifier_flags.contains(EventFlags::SHIFT)
+    if (modifier_flags.contains(EventFlags::SHIFT)
+        || modifier_flags.contains(EventFlags::LEFT_SHIFT)
+        || modifier_flags.contains(EventFlags::RIGHT_SHIFT))
         && !matches!(key_code, KeyCode::ShiftLeft | KeyCode::ShiftRight)
     {
         modifiers.insert(Modifiers::SHIFT);
     }
 
-    if modifier_flags.contains(EventFlags::CONTROL)
+    if (modifier_flags.contains(EventFlags::CONTROL)
+        || modifier_flags.contains(EventFlags::LEFT_CONTROL)
+        || modifier_flags.contains(EventFlags::RIGHT_CONTROL))
         && !matches!(key_code, KeyCode::ControlLeft | KeyCode::ControlRight)
     {
         modifiers.insert(Modifiers::CONTROL);
     }
 
-    if modifier_flags.contains(EventFlags::OPTION)
+    if (modifier_flags.contains(EventFlags::OPTION)
+        || modifier_flags.contains(EventFlags::LEFT_OPTION)
+        || modifier_flags.contains(EventFlags::RIGHT_OPTION))
         && !matches!(key_code, KeyCode::AltLeft | KeyCode::AltRight)
     {
         modifiers.insert(Modifiers::ALT);
     }
 
-    if modifier_flags.contains(EventFlags::COMMAND)
+    if (modifier_flags.contains(EventFlags::COMMAND)
+        || modifier_flags.contains(EventFlags::LEFT_COMMAND)
+        || modifier_flags.contains(EventFlags::RIGHT_COMMAND))
         && !matches!(key_code, KeyCode::MetaLeft | KeyCode::MetaRight)
     {
         modifiers.insert(Modifiers::META);


### PR DESCRIPTION
Check both device-independent and device-dependent modifier flags when processing events. This fixes an issue where virtual keys/remappers (such as Raycast or Karabiner-Elements Hyper Key) only set the device-dependent flags, preventing the hotkey from triggering.

Closes #895