### PR TITLE
Expose Segment Groups in C API

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -63,6 +63,7 @@ pub mod run_metadata_custom_variables_iter;
 pub mod run_metadata_speedrun_com_variable;
 pub mod run_metadata_speedrun_com_variables_iter;
 pub mod segment;
+pub mod segment_group;
 pub mod segment_history;
 pub mod segment_history_element;
 pub mod segment_history_iter;

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -8,7 +8,7 @@ use crate::{
 use livesplit_core::{
     Attempt, Run, RunMetadata, Segment, TimeSpan,
     run::{
-        parser,
+        SegmentGroup, parser,
         saver::{self, livesplit::IoWrite},
     },
 };
@@ -238,6 +238,19 @@ pub extern "C" fn Run_has_been_modified(this: &Run) -> bool {
 #[unsafe(no_mangle)]
 pub extern "C" fn Run_segment(this: &Run, index: usize) -> &Segment {
     this.segment(index)
+}
+
+/// Returns the amount of native segment groups stored in this Run.
+#[unsafe(no_mangle)]
+pub extern "C" fn Run_segment_groups_len(this: &Run) -> usize {
+    this.segment_groups().groups().len()
+}
+
+/// Accesses a native segment group stored in this Run by its index. You may not
+/// provide an out of bounds index.
+#[unsafe(no_mangle)]
+pub extern "C" fn Run_segment_group(this: &Run, index: usize) -> &SegmentGroup {
+    &this.segment_groups().groups()[index]
 }
 
 /// Returns the amount of segments in this Run.

--- a/capi/src/segment_group.rs
+++ b/capi/src/segment_group.rs
@@ -1,0 +1,38 @@
+//! A Segment Group describes a contiguous range of segments that forms a
+//! one-level group.
+
+use super::output_str;
+use livesplit_core::run::SegmentGroup;
+use std::os::raw::c_char;
+
+/// Accesses the inclusive start index of the segment group.
+#[unsafe(no_mangle)]
+pub extern "C" fn SegmentGroup_start(this: &SegmentGroup) -> usize {
+    this.start()
+}
+
+/// Accesses the exclusive end index of the segment group.
+#[unsafe(no_mangle)]
+pub extern "C" fn SegmentGroup_end(this: &SegmentGroup) -> usize {
+    this.end()
+}
+
+/// Accesses the explicit name of the segment group. If the group uses the
+/// final segment's name instead, an empty string is returned.
+#[unsafe(no_mangle)]
+pub extern "C" fn SegmentGroup_name(this: &SegmentGroup) -> *const c_char {
+    output_str(this.name().unwrap_or_default())
+}
+
+/// Accesses the explicit icon's data. If the group uses the final segment's
+/// icon instead, an empty buffer is returned.
+#[unsafe(no_mangle)]
+pub extern "C" fn SegmentGroup_icon_ptr(this: &SegmentGroup) -> *const u8 {
+    this.icon().map_or([].as_ptr(), |icon| icon.data().as_ptr())
+}
+
+/// Accesses the amount of bytes the explicit icon's data takes up.
+#[unsafe(no_mangle)]
+pub extern "C" fn SegmentGroup_icon_len(this: &SegmentGroup) -> usize {
+    this.icon().map_or(0, |icon| icon.data().len())
+}


### PR DESCRIPTION
Add read-only access to a run's native segment groups and expose each group's range, explicit name, and explicit icon.

This lets C API consumers preserve group metadata without serializing the run or reconstructing groups from segment names.