### PR TITLE
Add Configurable C API Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ cargo run
 
 The bindings will then be available in `capi/bindings`.
 
+The C API can also be built as a smaller subset. High-level features such as
+`parsing`, `timing`, `run-editing`, and `layouts` select coherent parts of the
+API, while features named after individual API types allow more precise
+control. For example, a library that only parses and inspects split files can
+be built with:
+
+```bash
+cargo rustc --profile max-opt -p livesplit-core-capi --crate-type cdylib \
+  --no-default-features --features parsing
+```
+
+The binding generator needs to receive the same feature selection so that it
+only generates bindings for functions that are present in the library:
+
+```bash
+cd capi/bind_gen
+cargo run -- --no-default-features --features parsing
+```
+
 ## Download
 
 Builds for a lot of common platforms are available in the [Releases](https://github.com/LiveSplit/livesplit-core/releases).

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -20,12 +20,164 @@ wasm-bindgen-futures = { version = "0.4.28", optional = true }
 web-sys = { version = "0.3.28", optional = true }
 
 [features]
-default = ["localization", "image-shrinking"]
+default = ["default-api", "localization", "image-shrinking"]
+
+# The default API preserves the portable C API surface that was historically
+# always available. Platform-specific facilities and facilities that require a
+# separate implementation feature are intentionally not represented by dummy
+# types anymore. They are enabled by their own features below.
+default-api = [
+    "analysis",
+    "hotkeys",
+    "layout-editing",
+    "layouts",
+    "parsing",
+    "run-editing",
+    "run-saving",
+    "shared-timer",
+    "timing",
+]
+
+# High-level feature groups. Most consumers should use these instead of
+# selecting the individual API type features below.
+parsing = ["parse-run-result"]
+run-saving = ["run"]
+timing = ["timer"]
+run-editing = ["fuzzy-list", "run-editor", "sum-of-best-cleaner"]
+layouts = ["components", "layout"]
+layout-editing = ["layout-editor"]
+hotkeys = ["hotkey-system"]
+components = [
+    "blank-space-component",
+    "carousel-component",
+    "current-comparison-component",
+    "current-pace-component",
+    "delta-component",
+    "detailed-timer-component",
+    "graph-component",
+    "group-component",
+    "pb-chance-component",
+    "possible-time-save-component",
+    "previous-segment-component",
+    "segment-time-component",
+    "separator-component",
+    "splits-component",
+    "sum-of-best-component",
+    "text-component",
+    "timer-component",
+    "title-component",
+    "total-playtime-component",
+]
+
+# Fine-grained API type features. Dependencies describe types that occur in the
+# public signatures of the selected type.
+analysis = ["run", "time-span", "timer"]
+atomic-date-time = []
+attempt = ["atomic-date-time", "time", "time-span"]
+blank-space-component = ["blank-space-component-state", "component", "timer"]
+blank-space-component-state = []
+carousel-component = ["carousel-component-state", "component"]
+carousel-component-state = []
+command-sink = []
+component = []
+current-comparison-component = ["component", "key-value-component-state", "lang", "timer"]
+current-pace-component = ["component", "key-value-component-state", "lang", "timer"]
+delta-component = ["component", "key-value-component-state", "lang", "timer"]
+detailed-timer-component = ["component", "detailed-timer-component-state", "lang", "timer"]
+detailed-timer-component-state = []
+fuzzy-list = []
+general-layout-settings = []
+graph-component = ["component", "general-layout-settings", "graph-component-state", "timer"]
+graph-component-state = []
+group-component = ["component", "group-component-state"]
+group-component-state = []
+hotkey-config = ["lang", "setting-value"]
+hotkey-system = ["command-sink", "hotkey-config"]
+image-cache = []
+key-value-component-state = []
+lang = []
+layout = ["component", "general-layout-settings", "image-cache", "lang", "layout-state", "timer"]
+layout-editor = [
+    "component",
+    "image-cache",
+    "lang",
+    "layout",
+    "layout-editor-state",
+    "layout-state",
+    "setting-value",
+    "timer",
+]
+layout-editor-state = ["setting-value"]
+layout-state = [
+    "blank-space-component-state",
+    "carousel-component-state",
+    "detailed-timer-component-state",
+    "graph-component-state",
+    "group-component-state",
+    "key-value-component-state",
+    "separator-component-state",
+    "splits-component-state",
+    "text-component-state",
+    "timer-component-state",
+    "title-component-state",
+]
+linked-layout = []
+parse-run-result = ["run"]
+pb-chance-component = ["component", "key-value-component-state", "lang", "timer"]
+possible-time-save-component = ["component", "key-value-component-state", "lang", "timer"]
+potential-clean-up = []
+previous-segment-component = ["component", "key-value-component-state", "lang", "timer"]
+run = [
+    "attempt",
+    "linked-layout",
+    "run-metadata",
+    "segment",
+    "segment-group",
+    "time-span",
+]
+run-editor = ["linked-layout", "run", "sum-of-best-cleaner"]
+run-metadata = [
+    "run-metadata-custom-variables-iter",
+    "run-metadata-speedrun-com-variables-iter",
+]
+run-metadata-custom-variable = []
+run-metadata-custom-variables-iter = ["run-metadata-custom-variable"]
+run-metadata-speedrun-com-variable = []
+run-metadata-speedrun-com-variables-iter = ["run-metadata-speedrun-com-variable"]
+segment = ["segment-history", "time"]
+segment-group = []
+segment-history = ["segment-history-iter"]
+segment-history-element = ["time"]
+segment-history-iter = ["segment-history-element"]
+segment-time-component = ["component", "key-value-component-state", "lang", "timer"]
+separator-component = ["component", "separator-component-state"]
+separator-component-state = []
+setting-value = []
+shared-timer = ["command-sink", "timer", "timer-read-lock", "timer-write-lock"]
+splits-component = ["component", "general-layout-settings", "lang", "splits-component-state", "timer"]
+splits-component-state = []
+sum-of-best-cleaner = ["potential-clean-up"]
+sum-of-best-component = ["component", "key-value-component-state", "lang", "timer"]
+text-component = ["component", "text-component-state", "timer"]
+text-component-state = []
+time = ["time-span"]
+time-span = ["lang"]
+timer = ["run", "time", "time-span"]
+timer-component = ["component", "lang", "timer", "timer-component-state"]
+timer-component-state = []
+timer-read-lock = ["timer"]
+timer-write-lock = ["timer"]
+title-component = ["component", "lang", "timer", "title-component-state"]
+title-component-state = []
+total-playtime-component = ["component", "key-value-component-state", "lang", "timer"]
+
 localization = ["livesplit-core/localization"]
 image-shrinking = ["livesplit-core/image-shrinking"]
-software-rendering = ["livesplit-core/software-rendering"]
+software-rendering = ["image-cache", "layout-state", "livesplit-core/software-rendering"]
 wasm-web = ["livesplit-core/wasm-web", "wasm-bindgen", "wasm-bindgen-futures", "web-sys"]
-auto-splitting = ["livesplit-core/auto-splitting"]
+auto-splitting = ["shared-timer", "livesplit-core/auto-splitting"]
 assume-str-parameters-are-utf8 = []
-web-rendering = ["wasm-web", "livesplit-core/web-rendering"]
-therun-gg = ["wasm-web", "livesplit-core/therun-gg"]
+web-command-sink = ["command-sink", "wasm-web"]
+server-protocol = ["command-sink", "wasm-web"]
+web-rendering = ["image-cache", "layout-state", "wasm-web", "livesplit-core/web-rendering"]
+therun-gg = ["timer", "wasm-web", "livesplit-core/therun-gg"]

--- a/capi/bind_gen/Cargo.toml
+++ b/capi/bind_gen/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 [dependencies]
 heck = "0.5.0"
 clap = { version = "4.0.2", features = ["derive"] }
+serde_json = "1.0.8"
 syn = { version = "3.0.3", default-features = false, features = ["parsing", "full", "printing"] }

--- a/capi/bind_gen/src/csharp.rs
+++ b/capi/bind_gen/src/csharp.rs
@@ -69,15 +69,15 @@ fn write_class_comments<W: Write>(mut writer: W, comments: &[String]) -> Result<
     )?;
 
     for comment in comments {
-        write!(
-            writer,
-            r#"
-    /// {}"#,
-            comment
-                .replace("<NULL>", "null")
-                .replace("<TRUE>", "true")
-                .replace("<FALSE>", "false")
-        )?;
+        let comment = comment
+            .replace("<NULL>", "null")
+            .replace("<TRUE>", "true")
+            .replace("<FALSE>", "false");
+        if comment.is_empty() {
+            write!(writer, "\n    ///")?;
+        } else {
+            write!(writer, "\n    /// {comment}")?;
+        }
     }
 
     write!(
@@ -102,15 +102,15 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         )?;
 
         for comment in &function.comments {
-            write!(
-                writer,
-                r#"
-        /// {}"#,
-                comment
-                    .replace("<NULL>", "null")
-                    .replace("<TRUE>", "true")
-                    .replace("<FALSE>", "false")
-            )?;
+            let comment = comment
+                .replace("<NULL>", "null")
+                .replace("<TRUE>", "true")
+                .replace("<FALSE>", "false");
+            if comment.is_empty() {
+                write!(writer, "\n        ///")?;
+            } else {
+                write!(writer, "\n        /// {comment}")?;
+            }
         }
 
         write!(
@@ -403,7 +403,7 @@ namespace LiveSplitCore
             }
         }
 
