### PR TITLE
Improve TypeScript Bindings

### DIFF
--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -13,6 +13,7 @@ mod typescript;
 mod wasm_bindgen;
 
 use clap::Parser;
+use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
     fs::{self, File, create_dir_all, remove_dir_all},
@@ -73,6 +74,33 @@ impl Function {
 
     fn has_return_type(&self) -> bool {
         self.output.name != "()"
+    }
+}
+
+/// Returns the public method name to use in JavaScript-facing bindings.
+///
+/// A static `name` method collides with the built-in `Function.name` property
+/// inherited by every JavaScript class constructor. Other target languages do
+/// not have that constraint, so the raw C API and their generated bindings can
+/// keep the concise name while only JavaScript exposes it as `displayName`.
+fn javascript_method_name(method: &str, is_static: bool) -> String {
+    let method = method.to_lower_camel_case();
+    if is_static && method == "name" {
+        "displayName".into()
+    } else {
+        method
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::javascript_method_name;
+
+    #[test]
+    fn avoids_the_static_function_name_property_in_javascript() {
+        assert_eq!(javascript_method_name("name", true), "displayName");
+        assert_eq!(javascript_method_name("name", false), "name");
+        assert_eq!(javascript_method_name("parse_locale", true), "parseLocale");
     }
 }
 

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -1,4 +1,4 @@
-use crate::{Class, Function, Type, TypeKind, typescript};
+use crate::{Class, Function, Type, TypeKind, javascript_method_name, typescript};
 use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
@@ -106,7 +106,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     let has_return_type = function.has_return_type();
     let return_type_with_null = get_hl_type_with_null(&function.output);
     let return_type_without_null = get_hl_type_without_null(&function.output);
-    let method = function.method.to_lower_camel_case();
+    let method = javascript_method_name(&function.method, is_static);
     let is_json = has_return_type && function.output.name == "Json";
 
     if !function.comments.is_empty() || !type_script {

--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -15,7 +15,7 @@ export type ComponentStateJson =
  * texts, lines and various other elements that are being shown. They are stored
  * as RGBA colors with floating point numbers ranging from 0.0 to 1.0 per channel.
  */
-export type Color = number[];
+export type Color = [red: number, green: number, blue: number, alpha: number];
 
 /**
  * Describes a Gradient for coloring a region with more than just a single
@@ -24,8 +24,8 @@ export type Color = number[];
 export type Gradient =
     "Transparent" |
     { Plain: Color } |
-    { Vertical: Color[] } |
-    { Horizontal: Color[] };
+    { Vertical: [top: Color, bottom: Color] } |
+    { Horizontal: [left: Color, right: Color] };
 
 /**
  * Describes an extended form of a gradient, specifically made for use with
@@ -33,7 +33,7 @@ export type Gradient =
  */
 export type ListGradient =
     { Same: Gradient } |
-    { Alternating: Color[] };
+    { Alternating: [even: Color, odd: Color] };
 
 /**
  * The ID of an image that can be used for looking up an image in an image

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -1,4 +1,4 @@
-use crate::{Class, Function, Type, TypeKind, typescript};
+use crate::{Class, Function, Type, TypeKind, javascript_method_name, typescript};
 use heck::ToLowerCamelCase;
 use std::{
     collections::BTreeMap,
@@ -79,7 +79,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, type_script: bool) -> 
     let has_return_type = function.has_return_type();
     let return_type_with_null = get_hl_type_with_null(&function.output);
     let return_type_without_null = get_hl_type_without_null(&function.output);
-    let method = function.method.to_lower_camel_case();
+    let method = javascript_method_name(&function.method, is_static);
     let is_json = has_return_type && function.output.name == "Json";
 
     if function.inputs.iter().any(|(_, ty)| {


### PR DESCRIPTION
Describe serialized RGBA colors as fixed four-channel tuples and represent two-color gradient variants as fixed pairs. This preserves the exact Rust serialization contracts in generated TypeScript and lets consumers use strict indexed access without defensive assertions.

Expose static methods named name as displayName in the JavaScript-facing Node and WebAssembly bindings to avoid colliding with Function.name. Keep the raw C API and non-JavaScript binding names unchanged, and cover the JavaScript naming rule with a generator test.

Validation: binding-generator tests, Clippy with warnings denied, targeted Rust formatting, a full WebAssembly core rebuild, frontend ESLint and TypeScript checks, and web and Tauri frontend builds.