### PR TITLE
Store Auto Splitter Settings in Splits Files

### DIFF
--- a/capi/src/auto_splitting_runtime.rs
+++ b/capi/src/auto_splitting_runtime.rs
@@ -26,9 +26,15 @@ impl AutoSplittingRuntime {
         Err(())
     }
 
-    pub fn load(&self, _: PathBuf, _: SharedTimer) -> Result<(), ()> {
+    pub fn load(&self, _: SharedTimer) -> Result<Option<PathBuf>, ()> {
         Err(())
     }
+
+    pub fn load_from_path(&self, _: SharedTimer, _: PathBuf) -> Result<(), ()> {
+        Err(())
+    }
+
+    pub fn store_settings(&self) {}
 }
 
 /// type
@@ -50,8 +56,24 @@ pub unsafe extern "C" fn AutoSplittingRuntime_load(
     shared_timer: OwnedSharedTimer,
 ) -> bool {
     // SAFETY: The caller guarantees that `path` is valid.
-    this.load(PathBuf::from(unsafe { str(path) }), *shared_timer)
+    this.load_from_path(*shared_timer, PathBuf::from(unsafe { str(path) }))
         .is_ok()
+}
+
+/// Attempts to load the auto splitter configured in the timer's run. Returns
+/// true if successful.
+#[unsafe(no_mangle)]
+pub extern "C" fn AutoSplittingRuntime_load_from_timer(
+    this: &AutoSplittingRuntime,
+    shared_timer: OwnedSharedTimer,
+) -> bool {
+    this.load(*shared_timer).is_ok()
+}
+
+/// Stores the loaded auto splitter's path and settings in the timer's run.
+#[unsafe(no_mangle)]
+pub extern "C" fn AutoSplittingRuntime_store_settings(this: &AutoSplittingRuntime) {
+    this.store_settings();
 }
 
 /// Attempts to unload the auto splitter. Returns true if successful.

--- a/capi/src/auto_splitting_runtime.rs
+++ b/capi/src/auto_splitting_runtime.rs
@@ -6,7 +6,6 @@ use crate::shared_timer::OwnedSharedTimer;
 use std::{os::raw::c_char, path::PathBuf};
 
 type AutoSplittingRuntime = livesplit_core::auto_splitting::Runtime<livesplit_core::SharedTimer>;
-
 /// type
 pub type OwnedAutoSplittingRuntime = Box<AutoSplittingRuntime>;
 /// type
@@ -26,8 +25,24 @@ pub unsafe extern "C" fn AutoSplittingRuntime_load(
     shared_timer: OwnedSharedTimer,
 ) -> bool {
     // SAFETY: The caller guarantees that `path` is valid.
-    this.load(PathBuf::from(unsafe { str(path) }), *shared_timer)
+    this.load_from_path(*shared_timer, PathBuf::from(unsafe { str(path) }))
         .is_ok()
+}
+
+/// Attempts to load the auto splitter configured in the timer's run. Returns
+/// true if successful.
+#[unsafe(no_mangle)]
+pub extern "C" fn AutoSplittingRuntime_load_from_timer(
+    this: &AutoSplittingRuntime,
+    shared_timer: OwnedSharedTimer,
+) -> bool {
+    this.load(*shared_timer).is_ok()
+}
+
+/// Stores the loaded auto splitter's path and settings in the timer's run.
+#[unsafe(no_mangle)]
+pub extern "C" fn AutoSplittingRuntime_store_settings(this: &AutoSplittingRuntime) {
+    this.store_settings();
 }
 
 /// Attempts to unload the auto splitter. Returns true if successful.

--- a/capi/src/command_sink.rs
+++ b/capi/src/command_sink.rs
@@ -11,7 +11,7 @@
 use std::{borrow::Cow, future::Future, ops::Deref, pin::Pin, sync::Arc};
 
 use livesplit_core::{
-    TimeSpan, Timer, TimingMethod,
+    StoredAutoSplitterSettings, TimeSpan, Timer, TimingMethod,
     event::{self, Result},
 };
 
@@ -59,6 +59,7 @@ pub(crate) trait CommandSinkAndQuery: Send + Sync + 'static {
     fn dyn_resume_game_time(&self) -> Fut;
     fn dyn_set_loading_times(&self, time: TimeSpan) -> Fut;
     fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut;
+    fn dyn_set_auto_splitter_settings(&self, settings: StoredAutoSplitterSettings) -> Fut;
 }
 
 type Fut = Pin<Box<dyn Future<Output = Result> + 'static>>;
@@ -133,6 +134,9 @@ where
     }
     fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut {
         Box::pin(self.set_custom_variable(name, value))
+    }
+    fn dyn_set_auto_splitter_settings(&self, settings: StoredAutoSplitterSettings) -> Fut {
+        Box::pin(self.set_auto_splitter_settings(settings))
     }
 }
 
@@ -229,6 +233,13 @@ impl event::CommandSink for CommandSink {
         value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         self.0.dyn_set_custom_variable(name, value)
+    }
+
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static {
+        self.0.dyn_set_auto_splitter_settings(settings)
     }
 }
 

--- a/capi/src/command_sink.rs
+++ b/capi/src/command_sink.rs
@@ -11,7 +11,7 @@
 use std::{borrow::Cow, future::Future, ops::Deref, pin::Pin, sync::Arc};
 
 use livesplit_core::{
-    TimeSpan, Timer, TimingMethod,
+    StoredAutoSplitterSettings, TimeSpan, Timer, TimingMethod,
     event::{self, Result},
 };
 
@@ -61,6 +61,7 @@ pub(crate) trait CommandSinkAndQuery: Send + Sync + 'static {
     fn dyn_resume_game_time(&self) -> Fut;
     fn dyn_set_loading_times(&self, time: TimeSpan) -> Fut;
     fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut;
