### PR TITLE
Add Detailed Timer `IconDisplayMode`

### DIFF
--- a/capi/bind_gen/src/typescript.ts
+++ b/capi/bind_gen/src/typescript.ts
@@ -655,6 +655,8 @@ export interface DetailedTimerComponentStateJson {
      * is no icon.
      */
     icon: ImageId,
+    /** Specifies how the segment icon should be displayed. */
+    display_icon: IconDisplayMode,
     /**
      * The color of the segment name if it's shown. If `null` is specified, the
      * color is taken from the layout.
@@ -791,6 +793,7 @@ export type SettingsDescriptionValueJson =
     { ColumnUpdateWith: ColumnUpdateWith } |
     { ColumnUpdateTrigger: ColumnUpdateTrigger } |
     { SubsplitDisplayMode: SubsplitDisplayMode } |
+    { IconDisplayMode: IconDisplayMode } |
     { Hotkey: string } |
     { LayoutDirection: LayoutDirection } |
     { Font: Font | null } |
@@ -852,6 +855,9 @@ export type SubsplitDisplayMode =
     "Flat" |
     "CurrentGroupExpanded" |
     "AllGroupsExpanded";
+
+/** Describes how the Detailed Timer Component's icon is displayed. */
+export type IconDisplayMode = "Hidden" | "BothRows" | "FirstRow";
 
 /**
  * The Accuracy describes how many digits to show for the fractional part of a

--- a/capi/src/detailed_timer_component_state.rs
+++ b/capi/src/detailed_timer_component_state.rs
@@ -140,6 +140,14 @@ pub extern "C" fn DetailedTimerComponentState_icon(
     output_str(this.icon.format_str(&mut [0; 64]))
 }
 
+/// Returns how the segment icon is displayed.
+#[unsafe(no_mangle)]
+pub extern "C" fn DetailedTimerComponentState_display_icon(
+    this: &DetailedTimerComponentState,
+) -> *const c_char {
+    output_vec(|f| write!(f, "{:?}", this.display_icon).unwrap())
+}
+
 /// The name of the segment. This may be <NULL> if it's not supposed to be
 /// visualized.
 #[unsafe(no_mangle)]

--- a/capi/src/setting_value.rs
+++ b/capi/src/setting_value.rs
@@ -5,6 +5,7 @@ use crate::{Json, output_vec, str};
 use livesplit_core::{
     TimingMethod,
     component::{
+        detailed_timer::IconDisplayMode,
         splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith, SubsplitDisplayMode},
         timer::DeltaGradient,
     },
@@ -342,6 +343,23 @@ pub unsafe extern "C" fn SettingValue_from_subsplit_display_mode(
         "Flat" => SubsplitDisplayMode::Flat,
         "CurrentGroupExpanded" => SubsplitDisplayMode::CurrentGroupExpanded,
         "AllGroupsExpanded" => SubsplitDisplayMode::AllGroupsExpanded,
+        _ => return None,
+    };
+    Some(Box::new(value.into()))
+}
+
+/// Creates a new setting value from the Detailed Timer icon display mode. If
+/// it doesn't match a known icon display mode, <NULL> is returned.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SettingValue_from_icon_display_mode(
+    value: *const c_char,
+) -> NullableOwnedSettingValue {
+    // SAFETY: The caller guarantees that `value` is valid.
+    let value = unsafe { str(value) };
+    let value = match value {
+        "Hidden" => IconDisplayMode::Hidden,
+        "BothRows" => IconDisplayMode::BothRows,
+        "FirstRow" => IconDisplayMode::FirstRow,
         _ => return None,
     };
     Some(Box::new(value.into()))

--- a/src/component/detailed_timer/mod.rs
+++ b/src/component/detailed_timer/mod.rs
@@ -58,8 +58,8 @@ pub struct Settings {
     pub timer: timer::Settings,
     /// The settings of the segment timer.
     pub segment_timer: timer::Settings,
-    /// Specifies whether the segment icon should be shown.
-    pub display_icon: bool,
+    /// Specifies how the segment icon should be displayed.
+    pub display_icon: IconDisplayMode,
     /// Specifies whether the segment name should be shown.
     pub show_segment_name: bool,
     /// The color of the segment name if it's shown. If [`None`] is specified,
@@ -73,6 +73,52 @@ pub struct Settings {
     pub comparison_times_color: Option<Color>,
     /// The accuracy of the comparison times.
     pub comparison_times_accuracy: Accuracy,
+}
+
+/// Describes how the segment icon is displayed.
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, Serialize)]
+pub enum IconDisplayMode {
+    /// The segment icon is not shown.
+    #[default]
+    Hidden,
+    /// The segment icon spans both rows of the component.
+    BothRows,
+    /// The segment icon only occupies space in the first row.
+    FirstRow,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum IconDisplayModeDeserialize {
+    Mode(IconDisplayModeName),
+    Legacy(bool),
+}
+
+#[derive(Deserialize)]
+enum IconDisplayModeName {
+    Hidden,
+    BothRows,
+    FirstRow,
+}
+
+impl<'de> serde::Deserialize<'de> for IconDisplayMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // `display_icon` was a boolean in released layouts. Accepting the old
+        // representation on the enum itself keeps the field name stable and
+        // confines compatibility logic to the value whose format changed.
+        Ok(
+            match <IconDisplayModeDeserialize as serde::Deserialize>::deserialize(deserializer)? {
+                IconDisplayModeDeserialize::Mode(IconDisplayModeName::Hidden) => Self::Hidden,
+                IconDisplayModeDeserialize::Mode(IconDisplayModeName::BothRows) => Self::BothRows,
+                IconDisplayModeDeserialize::Mode(IconDisplayModeName::FirstRow) => Self::FirstRow,
+                IconDisplayModeDeserialize::Legacy(false) => Self::Hidden,
+                IconDisplayModeDeserialize::Legacy(true) => Self::BothRows,
+            },
+        )
+    }
 }
 
 /// The state object describes the information to visualize for this component.
@@ -95,6 +141,8 @@ pub struct State {
     /// image cache. The image may be the empty image. This indicates that there
     /// is no icon.
     pub icon: ImageId,
+    /// Specifies how the segment icon should be displayed.
+    pub display_icon: IconDisplayMode,
     /// The color of the segment name if it's shown. If [`None`] is specified,
     /// the color is taken from the layout.
     pub segment_name_color: Option<Color>,
@@ -123,6 +171,7 @@ impl State {
         comparison_fingerprint(state, &self.comparison2);
         self.segment_name.hash(state);
         self.icon.hash(state);
+        self.display_icon.hash(state);
     }
 
     pub(crate) const fn updates_frequently(&self) -> bool {
@@ -189,7 +238,7 @@ impl Default for Settings {
                 color_override: Some(SEGMENT_TIMER_DEFAULT_COLOR),
                 ..Default::default()
             },
-            display_icon: false,
+            display_icon: IconDisplayMode::Hidden,
             show_segment_name: false,
             segment_name_color: None,
             comparison_names_color: None,
@@ -330,10 +379,11 @@ impl Component {
         };
 
         let icon = current_split
-            .filter(|_| self.settings.display_icon)
+            .filter(|_| self.settings.display_icon != IconDisplayMode::Hidden)
             .map(|s| s.icon())
             .unwrap_or(Image::EMPTY);
         state.icon = *image_cache.cache(icon.id(), || icon.clone()).id();
+        state.display_icon = self.settings.display_icon;
 
         self.timer
             .update_state(&mut state.timer, timer, layout_settings, lang);

--- a/src/component/detailed_timer/tests.rs
+++ b/src/component/detailed_timer/tests.rs
@@ -1,7 +1,7 @@
-use super::{Component, Settings};
+use super::{Component, IconDisplayMode, Settings};
 use crate::{
     GeneralLayoutSettings, Lang, Run, Segment, Timer,
-    settings::{Image, ImageCache},
+    settings::{Image, ImageCache, Value},
 };
 
 fn prepare() -> (Timer, Component, GeneralLayoutSettings, ImageCache) {
@@ -12,7 +12,7 @@ fn prepare() -> (Timer, Component, GeneralLayoutSettings, ImageCache) {
     let timer = Timer::new(run).unwrap();
 
     let component = Component::with_settings(Settings {
-        display_icon: true,
+        display_icon: IconDisplayMode::BothRows,
         show_segment_name: true,
         ..Default::default()
     });
@@ -224,4 +224,52 @@ fn stops_showing_icon_when_resetting() {
             .icon
             .is_empty()
     );
+}
+
+#[test]
+fn exposes_icon_display_mode_in_state() {
+    let (mut timer, mut component, layout_settings, mut image_cache) = prepare();
+    timer.start().unwrap();
+
+    // Setting indices are part of the generic component settings API. Keep
+    // this assertion on the generic path so layout editors are covered in
+    // addition to callers that modify the strongly typed settings directly.
+    component.set_value(20, Value::IconDisplayMode(IconDisplayMode::FirstRow));
+
+    let state = component.state(
+        &mut image_cache,
+        &timer.snapshot(),
+        &layout_settings,
+        Lang::English,
+    );
+    let description = component.settings_description(Lang::English);
+
+    assert_eq!(state.display_icon, IconDisplayMode::FirstRow);
+    assert!(matches!(
+        description.fields[20].value,
+        Value::IconDisplayMode(IconDisplayMode::FirstRow)
+    ));
+}
+
+#[test]
+fn deserializes_released_display_icon_setting() {
+    let hidden: Settings = serde_json::from_str(r#"{"display_icon":false}"#).unwrap();
+    let visible: Settings = serde_json::from_str(r#"{"display_icon":true}"#).unwrap();
+
+    assert_eq!(hidden.display_icon, IconDisplayMode::Hidden);
+    assert_eq!(visible.display_icon, IconDisplayMode::BothRows);
+}
+
+#[test]
+fn serializes_and_deserializes_display_icon_mode() {
+    let settings = Settings {
+        display_icon: IconDisplayMode::FirstRow,
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&settings).unwrap();
+    assert!(json.contains(r#""display_icon":"FirstRow""#));
+
+    let deserialized: Settings = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.display_icon, IconDisplayMode::FirstRow);
 }

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -2,7 +2,9 @@ use super::{
     DeltaGradientKind, GradientBuilder, Result, accuracy, color, comparison_override, end_tag,
     parse_bool, parse_children, text_parsed, timer_format, timing_method_override, translate_size,
 };
-use crate::{timing::formatter::DigitsFormat, util::xml::Reader};
+use crate::{
+    component::detailed_timer::IconDisplayMode, timing::formatter::DigitsFormat, util::xml::Reader,
+};
 
 pub use crate::component::detailed_timer::Component;
 
@@ -66,7 +68,13 @@ pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
                     color(reader, |v| settings.comparison_names_color = Some(v))
                 }
                 "SegmentTimesColor" => color(reader, |v| settings.comparison_times_color = Some(v)),
-                "DisplayIcon" => parse_bool(reader, |b| settings.display_icon = b),
+                "DisplayIcon" => parse_bool(reader, |display| {
+                    settings.display_icon = if display {
+                        IconDisplayMode::BothRows
+                    } else {
+                        IconDisplayMode::Hidden
+                    }
+                }),
                 "ShowSplitName" => parse_bool(reader, |b| settings.show_segment_name = b),
                 "SplitNameColor" => color(reader, |v| settings.segment_name_color = Some(v)),
                 "Comparison" => comparison_override(reader, |v| settings.comparison1 = v),

--- a/src/localization/brazilian_portuguese.rs
+++ b/src/localization/brazilian_portuguese.rs
@@ -398,7 +398,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Mostrar ícone",
         Text::DetailedTimerDisplayIconDescription => {
-            "Indica se o ícone do segmento deve ser exibido."
+            "Controla se o ícone do segmento fica oculto, ocupa as duas linhas ou apenas a primeira."
         }
         Text::SplitsBackground => "Fundo",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/chinese_simplified.rs
+++ b/src/localization/chinese_simplified.rs
@@ -287,7 +287,9 @@ pub const fn resolve(text: Text) -> &'static str {
             "显示分段名称时的颜色。如未指定则使用布局颜色。"
         }
         Text::DetailedTimerDisplayIcon => "显示图标",
-        Text::DetailedTimerDisplayIconDescription => "指定是否显示分段图标。",
+        Text::DetailedTimerDisplayIconDescription => {
+            "控制分段图标是隐藏、占用两行，还是仅占用第一行。"
+        }
         Text::SplitsBackground => "背景",
         Text::SplitsBackgroundDescription => {
             "组件背后的背景。可选择交替颜色；若启用，行会在两种颜色之间交替。"

--- a/src/localization/dutch.rs
+++ b/src/localization/dutch.rs
@@ -398,7 +398,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Icoon tonen",
         Text::DetailedTimerDisplayIconDescription => {
-            "Geeft aan of het segmenticoon getoond moet worden."
+            "Bepaalt of het segmenticoon verborgen is, beide rijen beslaat of alleen ruimte in de eerste rij inneemt."
         }
         Text::SplitsBackground => "Achtergrond",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/english.rs
+++ b/src/localization/english.rs
@@ -396,7 +396,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Display Icon",
         Text::DetailedTimerDisplayIconDescription => {
-            "Specifies whether the segment icon should be shown."
+            "Controls whether the segment icon is hidden, spans both rows, or only occupies the first row."
         }
         Text::SplitsBackground => "Background",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/french.rs
+++ b/src/localization/french.rs
@@ -406,7 +406,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Afficher l’icône",
         Text::DetailedTimerDisplayIconDescription => {
-            "Indique si l’icône du segment doit être affichée."
+            "Détermine si l’icône du segment est masquée, s’étend sur les deux lignes ou occupe uniquement la première."
         }
         Text::SplitsBackground => "Arrière-plan",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/german.rs
+++ b/src/localization/german.rs
@@ -422,7 +422,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Symbol anzeigen",
         Text::DetailedTimerDisplayIconDescription => {
-            "Legt fest, ob das Segmentsymbol angezeigt werden soll."
+            "Legt fest, ob das Segmentsymbol ausgeblendet wird, beide Zeilen überspannt oder nur die erste Zeile belegt."
         }
         Text::SplitsBackground => "Hintergrund",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/italian.rs
+++ b/src/localization/italian.rs
@@ -399,7 +399,9 @@ pub const fn resolve(text: Text) -> &'static str {
             "Il colore del nome del segmento se è mostrato. Se non specificato, viene usato il colore del layout."
         }
         Text::DetailedTimerDisplayIcon => "Mostra icona",
-        Text::DetailedTimerDisplayIconDescription => "Indica se mostrare l’icona del segmento.",
+        Text::DetailedTimerDisplayIconDescription => {
+            "Controlla se l’icona del segmento è nascosta, occupa entrambe le righe o soltanto la prima."
+        }
         Text::SplitsBackground => "Sfondo",
         Text::SplitsBackgroundDescription => {
             "Lo sfondo mostrato dietro il componente. È possibile scegliere colori alternati; in tal caso ogni riga alterna tra i due colori scelti."

--- a/src/localization/japanese.rs
+++ b/src/localization/japanese.rs
@@ -365,7 +365,9 @@ pub const fn resolve(text: Text) -> &'static str {
             "区間名を表示する場合の色。指定しない場合はレイアウトの色が使用されます。"
         }
         Text::DetailedTimerDisplayIcon => "アイコンを表示",
-        Text::DetailedTimerDisplayIconDescription => "区間アイコンを表示するかどうか。",
+        Text::DetailedTimerDisplayIconDescription => {
+            "区間アイコンを非表示にするか、両方の行に表示するか、最初の行のみに表示するかを設定します。"
+        }
         Text::SplitsBackground => "背景",
         Text::SplitsBackgroundDescription => {
             "コンポーネントの背景。交互色を選択すると、各行が2色で交互に表示されます。"

--- a/src/localization/korean.rs
+++ b/src/localization/korean.rs
@@ -359,7 +359,9 @@ pub const fn resolve(text: Text) -> &'static str {
             "세그먼트 이름을 표시할 때의 색상입니다. 지정하지 않으면 레이아웃의 색상을 사용합니다."
         }
         Text::DetailedTimerDisplayIcon => "아이콘 표시",
-        Text::DetailedTimerDisplayIconDescription => "세그먼트 아이콘을 표시할지 지정합니다.",
+        Text::DetailedTimerDisplayIconDescription => {
+            "세그먼트 아이콘을 숨길지, 두 행 모두에 표시할지, 첫 번째 행에만 표시할지 설정합니다."
+        }
         Text::SplitsBackground => "배경",
         Text::SplitsBackgroundDescription => {
             "컴포넌트 뒤에 표시되는 배경입니다. 교차 색상을 선택하면 각 줄이 두 색을 번갈아 사용합니다."

--- a/src/localization/polish.rs
+++ b/src/localization/polish.rs
@@ -385,7 +385,9 @@ pub const fn resolve(text: Text) -> &'static str {
             "Kolor nazwy segmentu, jeśli jest wyświetlana. Jeśli nie określono, kolor jest pobierany z układu."
         }
         Text::DetailedTimerDisplayIcon => "Wyświetl ikonę",
-        Text::DetailedTimerDisplayIconDescription => "Określa, czy wyświetlać ikonę segmentu.",
+        Text::DetailedTimerDisplayIconDescription => {
+            "Określa, czy ikona segmentu jest ukryta, zajmuje oba wiersze, czy tylko pierwszy."
+        }
         Text::SplitsBackground => "Tło",
         Text::SplitsBackgroundDescription => {
             "Tło wyświetlane za komponentem. Możesz wybrać kolory naprzemienne. W takim przypadku każdy wiersz naprzemiennie używa dwóch wybranych kolorów."

--- a/src/localization/portuguese.rs
+++ b/src/localization/portuguese.rs
@@ -398,7 +398,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Mostrar ícone",
         Text::DetailedTimerDisplayIconDescription => {
-            "Indica se o ícone do segmento deve ser exibido."
+            "Controla se o ícone do segmento fica oculto, ocupa ambas as linhas ou apenas a primeira."
         }
         Text::SplitsBackground => "Fundo",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/russian.rs
+++ b/src/localization/russian.rs
@@ -388,7 +388,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Показывать иконку",
         Text::DetailedTimerDisplayIconDescription => {
-            "Определяет, следует ли показывать иконку сегмента."
+            "Определяет, скрыта ли иконка сегмента, занимает ли она обе строки или только первую."
         }
         Text::SplitsBackground => "Фон",
         Text::SplitsBackgroundDescription => {

--- a/src/localization/spanish.rs
+++ b/src/localization/spanish.rs
@@ -398,7 +398,7 @@ pub const fn resolve(text: Text) -> &'static str {
         }
         Text::DetailedTimerDisplayIcon => "Mostrar icono",
         Text::DetailedTimerDisplayIconDescription => {
-            "Indica si debe mostrarse el icono del segmento."
+            "Controla si el icono del segmento se oculta, ocupa ambas filas o solo la primera."
         }
         Text::SplitsBackground => "Fondo",
         Text::SplitsBackgroundDescription => {

--- a/src/rendering/component/detailed_timer.rs
+++ b/src/rendering/component/detailed_timer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::detailed_timer::State,
+    component::detailed_timer::{IconDisplayMode, State},
     layout::LayoutState,
     rendering::{
         RenderContext,
@@ -45,19 +45,37 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
 ) {
     context.render_background([width, height], &component.background);
 
-    let vertical_padding = vertical_padding(height);
-    let icon_size = height - 2.0 * vertical_padding;
+    let total_height = component.timer.height + component.segment_timer.height;
+    let top_height = (component.timer.height as f32 / total_height as f32) * height;
+    let bottom_height = height - top_height;
 
-    let left_side = if let Some(icon) = context.create_image(&component.icon) {
-        context.render_image([PADDING, vertical_padding], [icon_size, icon_size], icon);
+    let icon_row_height = if component.display_icon == IconDisplayMode::FirstRow {
+        top_height
+    } else {
+        height
+    };
+    let icon_vertical_padding = vertical_padding(icon_row_height);
+    let icon_size = icon_row_height - 2.0 * icon_vertical_padding;
+
+    let segment_name_left_side = if let Some(icon) = context.create_image(&component.icon) {
+        context.render_image(
+            [PADDING, icon_vertical_padding],
+            [icon_size, icon_size],
+            icon,
+        );
         BOTH_PADDINGS + icon_size
     } else {
         PADDING
     };
 
-    let total_height = component.timer.height + component.segment_timer.height;
-    let top_height = (component.timer.height as f32 / total_height as f32) * height;
-    let bottom_height = height - top_height;
+    // The icon still shifts the segment name in the first row. When it is
+    // constrained to that row, however, the comparisons below it can reclaim
+    // the otherwise unused horizontal space.
+    let comparison_left_side = if component.display_icon == IconDisplayMode::FirstRow {
+        PADDING
+    } else {
+        segment_name_left_side
+    };
 
     let timer_end = timer::render(
         &mut cache.timer,
@@ -76,7 +94,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
         context.render_text_ellipsis(
             segment_name,
             &mut cache.segment_name,
-            [left_side, 0.6 * top_height],
+            [segment_name_left_side, 0.6 * top_height],
             0.5 * top_height,
             segment_name_color,
             timer_end,
@@ -110,7 +128,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             .render_text_ellipsis(
                 &comparison.name,
                 &mut cache.comparison2_name,
-                [left_side, comparison2_y],
+                [comparison_left_side, comparison2_y],
                 comparison_text_scale,
                 comparison_names_color,
                 segment_timer_end,
@@ -135,7 +153,7 @@ pub(in crate::rendering) fn render<A: ResourceAllocator>(
             .render_text_ellipsis(
                 &comparison.name,
                 &mut cache.comparison1_name,
-                [left_side, comparison1_y],
+                [comparison_left_side, comparison1_y],
                 comparison_text_scale,
                 comparison_names_color,
                 segment_timer_end,

--- a/src/settings/value.rs
+++ b/src/settings/value.rs
@@ -1,6 +1,7 @@
 use crate::{
     TimingMethod,
     component::{
+        detailed_timer::IconDisplayMode,
         splits::{ColumnStartWith, ColumnUpdateTrigger, ColumnUpdateWith, SubsplitDisplayMode},
         timer::DeltaGradient,
     },
@@ -68,6 +69,8 @@ pub enum Value {
     ColumnUpdateTrigger(ColumnUpdateTrigger),
     /// A value describing how native subsplits are displayed.
     SubsplitDisplayMode(SubsplitDisplayMode),
+    /// A value describing how the Detailed Timer Component's icon is displayed.
+    IconDisplayMode(IconDisplayMode),
     /// A value describing what hotkey to press to trigger a certain action.
     Hotkey(Option<Hotkey>),
     /// A value describing the direction of a layout.
@@ -187,6 +190,12 @@ impl From<ColumnUpdateTrigger> for Value {
 impl From<SubsplitDisplayMode> for Value {
     fn from(x: SubsplitDisplayMode) -> Self {
         Value::SubsplitDisplayMode(x)
+    }
+}
+
+impl From<IconDisplayMode> for Value {
+    fn from(x: IconDisplayMode) -> Self {
+        Value::IconDisplayMode(x)
     }
 }
 
@@ -386,6 +395,14 @@ impl Value {
         }
     }
 
+    /// Tries to convert the value into a Detailed Timer icon display mode.
+    pub fn into_icon_display_mode(self) -> Result<IconDisplayMode> {
+        match self {
+            Value::IconDisplayMode(v) => Ok(v),
+            _ => Err(Error::WrongType),
+        }
+    }
+
     /// Tries to convert the value into a hotkey.
     pub fn into_hotkey(self) -> Result<Option<Hotkey>> {
         match self {
@@ -548,6 +565,12 @@ impl From<Value> for ColumnUpdateTrigger {
 impl From<Value> for SubsplitDisplayMode {
     fn from(value: Value) -> Self {
         value.into_subsplit_display_mode().unwrap()
+    }
+}
+
+impl From<Value> for IconDisplayMode {
+    fn from(value: Value) -> Self {
+        value.into_icon_display_mode().unwrap()
     }
 }
 

--- a/tests/rendering.rs
+++ b/tests/rendering.rs
@@ -468,7 +468,7 @@ fn horizontal() {
     layout.push(component::separator::Component::new());
     layout.push(Box::new(
         component::detailed_timer::Component::with_settings(component::detailed_timer::Settings {
-            display_icon: true,
+            display_icon: component::detailed_timer::IconDisplayMode::BothRows,
             ..Default::default()
         }),
     ));
@@ -488,6 +488,32 @@ fn horizontal() {
         "23d8f03a5a08157e",
         "4d9aecef410a844f",
         "horizontal",
+    );
+}
+
+#[test]
+fn detailed_timer_icon_only_in_first_row() {
+    let run = lss(run_files::LIVESPLIT_1_0);
+    let mut timer = Timer::new(run).unwrap();
+    let mut layout = Layout::new();
+    layout.push(Box::new(
+        component::detailed_timer::Component::with_settings(component::detailed_timer::Settings {
+            display_icon: component::detailed_timer::IconDisplayMode::FirstRow,
+            show_segment_name: true,
+            ..Default::default()
+        }),
+    ));
+    timer.start().unwrap();
+
+    let mut image_cache = ImageCache::new();
+
+    check_dims(
+        &layout.state(&mut image_cache, &timer.snapshot(), Lang::English),
+        &image_cache,
+        [300, 100],
+        "b554096a2202f26a",
+        "7e6411c1b845d23a",
+        "detailed_timer_icon_only_in_first_row",
     );
 }
 


### PR DESCRIPTION
The Detailed Timer currently makes its segment icon span the full component, which also shifts comparison rows to the right. Add `IconDisplayMode` with `Hidden`, `BothRows`, and `FirstRow` so layouts can keep the segment name aligned with the icon while allowing comparisons to use the full width.

Keep the serialized setting name `display_icon` and deserialize its released boolean representation as `Hidden` or `BothRows`. Expose the typed value through settings metadata and the C API, update localized descriptions, and preserve LiveSplit XML compatibility.

Update the renderer and state bindings for the new mode, and cover the serialization migration and first-row rendering behavior. This implements [LiveSplit/livesplit-core#660](https://github.com/LiveSplit/livesplit-core/issues/660).