-        if class_name == "Run" {
+        if class_name == "Run" && class.has_function("Run_parse") {
             write!(
                 writer,
                 "{}",

--- a/capi/bind_gen/src/java/jna.rs
+++ b/capi/bind_gen/src/java/jna.rs
@@ -168,11 +168,7 @@ fn write_fn<W: Write>(mut writer: W, function: &Function, class_name: &str) -> R
         }
     }
 
-    write!(
-        writer,
-        r#"LiveSplitCoreNative.INSTANCE.{}("#,
-        function.name
-    )?;
+    write!(writer, r#"LiveSplitCoreNative.INSTANCE.{}("#, function.name)?;
 
     for (i, (name, typ)) in function.inputs.iter().enumerate() {
         if i != 0 {
@@ -392,7 +388,7 @@ public class {class_name} extends {class_name_ref_mut} implements AutoCloseable 
         }
     }
 
-    if class_name == "Run" {
+    if class_name == "Run" && class.has_function("Run_parse") {
         write!(
             writer,
             "{}",

--- a/capi/bind_gen/src/java/jni.rs
+++ b/capi/bind_gen/src/java/jni.rs
@@ -356,7 +356,7 @@ public class {class_name} extends {class_name_ref_mut} implements AutoCloseable 
         }
     }
 
-    if class_name == "Run" {
+    if class_name == "Run" && class.has_function("Run_parse") {
         write!(
             writer,
             "{}",
@@ -389,9 +389,19 @@ fn write_native_class<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>
 public class LiveSplitCoreNative {
     static {
         System.loadLibrary("native-lib");
-    }
-    public static native long Run_parseString(String data);"#
+    }"#
     )?;
+
+    if classes
+        .get("Run")
+        .is_some_and(|class| class.has_function("Run_parse"))
+    {
+        write!(
+            writer,
+            r#"
+    public static native long Run_parseString(String data);"#
+        )?;
+    }
 
     for class in classes.values() {
         for function in class

--- a/capi/bind_gen/src/jni_cpp.rs
+++ b/capi/bind_gen/src/jni_cpp.rs
@@ -179,8 +179,17 @@ pub fn write<W: Write>(mut writer: W, classes: &BTreeMap<String, Class>) -> Resu
 #include "livesplit_core.h"
 
 using namespace LiveSplit;
+"#
+    )?;
 
-extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseString(JNIEnv* jni_env, jobject, jstring data, jstring load_files_path) {
+    if classes
+        .get("Run")
+        .is_some_and(|class| class.has_function("Run_parse"))
+    {
+        write!(
+            writer,
+            "{}",
+            r#"extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseString(JNIEnv* jni_env, jobject, jstring data, jstring load_files_path) {
     auto cstr_data = jni_env->GetStringUTFChars(data, nullptr);
     auto cstr_load_files_path = jni_env->GetStringUTFChars(load_files_path, nullptr);
     auto result = (jlong)Run_parse(cstr_data, strlen(cstr_data), cstr_load_files_path);
@@ -189,7 +198,8 @@ extern "C" JNIEXPORT jlong Java_livesplitcore_LiveSplitCoreNative_Run_1parseStri
     return result;
 }
 "#
-    )?;
+        )?;
+    }
 
     for (class_name, class) in classes {
         for function in class

--- a/capi/bind_gen/src/kotlin/jni.rs
+++ b/capi/bind_gen/src/kotlin/jni.rs
@@ -396,7 +396,7 @@ open class {class_name} : {class_name_ref_mut}, AutoCloseable {{
             }
         }
 
-        if class_name == "Run" {
+        if class_name == "Run" && class.has_function("Run_parse") {
             write!(
                 writer,
                 "{}",
@@ -438,9 +438,19 @@ fn write_native_class<P: AsRef<Path>>(path: P, classes: &BTreeMap<String, Class>
 object LiveSplitCoreNative {
     init {
         System.loadLibrary("native-lib")
-    }
-    external fun Run_parseString(data: String): Long"#
+    }"#
     )?;
+
+    if classes
+        .get("Run")
+        .is_some_and(|class| class.has_function("Run_parse"))
+    {
+        write!(
+            writer,
+            r#"
+    external fun Run_parseString(data: String): Long"#
+        )?;
+    }
 
     for class in classes.values() {
         for function in class

--- a/capi/bind_gen/src/main.rs
+++ b/capi/bind_gen/src/main.rs
@@ -15,15 +15,16 @@ mod wasm_bindgen;
 use clap::Parser;
 use heck::ToLowerCamelCase;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File, create_dir_all, remove_dir_all},
     io::{BufWriter, Read, Result},
     path::PathBuf,
+    process::Command,
     rc::Rc,
 };
 use syn::{
-    Expr, ExprLit, FnArg, Item, ItemFn, Lit, Meta, MetaList, Pat, ReturnType, Signature,
-    Type as SynType, Visibility, parse_file,
+    Expr, ExprLit, FnArg, Item, ItemFn, Lit, Meta, MetaList, Pat, ReturnType, Signature, Token,
+    Type as SynType, Visibility, parse_file, punctuated::Punctuated,
 };
 
 #[derive(clap::Parser)]
@@ -35,6 +36,18 @@ pub struct Opt {
         default_value = "../liblivesplit_core.so"
     )]
     ruby_lib_path: String,
+
+    /// Features to enable for the C API and the generated bindings.
+    #[clap(long, value_delimiter = ',')]
+    features: Vec<String>,
+
+    /// Do not include the C API's default features.
+    #[clap(long)]
+    no_default_features: bool,
+
+    /// Directory to write the generated bindings to.
+    #[clap(long, default_value = "../bindings")]
+    output_dir: PathBuf,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -111,6 +124,17 @@ pub struct Class {
     shared_fns: Vec<Function>,
     mut_fns: Vec<Function>,
     own_fns: Vec<Function>,
+}
+
+impl Class {
+    fn has_function(&self, name: &str) -> bool {
+        self.static_fns
+            .iter()
+            .chain(&self.shared_fns)
+            .chain(&self.mut_fns)
+            .chain(&self.own_fns)
+            .any(|function| function.name == name)
+    }
 }
 
 fn get_type(ty: &SynType) -> Type {
@@ -197,6 +221,7 @@ fn get_comment(attrs: &[syn::Attribute]) -> Vec<String> {
 
 fn main() {
     let opt = Opt::parse();
+    let features = resolve_features(&opt);
 
     let mut contents = fs::read_to_string("../src/lib.rs").unwrap();
     let file = parse_file(&contents).unwrap();
@@ -205,7 +230,7 @@ fn main() {
 
     for item in &file.items {
         let module = match item {
-            Item::Mod(m) => m,
+            Item::Mod(m) if attrs_enabled(&m.attrs, &features) => m,
             _ => continue,
         };
 
@@ -231,7 +256,12 @@ fn main() {
                     },
                 ..
             } = match item {
-                Item::Fn(i) if matches!(i.vis, Visibility::Public(_)) => i,
+                Item::Fn(i)
+                    if matches!(i.vis, Visibility::Public(_))
+                        && attrs_enabled(&i.attrs, &features) =>
+                {
+                    i
+                }
                 _ => continue,
             };
 
@@ -296,6 +326,119 @@ fn main() {
     write_files(&fns_to_classes(functions), &opt).unwrap();
 }
 
+/// Resolves the selected feature set using the C API's Cargo feature graph.
+///
+/// The binding generator deliberately reads Cargo's feature definitions rather
+/// than maintaining a second dependency graph. Build scripts still pass the
+/// same top-level feature list to Cargo and this executable, while aggregate
+/// features such as `parsing` are expanded from the single authoritative
+/// definition in the C API's manifest.
+fn resolve_features(opt: &Opt) -> BTreeSet<String> {
+    let output = Command::new("cargo")
+        .args([
+            "metadata",
+            "--format-version=1",
+            "--no-deps",
+            "--manifest-path=../Cargo.toml",
+        ])
+        .output()
+        .expect("failed to query the C API's Cargo features");
+    assert!(
+        output.status.success(),
+        "failed to query the C API's Cargo features: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("Cargo returned invalid metadata");
+    let package = metadata["packages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|package| package["name"] == "livesplit-core-capi")
+        .expect("the C API package is missing from Cargo metadata");
+    let definitions = package["features"]
+        .as_object()
+        .expect("the C API's feature definitions are missing");
+
+    let mut pending = opt.features.clone();
+    if !opt.no_default_features {
+        pending.push("default".into());
+    }
+
+    let mut resolved = BTreeSet::new();
+    while let Some(feature) = pending.pop() {
+        if !resolved.insert(feature.clone()) {
+            continue;
+        }
+
+        let dependencies = definitions
+            .get(&feature)
+            .unwrap_or_else(|| panic!("unknown C API feature `{feature}`"))
+            .as_array()
+            .unwrap();
+        for dependency in dependencies {
+            let dependency = dependency.as_str().unwrap();
+            // Entries containing a slash enable a feature of a dependency.
+            // `dep:` entries enable an optional dependency. Neither represents
+            // a feature that can occur in this crate's cfg attributes.
+            if !dependency.contains('/') && !dependency.starts_with("dep:") {
+                pending.push(dependency.into());
+            }
+        }
+    }
+
+    resolved
+}
+
+/// Evaluates the feature-related portion of `cfg` attributes.
+///
+/// Target predicates are intentionally treated as enabled. The generated C,
+/// C#, Java, and similar bindings describe the C ABI, while target-specific
+/// wasm-bindgen exports are generated by wasm-bindgen itself. Treating unknown
+/// predicates as enabled also preserves the historical union of native target
+/// APIs, while feature predicates are still applied consistently.
+fn attrs_enabled(attrs: &[syn::Attribute], features: &BTreeSet<String>) -> bool {
+    attrs.iter().all(|attribute| {
+        let Meta::List(list) = &attribute.meta else {
+            return true;
+        };
+        if !list.path.is_ident("cfg") {
+            return true;
+        }
+        eval_cfg(&list.parse_args().expect("invalid cfg attribute"), features)
+    })
+}
+
+fn eval_cfg(meta: &Meta, features: &BTreeSet<String>) -> bool {
+    match meta {
+        Meta::NameValue(value) if value.path.is_ident("feature") => {
+            let Expr::Lit(ExprLit {
+                lit: Lit::Str(feature),
+                ..
+            }) = &value.value
+            else {
+                panic!("invalid feature cfg");
+            };
+            features.contains(&feature.value())
+        }
+        Meta::List(list) if list.path.is_ident("all") => list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .unwrap()
+            .iter()
+            .all(|meta| eval_cfg(meta, features)),
+        Meta::List(list) if list.path.is_ident("any") => list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .unwrap()
+            .iter()
+            .any(|meta| eval_cfg(meta, features)),
+        Meta::List(list) if list.path.is_ident("not") => {
+            !eval_cfg(&list.parse_args().expect("invalid not cfg"), features)
+        }
+        _ => true,
+    }
+}
+
 fn is_no_mangle(list: &MetaList) -> bool {
     if !list.path.is_ident("unsafe") {
         return false;
@@ -332,8 +475,7 @@ fn fns_to_classes(functions: Vec<Function>) -> BTreeMap<String, Class> {
 }
 
 fn write_files(classes: &BTreeMap<String, Class>, opt: &Opt) -> Result<()> {
-    let mut path = PathBuf::from("..");
-    path.push("bindings");
+    let mut path = opt.output_dir.clone();
 
     drop(remove_dir_all(&path));
     create_dir_all(&path)?;

--- a/capi/bind_gen/src/node.rs
+++ b/capi/bind_gen/src/node.rs
@@ -602,7 +602,7 @@ const liveSplitCoreNative = ffi.Library('livesplit_core', {"#
             }
         }
 
-        if class_name == "Run" {
+        if class_name == "Run" && class.has_function("Run_parse") {
             if type_script {
                 write!(
                     writer,

--- a/capi/bind_gen/src/python.rs
+++ b/capi/bind_gen/src/python.rs
@@ -334,7 +334,7 @@ class {class_name}({class_name_ref_mut}):"#
             }
         }
 
-        if class_name == "Run" {
+        if class_name == "Run" && class.has_function("Run_parse") {
             writeln!(
                 writer,
                 r#"

--- a/capi/bind_gen/src/wasm_bindgen.rs
+++ b/capi/bind_gen/src/wasm_bindgen.rs
@@ -611,7 +611,7 @@ export class {class_name_ref} {{"#,
     }"#
                 )?;
             }
-        } else if class_name == "Run" {
+        } else if class_name == "Run" && class.has_function("Run_save_as_lss") {
             if type_script {
                 write!(
                     writer,
@@ -871,7 +871,7 @@ export class {class_name} extends {class_name_ref_mut} {{
             }
         }
 
-        if class_name == "Run" {
+        if class_name == "Run" && class.has_function("Run_parse") {
             if type_script {
                 write!(
                     writer,

--- a/capi/src/auto_splitting_runtime.rs
+++ b/capi/src/auto_splitting_runtime.rs
@@ -5,31 +5,7 @@ use super::str;
 use crate::shared_timer::OwnedSharedTimer;
 use std::{os::raw::c_char, path::PathBuf};
 
-#[cfg(feature = "auto-splitting")]
 type AutoSplittingRuntime = livesplit_core::auto_splitting::Runtime<livesplit_core::SharedTimer>;
-
-#[cfg(not(feature = "auto-splitting"))]
-use livesplit_core::SharedTimer;
-
-#[cfg(not(feature = "auto-splitting"))]
-#[expect(missing_docs)]
-pub struct AutoSplittingRuntime;
-
-#[expect(warnings)]
-#[cfg(not(feature = "auto-splitting"))]
-impl AutoSplittingRuntime {
-    pub fn new() -> Self {
-        Self
-    }
-
-    pub fn unload(&self) -> Result<(), ()> {
-        Err(())
-    }
-
-    pub fn load(&self, _: PathBuf, _: SharedTimer) -> Result<(), ()> {
-        Err(())
-    }
-}
 
 /// type
 pub type OwnedAutoSplittingRuntime = Box<AutoSplittingRuntime>;

--- a/capi/src/command_sink.rs
+++ b/capi/src/command_sink.rs
@@ -15,6 +15,7 @@ use livesplit_core::{
     event::{self, Result},
 };
 
+#[cfg(feature = "shared-timer")]
 use crate::shared_timer::OwnedSharedTimer;
 
 /// type
@@ -26,6 +27,7 @@ pub type OwnedCommandSink = Box<CommandSink>;
 
 /// Creates a new Command Sink.
 #[unsafe(no_mangle)]
+#[cfg(feature = "shared-timer")]
 pub extern "C" fn CommandSink_from_timer(timer: OwnedSharedTimer) -> OwnedCommandSink {
     Box::new(CommandSink(Arc::new(*timer)))
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -10,99 +10,184 @@
 
 //! mod
 
-use std::{
-    cell::{Cell, RefCell},
-    ffi::CStr,
-    fs::File,
-    mem::ManuallyDrop,
-    os::raw::c_char,
-    ptr, slice,
-};
+#[cfg(any(
+    feature = "attempt",
+    feature = "run",
+    feature = "run-metadata-custom-variables-iter",
+    feature = "run-metadata-speedrun-com-variables-iter",
+    feature = "segment",
+    feature = "segment-history-element",
+    feature = "segment-history-iter",
+    feature = "timer",
+))]
+use std::cell::Cell;
+use std::{cell::RefCell, ffi::CStr, os::raw::c_char, slice};
+#[cfg(any(feature = "hotkey-config", feature = "layout", feature = "parsing"))]
+use std::{fs::File, mem::ManuallyDrop};
 
+#[cfg(feature = "analysis")]
 pub mod analysis;
+#[cfg(feature = "atomic-date-time")]
 pub mod atomic_date_time;
+#[cfg(feature = "attempt")]
 pub mod attempt;
+#[cfg(feature = "auto-splitting")]
 pub mod auto_splitting_runtime;
+#[cfg(feature = "blank-space-component")]
 pub mod blank_space_component;
+#[cfg(feature = "blank-space-component-state")]
 pub mod blank_space_component_state;
+#[cfg(feature = "carousel-component")]
 pub mod carousel_component;
+#[cfg(feature = "carousel-component-state")]
 pub mod carousel_component_state;
+#[cfg(feature = "command-sink")]
 pub mod command_sink;
+#[cfg(feature = "component")]
 pub mod component;
+#[cfg(feature = "current-comparison-component")]
 pub mod current_comparison_component;
+#[cfg(feature = "current-pace-component")]
 pub mod current_pace_component;
+#[cfg(feature = "delta-component")]
 pub mod delta_component;
+#[cfg(feature = "detailed-timer-component")]
 pub mod detailed_timer_component;
+#[cfg(feature = "detailed-timer-component-state")]
 pub mod detailed_timer_component_state;
+#[cfg(feature = "fuzzy-list")]
 pub mod fuzzy_list;
+#[cfg(feature = "general-layout-settings")]
 pub mod general_layout_settings;
+#[cfg(feature = "graph-component")]
 pub mod graph_component;
+#[cfg(feature = "graph-component-state")]
 pub mod graph_component_state;
+#[cfg(feature = "group-component")]
 pub mod group_component;
+#[cfg(feature = "group-component-state")]
 pub mod group_component_state;
+#[cfg(feature = "hotkey-config")]
 pub mod hotkey_config;
+#[cfg(feature = "hotkey-system")]
 pub mod hotkey_system;
+#[cfg(feature = "image-cache")]
 pub mod image_cache;
+#[cfg(feature = "key-value-component-state")]
 pub mod key_value_component_state;
+#[cfg(feature = "lang")]
 pub mod lang;
+#[cfg(feature = "layout")]
 pub mod layout;
+#[cfg(feature = "layout-editor")]
 pub mod layout_editor;
+#[cfg(feature = "layout-editor-state")]
 pub mod layout_editor_state;
+#[cfg(feature = "layout-state")]
 pub mod layout_state;
+#[cfg(feature = "linked-layout")]
 pub mod linked_layout;
+#[cfg(feature = "parse-run-result")]
 pub mod parse_run_result;
+#[cfg(feature = "pb-chance-component")]
 pub mod pb_chance_component;
+#[cfg(feature = "possible-time-save-component")]
 pub mod possible_time_save_component;
+#[cfg(feature = "potential-clean-up")]
 pub mod potential_clean_up;
+#[cfg(feature = "previous-segment-component")]
 pub mod previous_segment_component;
+#[cfg(feature = "run")]
 pub mod run;
+#[cfg(feature = "run-editor")]
 pub mod run_editor;
+#[cfg(feature = "run-metadata")]
 pub mod run_metadata;
+#[cfg(feature = "run-metadata-custom-variable")]
 pub mod run_metadata_custom_variable;
+#[cfg(feature = "run-metadata-custom-variables-iter")]
 pub mod run_metadata_custom_variables_iter;
+#[cfg(feature = "run-metadata-speedrun-com-variable")]
 pub mod run_metadata_speedrun_com_variable;
+#[cfg(feature = "run-metadata-speedrun-com-variables-iter")]
 pub mod run_metadata_speedrun_com_variables_iter;
+#[cfg(feature = "segment")]
 pub mod segment;
+#[cfg(feature = "segment-group")]
 pub mod segment_group;
+#[cfg(feature = "segment-history")]
 pub mod segment_history;
+#[cfg(feature = "segment-history-element")]
 pub mod segment_history_element;
+#[cfg(feature = "segment-history-iter")]
 pub mod segment_history_iter;
+#[cfg(feature = "segment-time-component")]
 pub mod segment_time_component;
+#[cfg(feature = "separator-component")]
 pub mod separator_component;
+#[cfg(feature = "separator-component-state")]
 pub mod separator_component_state;
-#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+#[cfg(all(target_family = "wasm", feature = "server-protocol"))]
 pub mod server_protocol;
+#[cfg(feature = "setting-value")]
 pub mod setting_value;
+#[cfg(feature = "shared-timer")]
 pub mod shared_timer;
+#[cfg(feature = "software-rendering")]
 pub mod software_renderer;
+#[cfg(feature = "splits-component")]
 pub mod splits_component;
+#[cfg(feature = "splits-component-state")]
 pub mod splits_component_state;
+#[cfg(feature = "sum-of-best-cleaner")]
 pub mod sum_of_best_cleaner;
+#[cfg(feature = "sum-of-best-component")]
 pub mod sum_of_best_component;
+#[cfg(feature = "text-component")]
 pub mod text_component;
+#[cfg(feature = "text-component-state")]
 pub mod text_component_state;
+#[cfg(feature = "time")]
 pub mod time;
+#[cfg(feature = "time-span")]
 pub mod time_span;
+#[cfg(feature = "timer")]
 pub mod timer;
+#[cfg(feature = "timer-component")]
 pub mod timer_component;
+#[cfg(feature = "timer-component-state")]
 pub mod timer_component_state;
+#[cfg(feature = "timer-read-lock")]
 pub mod timer_read_lock;
+#[cfg(feature = "timer-write-lock")]
 pub mod timer_write_lock;
+#[cfg(feature = "title-component")]
 pub mod title_component;
+#[cfg(feature = "title-component-state")]
 pub mod title_component_state;
+#[cfg(feature = "total-playtime-component")]
 pub mod total_playtime_component;
-#[cfg(all(target_family = "wasm", feature = "wasm-web"))]
+#[cfg(all(target_family = "wasm", feature = "web-command-sink"))]
 pub mod web_command_sink;
 #[cfg(all(target_family = "wasm", feature = "web-rendering"))]
 pub mod web_rendering;
 #[cfg(all(target_family = "wasm", feature = "therun-gg"))]
 pub mod web_therun_gg;
 
-use crate::{
-    run_metadata_custom_variable::RunMetadataCustomVariable,
-    run_metadata_speedrun_com_variable::RunMetadataSpeedrunComVariable,
-    segment_history_element::SegmentHistoryElement,
-};
+#[cfg(feature = "run-metadata-custom-variables-iter")]
+use crate::run_metadata_custom_variable::RunMetadataCustomVariable;
+#[cfg(feature = "run-metadata-speedrun-com-variables-iter")]
+use crate::run_metadata_speedrun_com_variable::RunMetadataSpeedrunComVariable;
+#[cfg(feature = "segment-history-iter")]
+use crate::segment_history_element::SegmentHistoryElement;
+#[cfg(any(
+    feature = "attempt",
+    feature = "run",
+    feature = "segment",
+    feature = "segment-history-element",
+    feature = "segment-history-iter",
+    feature = "timer",
+))]
 use livesplit_core::{Time, TimeSpan};
 
 /// type
@@ -113,13 +198,19 @@ pub type Nullablec_char = c_char;
 
 thread_local! {
     static OUTPUT_VEC: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    #[cfg(any(feature = "attempt", feature = "run", feature = "timer"))]
     static TIME_SPAN: Cell<TimeSpan> = const { Cell::new(TimeSpan::zero()) };
+    #[cfg(any(feature = "attempt", feature = "segment", feature = "segment-history-element", feature = "timer"))]
     static TIME: Cell<Time> = const { Cell::new(Time::new()) };
+    #[cfg(feature = "segment-history-iter")]
     static SEGMENT_HISTORY_ELEMENT: Cell<SegmentHistoryElement> = const { Cell::new((0, Time::new())) };
-    static RUN_METADATA_SPEEDRUN_COM_VARIABLE: Cell<RunMetadataSpeedrunComVariable> = const { Cell::new(("", ptr::null())) };
-    static RUN_METADATA_CUSTOM_VARIABLE: Cell<RunMetadataCustomVariable> = const { Cell::new(("", ptr::null())) };
+    #[cfg(feature = "run-metadata-speedrun-com-variables-iter")]
+    static RUN_METADATA_SPEEDRUN_COM_VARIABLE: Cell<RunMetadataSpeedrunComVariable> = const { Cell::new(("", std::ptr::null())) };
+    #[cfg(feature = "run-metadata-custom-variables-iter")]
+    static RUN_METADATA_CUSTOM_VARIABLE: Cell<RunMetadataCustomVariable> = const { Cell::new(("", std::ptr::null())) };
 }
 
+#[cfg(any(feature = "attempt", feature = "run", feature = "timer"))]
 fn output_time_span(time_span: TimeSpan) -> *const TimeSpan {
     TIME_SPAN.with(|output| {
         output.set(time_span);
@@ -127,6 +218,12 @@ fn output_time_span(time_span: TimeSpan) -> *const TimeSpan {
     })
 }
 
+#[cfg(any(
+    feature = "attempt",
+    feature = "segment",
+    feature = "segment-history-element",
+    feature = "timer",
+))]
 fn output_time(time: Time) -> *const Time {
     TIME.with(|output| {
         output.set(time);
@@ -140,6 +237,7 @@ fn output_str<S: AsRef<str>>(s: S) -> *const c_char {
     })
 }
 
+#[cfg(feature = "parsing")]
 fn with_vec<F, R>(f: F) -> R
 where
     F: FnOnce(&mut Vec<u8>) -> R,
@@ -171,6 +269,7 @@ unsafe fn slice<T>(ptr: *const T, len: usize) -> &'static [T] {
     }
 }
 
+#[cfg(feature = "software-rendering")]
 unsafe fn slice_mut<T>(ptr: *mut T, len: usize) -> &'static mut [T] {
     if len == 0 {
         &mut []
@@ -209,21 +308,30 @@ unsafe fn str(s: *const c_char) -> &'static str {
 }
 
 // raw file descriptor handling
-#[cfg(unix)]
+#[cfg(all(
+    unix,
+    any(feature = "hotkey-config", feature = "layout", feature = "parsing"),
+))]
 unsafe fn get_file(fd: i64) -> ManuallyDrop<File> {
     use std::os::unix::io::FromRawFd;
     // SAFETY: The caller guarantees that `fd` is valid.
     ManuallyDrop::new(unsafe { File::from_raw_fd(fd as _) })
 }
 
-#[cfg(windows)]
+#[cfg(all(
+    windows,
+    any(feature = "hotkey-config", feature = "layout", feature = "parsing"),
+))]
 unsafe fn get_file(handle: i64) -> ManuallyDrop<File> {
     use std::os::windows::io::FromRawHandle;
     // SAFETY: The caller guarantees that `handle` is valid.
     ManuallyDrop::new(unsafe { File::from_raw_handle(handle as *mut () as _) })
 }
 
-#[cfg(not(any(windows, unix)))]
+#[cfg(all(
+    not(any(windows, unix)),
+    any(feature = "hotkey-config", feature = "layout", feature = "parsing"),
+))]
 unsafe fn get_file(_: i64) -> ManuallyDrop<File> {
     panic!("File Descriptor Parsing is not implemented for this platform");
 }

--- a/capi/src/run.rs
+++ b/capi/src/run.rs
@@ -1,22 +1,19 @@
 //! A Run stores the split times for a specific game and category of a runner.
 
-use super::{get_file, output_str, output_time_span, output_vec, str};
-use crate::{
-    linked_layout::NullableOwnedLinkedLayout, parse_run_result::OwnedParseRunResult,
-    segment::OwnedSegment, slice, with_vec,
-};
-use livesplit_core::{
-    Attempt, Run, RunMetadata, Segment, TimeSpan,
-    run::{
-        SegmentGroup, parser,
-        saver::{self, livesplit::IoWrite},
-    },
-};
-use std::{
-    io::{Read, Write},
-    os::raw::c_char,
-    path::Path,
-};
+#[cfg(feature = "parsing")]
+use super::{get_file, with_vec};
+use super::{output_str, output_time_span, output_vec, str};
+use crate::{linked_layout::NullableOwnedLinkedLayout, segment::OwnedSegment};
+#[cfg(feature = "parsing")]
+use crate::{parse_run_result::OwnedParseRunResult, slice};
+#[cfg(feature = "parsing")]
+use livesplit_core::run::parser;
+#[cfg(feature = "run-saving")]
+use livesplit_core::run::saver::{self, livesplit::IoWrite};
+use livesplit_core::{Attempt, Run, RunMetadata, Segment, TimeSpan, run::SegmentGroup};
+#[cfg(feature = "parsing")]
+use std::{io::Read, path::Path};
+use std::{io::Write, os::raw::c_char};
 
 /// type
 pub type OwnedRun = Box<Run>;
@@ -43,6 +40,7 @@ pub extern "C" fn Run_drop(this: OwnedRun) {
 /// normal parsing function, it also fixes problems in the Run, such as
 /// decreasing times and missing information.
 #[unsafe(no_mangle)]
+#[cfg(feature = "parsing")]
 pub unsafe extern "C" fn Run_parse(
     data: *const u8,
     length: usize,
@@ -70,6 +68,7 @@ pub unsafe extern "C" fn Run_parse(
 /// to this function. On Windows you pass a file handle to this function. The
 /// file descriptor / handle does not get closed.
 #[unsafe(no_mangle)]
+#[cfg(feature = "parsing")]
 pub unsafe extern "C" fn Run_parse_file_handle(
     handle: i64,
     load_files_path: *const c_char,
@@ -278,6 +277,7 @@ pub extern "C" fn Run_attempt_history_index(this: &Run, index: usize) -> &Attemp
 /// use by a timer, use the appropriate method on the timer instead, in order to
 /// properly save the current attempt as well.
 #[unsafe(no_mangle)]
+#[cfg(feature = "run-saving")]
 pub extern "C" fn Run_save_as_lss(this: &Run) -> *const c_char {
     output_vec(|o| {
         saver::livesplit::save_run(this, IoWrite(o)).unwrap();

--- a/capi/src/software_renderer.rs
+++ b/capi/src/software_renderer.rs
@@ -1,34 +1,12 @@
 //! The software renderer allows rendering layouts entirely on the CPU. This is
 //! surprisingly fast and can be considered the default renderer.
 
-use livesplit_core::{layout::LayoutState, settings::ImageCache};
-
-#[cfg(feature = "software-rendering")]
-use livesplit_core::rendering::software::BorrowedRenderer as SoftwareRenderer;
+use livesplit_core::{
+    layout::LayoutState, rendering::software::BorrowedRenderer as SoftwareRenderer,
+    settings::ImageCache,
+};
 
 use crate::slice_mut;
-
-#[cfg(not(feature = "software-rendering"))]
-/// dummy
-pub struct SoftwareRenderer;
-#[cfg(not(feature = "software-rendering"))]
-impl SoftwareRenderer {
-    fn new() -> Self {
-        panic!("The software renderer is not compiled in.")
-    }
-
-    #[expect(warnings)]
-    fn render(
-        &mut self,
-        _: &LayoutState,
-        _: &ImageCache,
-        _: &mut [u8],
-        _: [u32; 2],
-        _: u32,
-        _: bool,
-    ) {
-    }
-}
 
 /// type
 pub type OwnedSoftwareRenderer = Box<SoftwareRenderer>;

--- a/capi/src/timer.rs
+++ b/capi/src/timer.rs
@@ -1,10 +1,9 @@
 //! A Timer provides all the capabilities necessary for doing speedrun attempts.
 
 use super::{output_str, output_time, output_time_span, output_vec, str};
-use crate::{
-    run::{NullableOwnedRun, OwnedRun},
-    shared_timer::OwnedSharedTimer,
-};
+use crate::run::{NullableOwnedRun, OwnedRun};
+#[cfg(feature = "shared-timer")]
+use crate::shared_timer::OwnedSharedTimer;
 use livesplit_core::{
     Run, Time, TimeSpan, Timer, TimerPhase, TimingMethod,
     event::{Error, Event},
@@ -29,6 +28,7 @@ pub extern "C" fn Timer_new(run: OwnedRun) -> NullableOwnedTimer {
 /// Consumes the Timer and creates a Shared Timer that can be shared across
 /// multiple threads with multiple owners.
 #[unsafe(no_mangle)]
+#[cfg(feature = "shared-timer")]
 pub extern "C" fn Timer_into_shared(this: OwnedTimer) -> OwnedSharedTimer {
     Box::new((*this).into_shared())
 }


### PR DESCRIPTION
Gate each exported C API type behind Cargo features and provide logical groups for parsing, timing, editing, layouts, and hotkeys. Remove disabled backend stubs so omitted capabilities no longer contribute types or exports.

Teach the binding generator to resolve the same feature graph and evaluate cfg attributes, writing subset output separately and only emitting handwritten helpers backed by selected functions. Document matching library and binding subset builds.