### PR TITLE
fix(hotkey): support remapped Caps Lock (hyper key) on macOS

### DIFF
--- a/crates/livesplit-hotkey/src/macos/cg.rs
+++ b/crates/livesplit-hotkey/src/macos/cg.rs
@@ -196,6 +196,14 @@ bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct EventFlags: u64 {
+        const LEFT_CONTROL = 1 << 0;
+        const LEFT_SHIFT = 1 << 1;
+        const RIGHT_SHIFT = 1 << 2;
+        const LEFT_COMMAND = 1 << 3;
+        const RIGHT_COMMAND = 1 << 4;
+        const LEFT_OPTION = 1 << 5;
+        const RIGHT_OPTION = 1 << 6;
+        const RIGHT_CONTROL = 1 << 13;
         const CAPS_LOCK = 1 << 16;
         const SHIFT = 1 << 17;
         const CONTROL = 1 << 18;

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -456,33 +456,25 @@ unsafe extern "C" fn callback(
     let modifier_flags = unsafe { CGEventGetFlags(event) };
     let mut modifiers = Modifiers::empty();
 
-    if (modifier_flags.contains(EventFlags::SHIFT)
-        || modifier_flags.contains(EventFlags::LEFT_SHIFT)
-        || modifier_flags.contains(EventFlags::RIGHT_SHIFT))
+    if modifier_flags.intersects(EventFlags::SHIFT | EventFlags::LEFT_SHIFT | EventFlags::RIGHT_SHIFT)
         && !matches!(key_code, KeyCode::ShiftLeft | KeyCode::ShiftRight)
     {
         modifiers.insert(Modifiers::SHIFT);
     }
 
-    if (modifier_flags.contains(EventFlags::CONTROL)
-        || modifier_flags.contains(EventFlags::LEFT_CONTROL)
-        || modifier_flags.contains(EventFlags::RIGHT_CONTROL))
+    if modifier_flags.intersects(EventFlags::CONTROL | EventFlags::LEFT_CONTROL | EventFlags::RIGHT_CONTROL)
         && !matches!(key_code, KeyCode::ControlLeft | KeyCode::ControlRight)
     {
         modifiers.insert(Modifiers::CONTROL);
     }
 
-    if (modifier_flags.contains(EventFlags::OPTION)
-        || modifier_flags.contains(EventFlags::LEFT_OPTION)
-        || modifier_flags.contains(EventFlags::RIGHT_OPTION))
+    if modifier_flags.intersects(EventFlags::OPTION | EventFlags::LEFT_OPTION | EventFlags::RIGHT_OPTION)
         && !matches!(key_code, KeyCode::AltLeft | KeyCode::AltRight)
     {
         modifiers.insert(Modifiers::ALT);
     }
 
-    if (modifier_flags.contains(EventFlags::COMMAND)
-        || modifier_flags.contains(EventFlags::LEFT_COMMAND)
-        || modifier_flags.contains(EventFlags::RIGHT_COMMAND))
+    if modifier_flags.intersects(EventFlags::COMMAND | EventFlags::LEFT_COMMAND | EventFlags::RIGHT_COMMAND)
         && !matches!(key_code, KeyCode::MetaLeft | KeyCode::MetaRight)
     {
         modifiers.insert(Modifiers::META);

--- a/crates/livesplit-hotkey/src/macos/mod.rs
+++ b/crates/livesplit-hotkey/src/macos/mod.rs
@@ -456,25 +456,33 @@ unsafe extern "C" fn callback(
     let modifier_flags = unsafe { CGEventGetFlags(event) };
     let mut modifiers = Modifiers::empty();
 
-    if modifier_flags.contains(EventFlags::SHIFT)
+    if (modifier_flags.contains(EventFlags::SHIFT)
+        || modifier_flags.contains(EventFlags::LEFT_SHIFT)
+        || modifier_flags.contains(EventFlags::RIGHT_SHIFT))
         && !matches!(key_code, KeyCode::ShiftLeft | KeyCode::ShiftRight)
     {
         modifiers.insert(Modifiers::SHIFT);
     }
 
-    if modifier_flags.contains(EventFlags::CONTROL)
+    if (modifier_flags.contains(EventFlags::CONTROL)
+        || modifier_flags.contains(EventFlags::LEFT_CONTROL)
+        || modifier_flags.contains(EventFlags::RIGHT_CONTROL))
         && !matches!(key_code, KeyCode::ControlLeft | KeyCode::ControlRight)
     {
         modifiers.insert(Modifiers::CONTROL);
     }
 
-    if modifier_flags.contains(EventFlags::OPTION)
+    if (modifier_flags.contains(EventFlags::OPTION)
+        || modifier_flags.contains(EventFlags::LEFT_OPTION)
+        || modifier_flags.contains(EventFlags::RIGHT_OPTION))
         && !matches!(key_code, KeyCode::AltLeft | KeyCode::AltRight)
     {
         modifiers.insert(Modifiers::ALT);
     }
 
-    if modifier_flags.contains(EventFlags::COMMAND)
+    if (modifier_flags.contains(EventFlags::COMMAND)
+        || modifier_flags.contains(EventFlags::LEFT_COMMAND)
+        || modifier_flags.contains(EventFlags::RIGHT_COMMAND))
         && !matches!(key_code, KeyCode::MetaLeft | KeyCode::MetaRight)
     {
         modifiers.insert(Modifiers::META);

--- a/src/platform/wasm/unknown/time.rs
+++ b/src/platform/wasm/unknown/time.rs
@@ -8,6 +8,7 @@ struct FFIDateTime {
     nsecs: u32,
 }
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn Date_now(data: *mut FFIDateTime);
 }
@@ -23,6 +24,7 @@ pub fn utc_now() -> DateTime {
     }
 }
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     safe fn Instant_now() -> f64;
 }


### PR DESCRIPTION
Check both device-independent and device-dependent modifier flags when processing events. This fixes an issue where virtual keys/remappers (such as Raycast or Karabiner-Elements Hyper Key) only set the device-dependent flags, preventing the hotkey from triggering.

Closes #895