+    fn dyn_set_auto_splitter_settings(&self, settings: StoredAutoSplitterSettings) -> Fut;
 }
 
 type Fut = Pin<Box<dyn Future<Output = Result> + 'static>>;
@@ -135,6 +136,9 @@ where
     }
     fn dyn_set_custom_variable(&self, name: Cow<str>, value: Cow<str>) -> Fut {
         Box::pin(self.set_custom_variable(name, value))
+    }
+    fn dyn_set_auto_splitter_settings(&self, settings: StoredAutoSplitterSettings) -> Fut {
+        Box::pin(self.set_auto_splitter_settings(settings))
     }
 }
 
@@ -231,6 +235,13 @@ impl event::CommandSink for CommandSink {
         value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         self.0.dyn_set_custom_variable(name, value)
+    }
+
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static {
+        self.0.dyn_set_auto_splitter_settings(settings)
     }
 }
 

--- a/capi/src/web_command_sink.rs
+++ b/capi/src/web_command_sink.rs
@@ -5,7 +5,7 @@
 use std::{borrow::Cow, cell::Cell, convert::TryFrom, future::Future, sync::Arc};
 
 use livesplit_core::{
-    TimeSpan, Timer, TimingMethod,
+    StoredAutoSplitterSettings, TimeSpan, Timer, TimingMethod,
     event::{CommandSink, Error, Event, Result, TimerQuery},
 };
 use wasm_bindgen::prelude::*;
@@ -41,6 +41,7 @@ pub struct WebCommandSink {
     resume_game_time: Option<Function>,
     set_loading_times: Option<Function>,
     set_custom_variable: Option<Function>,
+    set_auto_splitter_settings: Option<Function>,
 
     get_timer: Function,
     locked: Cell<bool>,
@@ -73,6 +74,7 @@ impl WebCommandSink {
             resume_game_time: get_func(&obj, "resumeGameTime"),
             set_loading_times: get_func(&obj, "setLoadingTimes"),
             set_custom_variable: get_func(&obj, "setCustomVariable"),
+            set_auto_splitter_settings: get_func(&obj, "setAutoSplitterSettings"),
 
             get_timer: get_func(&obj, "getTimer").unwrap(),
             locked: Cell::new(false),
@@ -315,6 +317,25 @@ impl CommandSink for WebCommandSink {
             )
             .ok()
         }))
+    }
+
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static {
+        debug_assert!(!self.locked.get());
+        #[cfg(feature = "auto-splitting")]
+        let settings = JsValue::from_str(&settings.to_xml_string());
+        #[cfg(not(feature = "auto-splitting"))]
+        let settings = {
+            drop(settings);
+            JsValue::UNDEFINED
+        };
+        handle_action_value(
+            self.set_auto_splitter_settings
+                .as_ref()
+                .and_then(|f| f.call1(&self.obj, &settings).ok()),
+        )
     }
 }
 

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -51,7 +51,7 @@ pub enum WidgetKind {
 }
 
 /// A filter for a file selection setting.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum FileFilter {
     /// A filter that matches on the name of the file.
     Name {

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -566,6 +566,7 @@
 use crate::{
     event::{self, TimerQuery},
     platform::Arc,
+    run::{StoredAutoSplitterSettings, StoredAutoSplitterSettingsParseError},
     timing::TimerPhase,
 };
 use arc_swap::ArcSwapOption;
@@ -576,7 +577,7 @@ pub use livesplit_auto_splitting::{settings, wasi_path};
 use snafu::Snafu;
 use std::{
     fmt, fs, io,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Condvar, Mutex,
         mpsc::{self, Receiver, RecvTimeoutError, Sender},
@@ -604,20 +605,27 @@ pub enum Error {
     },
     /// Failed reading the auto splitter settings.
     SettingsLoadFailed,
+    /// Failed parsing the auto splitter settings stored in the splits file.
+    StoredSettingsLoadFailed {
+        /// The underlying parsing error.
+        source: StoredAutoSplitterSettingsParseError,
+    },
     /// The asked setting was not found.
     SettingNotFound,
 }
 
 /// An auto splitter runtime that allows using an auto splitter provided as a
 /// WebAssembly module to control a timer.
-pub struct Runtime<T: event::CommandSink + TimerQuery + Send + 'static> {
+pub struct Runtime<T: event::CommandSink + TimerQuery + Send + Sync + 'static> {
     shared_state: Arc<SharedState<T>>,
     changed_sender: Sender<()>,
     runtime: livesplit_auto_splitting::Runtime,
+    loaded_path: ArcSwapOption<PathBuf>,
+    timer: ArcSwapOption<T>,
 }
 
 struct SharedState<T: 'static> {
-    auto_splitter: ArcSwapOption<AutoSplitter<Timer<T>>>,
+    auto_splitter: ArcSwapOption<AutoSplitter<Timer<Arc<T>>>>,
     watchdog_state: Mutex<WatchdogState>,
     watchdog_state_update: Condvar,
 }
@@ -636,7 +644,7 @@ impl<T> SharedState<T> {
     }
 }
 
-impl<T: event::CommandSink + TimerQuery + Send + 'static> Drop for Runtime<T> {
+impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Drop for Runtime<T> {
     fn drop(&mut self) {
         let _ = self.shared_state.update_watchdog(WatchdogState::Shutdown);
         if let Some(auto_splitter) = &*self.shared_state.auto_splitter.load() {
@@ -646,13 +654,13 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Drop for Runtime<T> {
     }
 }
 
-impl<T: event::CommandSink + TimerQuery + Send + 'static> Default for Runtime<T> {
+impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Default for Runtime<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
+impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Runtime<T> {
     /// Starts the runtime. Doesn't actually load an auto splitter until
     /// [`load`][Runtime::load] is called.
     pub fn new() -> Self {
@@ -688,23 +696,89 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
             changed_sender,
             // TODO: unwrap?
             runtime: livesplit_auto_splitting::Runtime::new(Config::default()).unwrap(),
+            loaded_path: ArcSwapOption::from(None),
+            timer: ArcSwapOption::from(None),
         }
     }
 
-    /// Attempts to load a wasm file containing an auto splitter module.
-    pub fn load(&self, path: PathBuf, timer: T) -> Result<(), Error> {
-        let data = fs::read(path).map_err(|e| Error::ReadFileFailed { source: e })?;
+    /// Attempts to load a WebAssembly file containing an auto splitter module
+    /// from the specified path.
+    ///
+    /// The settings stored in the timer's run are passed to the auto splitter
+    /// during instantiation. Settings without a stored script path are accepted
+    /// for compatibility with frontends that provide a fixed script externally.
+    /// When a path is stored, it needs to match `path` so settings from a
+    /// previously selected auto splitter are not applied to a different one.
+    pub fn load_from_path(&self, timer: T, path: PathBuf) -> Result<(), Error> {
+        let timer = Arc::new(timer);
+        self.timer.store(Some(timer.clone()));
+        self.unload()?;
+
+        let settings_map = {
+            let timer = timer.get_timer();
+            settings_map_for_path(timer.run(), &path)
+                .map_err(|source| Error::StoredSettingsLoadFailed { source })?
+        };
+
+        self.load_with_settings(timer, path, settings_map)
+    }
+
+    /// Loads the auto splitter configured in the timer's run together with its
+    /// stored settings. If no script path is configured, the currently loaded
+    /// auto splitter is unloaded and [`None`] is returned.
+    ///
+    /// This is the preferred entry point when a frontend opens or replaces a
+    /// splits file, as it keeps parsing, unloading, and instantiation entirely
+    /// within livesplit-core.
+    pub fn load(&self, timer: T) -> Result<Option<PathBuf>, Error> {
+        let timer = Arc::new(timer);
+        self.timer.store(Some(timer.clone()));
+        self.unload()?;
+
+        let stored_settings = {
+            let timer = timer.get_timer();
+            timer
+                .run()
+                .stored_auto_splitter_settings()
+                .map_err(|source| Error::StoredSettingsLoadFailed { source })?
+        };
+
+        let path = stored_settings
+            .script_path()
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from);
+        let settings_map = (!stored_settings.settings_map().is_empty())
+            .then(|| stored_settings.into_settings_map());
+
+        // A run's selection is authoritative. In particular, a missing or
+        // invalid replacement must not leave the previous run's module active.
+        let Some(path) = path else {
+            return Ok(None);
+        };
+
+        self.load_with_settings(timer, path.clone(), settings_map)?;
+        Ok(Some(path))
+    }
+
+    fn load_with_settings(
+        &self,
+        timer: Arc<T>,
+        path: PathBuf,
+        settings_map: Option<settings::Map>,
+    ) -> Result<(), Error> {
+        let data = fs::read(&path).map_err(|e| Error::ReadFileFailed { source: e })?;
 
         let auto_splitter = self
             .runtime
             .compile(&data)
             .map_err(|e| Error::LoadFailed { source: e })?
-            .instantiate(Timer(timer), None, None)
+            .instantiate(Timer(timer), settings_map, None)
             .map_err(|e| Error::LoadFailed { source: e })?;
 
         self.shared_state
             .auto_splitter
             .store(Some(Arc::new(auto_splitter)));
+        self.loaded_path.store(Some(Arc::new(path)));
 
         self.changed_sender
             .send(())
@@ -716,10 +790,41 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
     /// thread stops unexpectedly.
     pub fn unload(&self) -> Result<(), Error> {
         self.shared_state.auto_splitter.store(None);
+        self.loaded_path.store(None);
 
         self.changed_sender
             .send(())
             .map_err(|_| Error::ThreadStopped)
+    }
+
+    /// Returns the path of the currently loaded auto splitter.
+    pub fn loaded_path(&self) -> Option<PathBuf> {
+        self.loaded_path.load_full().as_deref().cloned()
+    }
+
+    /// Stores the currently loaded auto splitter path and its live settings map
+    /// in the run of the timer provided to [`load`](Self::load) or
+    /// [`load_from_path`](Self::load_from_path).
+    ///
+    /// Frontends should call this before saving splits and whenever they want
+    /// the active run to reflect runtime-side setting changes. If no auto
+    /// splitter is loaded, any previously stored path and settings are cleared.
+    pub fn store_settings(&self) {
+        let Some(timer) = self.timer.load_full() else {
+            return;
+        };
+
+        let mut stored_settings = StoredAutoSplitterSettings::new();
+        stored_settings.set_script_path(
+            self.loaded_path()
+                .map(|path| path.to_string_lossy().into_owned()),
+        );
+
+        if let Some(settings_map) = self.settings_map().filter(|map| !map.is_empty()) {
+            stored_settings.set_settings_map(settings_map);
+        }
+
+        drop(timer.set_auto_splitter_settings(stored_settings));
     }
 
     /// Accesses a copy of the currently stored settings. The auto splitter can
@@ -782,6 +887,148 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
                 .as_ref()?
                 .settings_widgets(),
         )
+    }
+}
+
+fn settings_map_for_path(
+    run: &crate::Run,
+    path: &Path,
+) -> Result<Option<settings::Map>, StoredAutoSplitterSettingsParseError> {
+    let stored_settings = run.stored_auto_splitter_settings()?;
+    let belongs_to_path = stored_settings
+        .script_path()
+        .is_none_or(|stored_path| Path::new(stored_path) == path);
+
+    Ok(
+        (belongs_to_path && !stored_settings.settings_map().is_empty())
+            .then(|| stored_settings.into_settings_map()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SCRIPT_PATH: &str = "Auto Splitters/Game.wasm";
+
+    #[test]
+    fn stored_settings_are_only_loaded_for_their_script() {
+        let mut run = crate::Run::new();
+        let mut stored_settings = StoredAutoSplitterSettings::new();
+        stored_settings.set_script_path(Some(SCRIPT_PATH));
+
+        let mut settings_map = settings::Map::new();
+        settings_map.insert("enabled".into(), settings::Value::Bool(true));
+        stored_settings.set_settings_map(settings_map.clone());
+        run.set_stored_auto_splitter_settings(&stored_settings);
+
+        assert_eq!(
+            settings_map_for_path(&run, Path::new(SCRIPT_PATH)).unwrap(),
+            Some(settings_map)
+        );
+        assert_eq!(
+            settings_map_for_path(&run, Path::new("Auto Splitters/Other.wasm")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn settings_without_a_script_path_support_fixed_script_frontends() {
+        let mut run = crate::Run::new();
+        let mut stored_settings = StoredAutoSplitterSettings::new();
+        let mut settings_map = settings::Map::new();
+        settings_map.insert("enabled".into(), settings::Value::Bool(true));
+        stored_settings.set_settings_map(settings_map.clone());
+        run.set_stored_auto_splitter_settings(&stored_settings);
+
+        assert_eq!(
+            settings_map_for_path(&run, Path::new(SCRIPT_PATH)).unwrap(),
+            Some(settings_map)
+        );
+    }
+
+    #[test]
+    fn foreign_operating_system_paths_do_not_match_local_paths() {
+        let paths = [
+            (
+                r"C:\Auto Splitters\Game.wasm",
+                "/home/runner/auto-splitters/Game.wasm",
+            ),
+            (
+                "/home/runner/auto-splitters/Game.wasm",
+                r"C:\Auto Splitters\Game.wasm",
+            ),
+        ];
+
+        for (stored_path, local_path) in paths {
+            let mut run = crate::Run::new();
+            let mut stored_settings = StoredAutoSplitterSettings::new();
+            stored_settings.set_script_path(Some(stored_path));
+
+            let mut settings_map = settings::Map::new();
+            settings_map.insert("enabled".into(), settings::Value::Bool(true));
+            stored_settings.set_settings_map(settings_map);
+            run.set_stored_auto_splitter_settings(&stored_settings);
+
+            // A path from another operating system cannot identify the local
+            // script, so its settings must not leak into the replacement.
+            assert_eq!(
+                settings_map_for_path(&run, Path::new(local_path)).unwrap(),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn foreign_operating_system_script_path_is_reported_as_load_error() {
+        let foreign_path = if cfg!(windows) {
+            "/home/__livesplit_foreign_path_test__/missing.wasm"
+        } else {
+            r"Z:\__livesplit_foreign_path_test__\missing.wasm"
+        };
+
+        let mut run = crate::Run::new();
+        run.push_segment(crate::Segment::new("Segment"));
+        let mut stored_settings = StoredAutoSplitterSettings::new();
+        stored_settings.set_script_path(Some(foreign_path));
+        run.set_stored_auto_splitter_settings(&stored_settings);
+
+        let timer = crate::Timer::new(run).unwrap().into_shared();
+        let runtime = Runtime::new();
+
+        assert!(matches!(
+            runtime.load(timer),
+            Err(Error::ReadFileFailed { .. })
+        ));
+        assert_eq!(runtime.loaded_path(), None);
+    }
+
+    #[test]
+    fn runtime_stores_settings_in_the_timer_it_loaded() {
+        let mut run = crate::Run::new();
+        run.push_segment(crate::Segment::new("Segment"));
+
+        let mut stored_settings = StoredAutoSplitterSettings::new();
+        let mut settings_map = settings::Map::new();
+        settings_map.insert("enabled".into(), settings::Value::Bool(true));
+        stored_settings.set_settings_map(settings_map);
+        run.set_stored_auto_splitter_settings(&stored_settings);
+
+        let timer = crate::Timer::new(run).unwrap().into_shared();
+        let runtime = Runtime::new();
+
+        assert_eq!(runtime.load(timer.clone()).unwrap(), None);
+        runtime.store_settings();
+
+        assert!(
+            timer
+                .read()
+                .unwrap()
+                .run()
+                .stored_auto_splitter_settings()
+                .unwrap()
+                .is_empty()
+        );
     }
 }
 
@@ -870,7 +1117,7 @@ impl<E: event::CommandSink + TimerQuery + Send + 'static> AutoSplitTimer for Tim
     }
 }
 
-fn run<T: event::CommandSink + TimerQuery + Send>(
+fn run<T: event::CommandSink + TimerQuery + Send + Sync>(
     shared_state: Arc<SharedState<T>>,
     changed_receiver: Receiver<()>,
 ) {
@@ -949,7 +1196,7 @@ fn run<T: event::CommandSink + TimerQuery + Send>(
     }
 }
 
-fn watchdog<T: event::CommandSink + TimerQuery + Send>(shared_state: Arc<SharedState<T>>) {
+fn watchdog<T: event::CommandSink + TimerQuery + Send + Sync>(shared_state: Arc<SharedState<T>>) {
     const TIMEOUT: Duration = Duration::from_secs(5);
     let mut has_timed_out = false;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,7 +13,7 @@ use core::{future::Future, ops::Deref};
 
 use alloc::{borrow::Cow, sync::Arc};
 
-use crate::{TimeSpan, Timer, TimingMethod};
+use crate::{StoredAutoSplitterSettings, TimeSpan, Timer, TimingMethod};
 
 /// An event informs you about a change in the timer.
 #[derive(
@@ -59,6 +59,8 @@ pub enum Event {
     LoadingTimesSet = 16,
     /// A custom variable has been set.
     CustomVariableSet = 17,
+    /// The Auto Splitter Settings stored in the run have been changed.
+    AutoSplitterSettingsChanged = 18,
     /// An unknown event occurred.
     #[serde(other)]
     Unknown,
@@ -85,6 +87,7 @@ impl From<u32> for Event {
             15 => Event::GameTimeResumed,
             16 => Event::LoadingTimesSet,
             17 => Event::CustomVariableSet,
+            18 => Event::AutoSplitterSettingsChanged,
             _ => Event::Unknown,
         }
     }
@@ -276,6 +279,15 @@ pub trait CommandSink {
         name: Cow<str>,
         value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static;
+    /// Stores the Auto Splitter Settings in the timer's run.
+    ///
+    /// The payload is empty in builds without the `auto-splitting` feature.
+    /// Keeping this command available in all builds ensures that enabling the
+    /// feature does not change the shape of this trait.
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static;
 }
 
 /// This trait provides functionality for querying information from the timer.
@@ -405,6 +417,16 @@ impl CommandSink for crate::SharedTimer {
         self.write().unwrap().set_custom_variable(name, value);
         async { Ok(Event::CustomVariableSet) }
     }
+
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static {
+        self.write()
+            .unwrap()
+            .set_stored_auto_splitter_settings(&settings);
+        async { Ok(Event::AutoSplitterSettingsChanged) }
+    }
 }
 
 #[cfg(feature = "std")]
@@ -508,6 +530,13 @@ impl<T: CommandSink + ?Sized> CommandSink for Arc<T> {
         value: Cow<str>,
     ) -> impl Future<Output = Result> + 'static {
         CommandSink::set_custom_variable(&**self, name, value)
+    }
+
+    fn set_auto_splitter_settings(
+        &self,
+        settings: StoredAutoSplitterSettings,
+    ) -> impl Future<Output = Result> + 'static {
+        CommandSink::set_auto_splitter_settings(&**self, settings)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,10 @@ pub use crate::{
 };
 pub use livesplit_hotkey as hotkey;
 
+pub use crate::run::StoredAutoSplitterSettings;
+#[cfg(feature = "auto-splitting")]
+pub use crate::run::StoredAutoSplitterSettingsParseError;
+
 #[cfg(not(feature = "std"))]
 pub use crate::platform::{Clock, Duration, register_clock};
 

--- a/src/networking/therun_gg.rs
+++ b/src/networking/therun_gg.rs
@@ -147,6 +147,7 @@ impl Client {
             | Event::GameTimeResumed
             | Event::LoadingTimesSet
             | Event::CustomVariableSet
+            | Event::AutoSplitterSettingsChanged
             | Event::Unknown => return None,
         };
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -24,6 +24,8 @@ pub mod saver;
 mod segment;
 mod segment_groups;
 mod segment_history;
+#[cfg(feature = "auto-splitting")]
+mod stored_auto_splitter_settings;
 
 #[cfg(test)]
 mod tests;
@@ -39,6 +41,33 @@ pub use segment_groups::{
     SegmentGroups, SegmentGroupsIter,
 };
 pub use segment_history::SegmentHistory;
+#[cfg(feature = "auto-splitting")]
+pub use stored_auto_splitter_settings::{
+    StoredAutoSplitterSettings, StoredAutoSplitterSettingsParseError,
+};
+
+/// An empty Auto Splitter Settings payload for builds without auto splitting.
+///
+/// The type remains available so enabling the `auto-splitting` feature does
+/// not change traits that transport this payload. Its structured contents and
+/// associated APIs are only available when that feature is enabled.
+#[cfg(not(feature = "auto-splitting"))]
+#[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub struct StoredAutoSplitterSettings {}
+
+#[cfg(not(feature = "auto-splitting"))]
+impl StoredAutoSplitterSettings {
+    /// Creates an empty settings payload.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {}
+    }
+
+    const fn to_xml_string(&self) -> String {
+        String::new()
+    }
+}
 
 use crate::{
     AtomicDateTime, Time, TimeSpan, TimingMethod,
@@ -393,6 +422,35 @@ impl Run {
     #[inline]
     pub const fn auto_splitter_settings_mut(&mut self) -> &mut String {
         &mut self.auto_splitter_settings
+    }
+
+    /// Parses the stored Auto Splitter Settings into the ASR-compatible
+    /// structure used by the LiveSplit desktop component. This is the
+    /// structured counterpart to the raw XML accessors above and is intended
+    /// for tools that want to persist the selected auto splitter path together
+    /// with its custom settings inside the splits file itself.
+    #[cfg(feature = "auto-splitting")]
+    #[inline]
+    pub fn stored_auto_splitter_settings(
+        &self,
+    ) -> Result<StoredAutoSplitterSettings, StoredAutoSplitterSettingsParseError> {
+        StoredAutoSplitterSettings::parse(self.auto_splitter_settings())
+    }
+
+    /// Stores the ASR-compatible Auto Splitter Settings into the raw XML field
+    /// that is serialized as `<AutoSplitterSettings>...</AutoSplitterSettings>`
+    /// in LiveSplit splits files.
+    ///
+    /// The run is marked as modified when the serialized representation
+    /// changes, because these settings now materially belong to the splits file
+    /// and should therefore participate in normal save prompts.
+    #[inline]
+    pub fn set_stored_auto_splitter_settings(&mut self, settings: &StoredAutoSplitterSettings) {
+        let next_settings = settings.to_xml_string();
+        if self.auto_splitter_settings != next_settings {
+            self.auto_splitter_settings = next_settings;
+            self.mark_as_modified();
+        }
     }
 
     /// Accesses the [`LinkedLayout`] of this `Run`. If a

--- a/src/run/stored_auto_splitter_settings.rs
+++ b/src/run/stored_auto_splitter_settings.rs
@@ -1,0 +1,445 @@
+use crate::{
+    auto_splitting::settings::{
+        List as AutoSplitterSettingsList, Map as AutoSplitterSettingsMap,
+        Value as AutoSplitterSettingValue,
+    },
+    platform::prelude::*,
+    util::xml::{
+        DisplayAlreadyEscaped, NO_ATTRIBUTES, Reader, Writer,
+        helper::{
+            Error as XmlError, attribute, end_tag, parse_base, parse_children, text,
+            text_as_escaped_string_err,
+        },
+    },
+};
+use alloc::{format, string::String};
+use core::fmt;
+
+/// The ASR-compatible Auto Splitter Settings stored inside a LiveSplit splits
+/// file.
+///
+/// LiveSplit's Auto Splitting Runtime persists both the script path and a
+/// recursively typed `CustomSettings` payload inside the splits file. This
+/// type intentionally uses the auto splitting runtime's settings map directly:
+/// the structured representation is only available with the `auto-splitting`
+/// feature, while builds without that feature continue to preserve the raw XML
+/// through [`crate::Run::auto_splitter_settings`].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct StoredAutoSplitterSettings {
+    script_path: Option<String>,
+    settings_map: AutoSplitterSettingsMap,
+}
+
+impl StoredAutoSplitterSettings {
+    const FORMAT_VERSION: &str = "1.0";
+
+    /// Creates an empty settings payload.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            script_path: None,
+            settings_map: AutoSplitterSettingsMap::new(),
+        }
+    }
+
+    /// Returns the stored auto splitter path, if one is configured.
+    #[inline]
+    pub fn script_path(&self) -> Option<&str> {
+        self.script_path.as_deref()
+    }
+
+    /// Sets the stored auto splitter path.
+    #[inline]
+    pub fn set_script_path<S>(&mut self, script_path: Option<S>)
+    where
+        S: Into<String>,
+    {
+        self.script_path = script_path.map(Into::into);
+    }
+
+    /// Accesses the stored custom settings map.
+    #[inline]
+    pub const fn settings_map(&self) -> &AutoSplitterSettingsMap {
+        &self.settings_map
+    }
+
+    /// Grants mutable access to the stored custom settings map.
+    #[inline]
+    pub const fn settings_map_mut(&mut self) -> &mut AutoSplitterSettingsMap {
+        &mut self.settings_map
+    }
+
+    /// Replaces the stored custom settings map.
+    #[inline]
+    pub fn set_settings_map(&mut self, settings_map: AutoSplitterSettingsMap) {
+        self.settings_map = settings_map;
+    }
+
+    /// Takes ownership of the stored custom settings map.
+    #[inline]
+    pub fn into_settings_map(self) -> AutoSplitterSettingsMap {
+        self.settings_map
+    }
+
+    /// Returns whether both the script path and the stored custom settings are
+    /// empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.script_path.is_none() && self.settings_map.is_empty()
+    }
+
+    /// Parses the XML contents stored inside a LiveSplit
+    /// `<AutoSplitterSettings>` element.
+    pub fn parse(source: &str) -> Result<Self, StoredAutoSplitterSettingsParseError> {
+        if source.trim().is_empty() {
+            return Ok(Self::new());
+        }
+
+        // The splits parser exposes the interior of the
+        // `<AutoSplitterSettings>` element. Wrapping it in the outer tag lets
+        // this structured, opt-in parser reuse the existing XML reader without
+        // changing the lossless raw-XML behavior of the normal splits parser.
+        let wrapped = format!("<AutoSplitterSettings>{source}</AutoSplitterSettings>");
+        let mut reader = Reader::new(&wrapped);
+        let mut settings = Self::new();
+
+        parse_base(&mut reader, "AutoSplitterSettings", |reader, _| {
+            parse_children(reader, |reader, tag, _| match tag.name() {
+                "Version" => end_tag::<StoredAutoSplitterSettingsParseError>(reader),
+                "ScriptPath" => text(reader, |path| {
+                    settings.script_path = Some(path.into_owned())
+                }),
+                "CustomSettings" => {
+                    settings.settings_map = parse_settings_map(reader)?;
+                    Ok(())
+                }
+                _ => end_tag::<StoredAutoSplitterSettingsParseError>(reader),
+            })
+        })?;
+
+        Ok(settings)
+    }
+
+    /// Serializes the settings into the XML contents expected inside a
+    /// LiveSplit `<AutoSplitterSettings>` element.
+    pub fn write_xml<W: fmt::Write>(&self, writer: W) -> fmt::Result {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let writer = &mut Writer::new_skip_header(writer);
+        writer.tag_with_text_content("Version", NO_ATTRIBUTES, Self::FORMAT_VERSION)?;
+
+        if let Some(script_path) = self.script_path() {
+            writer.tag_with_text_content("ScriptPath", NO_ATTRIBUTES, script_path)?;
+        }
+
+        writer.tag_with_content("CustomSettings", NO_ATTRIBUTES, |writer| {
+            write_settings_map(writer, &self.settings_map)
+        })?;
+
+        Ok(())
+    }
+
+    /// Serializes the settings into a string suitable for
+    /// [`crate::Run::auto_splitter_settings_mut`].
+    pub fn to_xml_string(&self) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+
+        let mut output = String::new();
+        self.write_xml(&mut output)
+            .expect("writing supported auto splitter setting values to a string should not fail");
+        output
+    }
+}
+
+fn parse_settings_map(
+    reader: &mut Reader<'_>,
+) -> Result<AutoSplitterSettingsMap, StoredAutoSplitterSettingsParseError> {
+    let mut map = AutoSplitterSettingsMap::new();
+
+    parse_children(reader, |reader, tag, attributes| {
+        ensure_setting_element(tag.name())?;
+
+        let mut id = None;
+        attribute::<_, StoredAutoSplitterSettingsParseError>(attributes, "id", |value| {
+            id = Some(value.into_owned())
+        })?;
+        let id = id.ok_or(StoredAutoSplitterSettingsParseError::MissingIdAttribute)?;
+
+        map.insert(id.into(), parse_setting_value(reader, attributes)?);
+        Ok::<_, StoredAutoSplitterSettingsParseError>(())
+    })?;
+
+    Ok(map)
+}
+
+fn parse_settings_list(
+    reader: &mut Reader<'_>,
+) -> Result<AutoSplitterSettingsList, StoredAutoSplitterSettingsParseError> {
+    let mut list = AutoSplitterSettingsList::new();
+
+    parse_children(reader, |reader, tag, attributes| {
+        ensure_setting_element(tag.name())?;
+        list.push(parse_setting_value(reader, attributes)?);
+        Ok::<_, StoredAutoSplitterSettingsParseError>(())
+    })?;
+
+    Ok(list)
+}
+
+fn ensure_setting_element(name: &str) -> Result<(), StoredAutoSplitterSettingsParseError> {
+    if name == "Setting" {
+        Ok(())
+    } else {
+        Err(StoredAutoSplitterSettingsParseError::UnexpectedElement {
+            name: name.to_owned(),
+        })
+    }
+}
+
+fn parse_setting_value(
+    reader: &mut Reader<'_>,
+    attributes: crate::util::xml::Attributes<'_>,
+) -> Result<AutoSplitterSettingValue, StoredAutoSplitterSettingsParseError> {
+    let mut kind = None;
+    let mut string_value = None;
+
+    for (key, value) in attributes.iter() {
+        match key {
+            "type" => kind = Some(value.unescape_str()),
+            "value" => string_value = Some(value.unescape_str()),
+            _ => {}
+        }
+    }
+
+    match kind.as_deref() {
+        Some("map") => Ok(AutoSplitterSettingValue::Map(parse_settings_map(reader)?)),
+        Some("list") => Ok(AutoSplitterSettingValue::List(parse_settings_list(reader)?)),
+        Some("bool") => text_as_escaped_string_err(reader, |value| {
+            parse_bool(value).map(AutoSplitterSettingValue::Bool)
+        }),
+        Some("i64") => text_as_escaped_string_err(reader, |value| {
+            value
+                .parse()
+                .map(AutoSplitterSettingValue::I64)
+                .map_err(StoredAutoSplitterSettingsParseError::from)
+        }),
+        Some("f64") => text_as_escaped_string_err(reader, |value| {
+            value
+                .parse()
+                .map(AutoSplitterSettingValue::F64)
+                .map_err(StoredAutoSplitterSettingsParseError::from)
+        }),
+        Some("string") => {
+            end_tag::<StoredAutoSplitterSettingsParseError>(reader)?;
+            Ok(AutoSplitterSettingValue::String(
+                string_value.unwrap_or_default().into(),
+            ))
+        }
+        Some(kind) => Err(StoredAutoSplitterSettingsParseError::UnknownType {
+            name: kind.to_owned(),
+        }),
+        None => Err(StoredAutoSplitterSettingsParseError::MissingTypeAttribute),
+    }
+}
+
+fn write_settings_map<W: fmt::Write>(
+    writer: &mut Writer<W>,
+    map: &AutoSplitterSettingsMap,
+) -> fmt::Result {
+    for (key, value) in map.iter() {
+        writer.tag("Setting", |mut tag| {
+            tag.attribute("id", key)?;
+            write_setting_value(tag, value)
+        })?;
+    }
+    Ok(())
+}
+
+fn write_settings_list<W: fmt::Write>(
+    writer: &mut Writer<W>,
+    list: &AutoSplitterSettingsList,
+) -> fmt::Result {
+    for value in list.iter() {
+        writer.tag("Setting", |tag| write_setting_value(tag, value))?;
+    }
+    Ok(())
+}
+
+fn write_setting_value<W: fmt::Write>(
+    mut tag: crate::util::xml::AttributeWriter<'_, W>,
+    value: &AutoSplitterSettingValue,
+) -> fmt::Result {
+    match value {
+        AutoSplitterSettingValue::Map(map) => {
+            tag.attribute("type", "map")?;
+            tag.content(|writer| write_settings_map(writer, map))
+        }
+        AutoSplitterSettingValue::List(list) => {
+            tag.attribute("type", "list")?;
+            tag.content(|writer| write_settings_list(writer, list))
+        }
+        AutoSplitterSettingValue::Bool(value) => {
+            tag.attribute("type", "bool")?;
+            tag.text_content(bool_text(*value))
+        }
+        AutoSplitterSettingValue::I64(value) => {
+            tag.attribute("type", "i64")?;
+            tag.text_content(DisplayAlreadyEscaped(*value))
+        }
+        AutoSplitterSettingValue::F64(value) => {
+            tag.attribute("type", "f64")?;
+            tag.text_content(DisplayAlreadyEscaped(*value))
+        }
+        AutoSplitterSettingValue::String(value) => {
+            tag.attribute("type", "string")?;
+            tag.attribute("value", value.as_ref())
+        }
+        // `Value` is non-exhaustive so future runtime value kinds cannot be
+        // silently serialized into a different shape. Failing the write is
+        // safer than losing a user's setting when the runtime gains a variant
+        // that this file format adapter does not understand yet.
+        _ => Err(fmt::Error),
+    }
+}
+
+/// The error returned when parsing the stored ASR-compatible Auto Splitter
+/// Settings fails.
+#[derive(Debug, snafu::Snafu)]
+pub enum StoredAutoSplitterSettingsParseError {
+    /// The XML structure itself was malformed.
+    Xml {
+        /// The underlying XML parsing error.
+        source: XmlError,
+    },
+    /// A `<Setting>` element was missing its `type` attribute.
+    MissingTypeAttribute,
+    /// A map entry was missing its `id` attribute.
+    MissingIdAttribute,
+    /// A setting used an unknown `type` discriminator.
+    UnknownType {
+        /// The unknown type name that was encountered.
+        name: String,
+    },
+    /// An unexpected XML element was encountered while parsing the stored
+    /// settings tree.
+    UnexpectedElement {
+        /// The unexpected element name that was encountered.
+        name: String,
+    },
+    /// Failed to parse an integer value.
+    ParseInt {
+        /// The underlying integer parsing error.
+        source: core::num::ParseIntError,
+    },
+    /// Failed to parse a floating point value.
+    ParseFloat {
+        /// The underlying floating point parsing error.
+        source: core::num::ParseFloatError,
+    },
+    /// Failed to parse a boolean value.
+    Bool,
+}
+
+impl From<XmlError> for StoredAutoSplitterSettingsParseError {
+    fn from(source: XmlError) -> Self {
+        Self::Xml { source }
+    }
+}
+
+impl From<core::num::ParseIntError> for StoredAutoSplitterSettingsParseError {
+    fn from(source: core::num::ParseIntError) -> Self {
+        Self::ParseInt { source }
+    }
+}
+
+impl From<core::num::ParseFloatError> for StoredAutoSplitterSettingsParseError {
+    fn from(source: core::num::ParseFloatError) -> Self {
+        Self::ParseFloat { source }
+    }
+}
+
+fn bool_text(value: bool) -> &'static str {
+    if value { "True" } else { "False" }
+}
+
+fn parse_bool(value: &str) -> Result<bool, StoredAutoSplitterSettingsParseError> {
+    match value {
+        "True" => Ok(true),
+        "False" => Ok(false),
+        _ => Err(StoredAutoSplitterSettingsParseError::Bool),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_payload_roundtrips_as_empty_string() {
+        let settings = StoredAutoSplitterSettings::new();
+
+        assert!(settings.is_empty());
+        assert_eq!(settings.to_xml_string(), "");
+        assert_eq!(
+            StoredAutoSplitterSettings::parse("").unwrap(),
+            StoredAutoSplitterSettings::new()
+        );
+    }
+
+    #[test]
+    fn parses_and_serializes_reference_shape() {
+        // Keep text values on indented lines to mirror common XML formatter
+        // output. This explicitly verifies that formatting whitespace is
+        // trimmed before paths and scalar settings are interpreted.
+        //
+        // The Windows-style path is also intentional. Script paths are opaque
+        // XML text at this layer and must round-trip unchanged even when these
+        // tests run on a non-Windows host.
+        let xml = r#"
+            <Version>
+                1.0
+            </Version>
+            <ScriptPath>
+                C:\Auto Splitters\Game.wasm
+            </ScriptPath>
+            <CustomSettings>
+                <Setting id="outer" type="map">
+                    <Setting id="enabled" type="bool">
+                        True
+                    </Setting>
+                    <Setting id="threshold" type="f64">
+                        2.5
+                    </Setting>
+                    <Setting id="choices" type="list">
+                        <Setting type="string" value="first"/>
+                        <Setting type="i64">
+                            7
+                        </Setting>
+                    </Setting>
+                </Setting>
+            </CustomSettings>
+        "#;
+
+        let parsed = StoredAutoSplitterSettings::parse(xml).unwrap();
+        assert_eq!(parsed.script_path(), Some(r"C:\Auto Splitters\Game.wasm"));
+
+        let outer = parsed
+            .settings_map()
+            .get("outer")
+            .expect("outer map should be present");
+        assert!(matches!(
+            outer,
+            AutoSplitterSettingValue::Map(map)
+                if matches!(map.get("enabled"), Some(AutoSplitterSettingValue::Bool(true)))
+        ));
+
+        assert_eq!(
+            StoredAutoSplitterSettings::parse(&parsed.to_xml_string()).unwrap(),
+            parsed
+        );
+    }
+}

--- a/src/timing/timer/mod.rs
+++ b/src/timing/timer/mod.rs
@@ -1,3 +1,4 @@
+use crate::StoredAutoSplitterSettings;
 use crate::{
     AtomicDateTime, Run, Segment, Time, TimeSpan, TimeStamp,
     TimerPhase::{self, *},
@@ -173,6 +174,15 @@ impl Timer {
     #[inline]
     pub const fn mark_as_unmodified(&mut self) {
         self.run.mark_as_unmodified();
+    }
+
+    /// Stores the structured ASR-compatible Auto Splitter Settings inside the
+    /// active run. This is intentionally a timer-level API so frontends can
+    /// update the splits-file-backed auto splitter state without replacing the
+    /// whole run or disturbing an in-progress attempt.
+    #[inline]
+    pub fn set_stored_auto_splitter_settings(&mut self, settings: &StoredAutoSplitterSettings) {
+        self.run.set_stored_auto_splitter_settings(settings);
     }
 
     /// Returns the current Timer Phase.


### PR DESCRIPTION
LiveSplit splits files already contain an `AutoSplitterSettings` XML payload, but livesplit-core only exposes its contents as an opaque string. Frontends therefore need to parse and serialize the script path and custom settings themselves.

This adds structured ASR-compatible settings types that round-trip the script path and recursively typed custom settings and convert to and from runtime settings maps. `Run` now exposes APIs for reading and updating the stored settings, and `Timer` forwards updates to the active run. Updates participate in the run's normal modified-state handling.