### PR TITLE
Defer WASI startup until the first update

### DIFF
--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -70,11 +70,6 @@ pub enum CreationError {
         /// The underlying error.
         source: wasmtime::Error,
     },
-    /// Failed running the WebAssembly System Interface (WASI) `_start` function.
-    WasiStart {
-        /// The underlying error.
-        source: wasmtime::Error,
-    },
 }
 
 slotmap::new_key_type! {
@@ -221,6 +216,7 @@ struct SharedData {
 struct ExclusiveData<T: 'static> {
     trapped: bool,
     store: Store<Context<T>>,
+    initialize: Option<TypedFunc<(), ()>>,
     update: TypedFunc<(), ()>,
 }
 
@@ -249,13 +245,21 @@ pub struct ExecutionGuard<'runtime, T: Timer> {
 
 impl<T: Timer> ExecutionGuard<'_, T> {
     /// Runs the exported `update` function of the WebAssembly module a single
-    /// time.
+    /// time. On the first call, the module's `_initialize` or `_start` export,
+    /// if present, runs immediately before `update`. This keeps arbitrary
+    /// initialization code interruptible through [`InterruptHandle`].
     pub fn update(&mut self) -> Result<()> {
         let data = &mut *self.data;
         if data.trapped {
             return Ok(());
         }
-        let result = data.update.call(&mut data.store, ());
+        let result = if let Some(initialize) = data.initialize.take() {
+            initialize
+                .call(&mut data.store, ())
+                .and_then(|()| data.update.call(&mut data.store, ()))
+        } else {
+            data.update.call(&mut data.store, ())
+        };
 
         if result.is_ok() {
             self.settings_widgets
@@ -365,7 +369,11 @@ impl Runtime {
 }
 
 impl CompiledAutoSplitter {
-    /// Instantiates the auto splitter with the given timer.
+    /// Instantiates the auto splitter with the given timer. A conventional
+    /// `_initialize` or `_start` export is retained for the first
+    /// [`ExecutionGuard::update`] call rather than executed here, so callers
+    /// can obtain an [`InterruptHandle`] before arbitrary initialization code
+    /// runs.
     pub fn instantiate<T: Timer>(
         &self,
         timer: T,
@@ -432,16 +440,16 @@ impl CompiledAutoSplitter {
                 format_args!("This auto splitter uses WASI. The API is subject to change, because WASI is still in preview. Auto splitters using WASI may need to be recompiled in the future."),
                 LogLevel::Warning,
             );
-
-            // These may be different in future WASI versions.
-            if let Ok(func) = instance.get_typed_func::<(), ()>(&mut store, "_initialize") {
-                func.call(&mut store, ())
-                    .map_err(|source| CreationError::WasiStart { source })?;
-            } else if let Ok(func) = instance.get_typed_func::<(), ()>(&mut store, "_start") {
-                func.call(&mut store, ())
-                    .map_err(|source| CreationError::WasiStart { source })?;
-            }
         }
+
+        // Initialization is deferred until the first update. This ensures that
+        // arbitrary startup code runs only after the caller can obtain an
+        // interrupt handle, just like every later invocation of `update`.
+        // These exports may be different in future WASI versions.
+        let initialize = instance
+            .get_typed_func::<(), ()>(&mut store, "_initialize")
+            .ok()
+            .or_else(|| instance.get_typed_func::<(), ()>(&mut store, "_start").ok());
 
         let update = instance
             .get_typed_func(&mut store, "update")
@@ -451,6 +459,7 @@ impl CompiledAutoSplitter {
             exclusive_data: Mutex::new(ExclusiveData {
                 trapped: false,
                 store,
+                initialize,
                 update,
             }),
             engine: engine.clone(),

--- a/crates/livesplit-auto-splitting/tests/sandboxing.rs
+++ b/crates/livesplit-auto-splitting/tests/sandboxing.rs
@@ -1,4 +1,5 @@
 use livesplit_auto_splitting::{AutoSplitter, Config, LogLevel, Runtime, Timer, TimerState};
+use livesplit_auto_splitting::{settings, settings::Value};
 use std::{
     ffi::OsStr,
     fmt, fs,
@@ -35,6 +36,14 @@ impl Timer for DummyTimer {
 
 #[track_caller]
 fn compile(crate_name: &str) -> wasmtime::Result<AutoSplitter<DummyTimer>> {
+    compile_with_settings(crate_name, None)
+}
+
+#[track_caller]
+fn compile_with_settings(
+    crate_name: &str,
+    settings_map: Option<settings::Map>,
+) -> wasmtime::Result<AutoSplitter<DummyTimer>> {
     let mut path = PathBuf::from("tests");
     path.push("test-cases");
     path.push(crate_name);
@@ -71,7 +80,7 @@ fn compile(crate_name: &str) -> wasmtime::Result<AutoSplitter<DummyTimer>> {
 
     Ok(Runtime::new(Config::default())?
         .compile(&fs::read(wasm_path).unwrap())?
-        .instantiate(DummyTimer, None, None)?)
+        .instantiate(DummyTimer, settings_map, None)?)
 }
 
 #[track_caller]
@@ -84,6 +93,38 @@ fn run(crate_name: &str) -> wasmtime::Result<()> {
 #[test]
 fn empty() {
     run("empty").unwrap();
+}
+
+#[test]
+fn startup_is_deferred_until_the_first_interruptible_update() {
+    let mut settings = settings::Map::new();
+    settings.insert("enabled".into(), Value::Bool(true));
+    let runtime = compile_with_settings("startup", Some(settings)).unwrap();
+
+    assert_eq!(runtime.tick_rate(), Duration::from_secs_f64(1.0 / 120.0));
+    assert!(runtime.settings_widgets().is_empty());
+
+    runtime.lock().update().unwrap();
+    assert_eq!(runtime.tick_rate(), Duration::from_secs_f64(1.0 / 42.0));
+    assert_eq!(runtime.settings_widgets().len(), 2);
+
+    runtime.lock().update().unwrap();
+    assert_eq!(runtime.settings_widgets().len(), 2);
+}
+
+#[test]
+fn startup_can_be_interrupted() {
+    let mut settings = settings::Map::new();
+    settings.insert("hang".into(), Value::Bool(true));
+    let runtime = compile_with_settings("startup", Some(settings)).unwrap();
+    let interrupt = runtime.interrupt_handle();
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        interrupt.interrupt();
+    });
+
+    assert!(runtime.lock().update().is_err());
 }
 
 #[test]

--- a/crates/livesplit-auto-splitting/tests/test-cases/startup/Cargo.toml
+++ b/crates/livesplit-auto-splitting/tests/test-cases/startup/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "startup"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+
+[dependencies]

--- a/crates/livesplit-auto-splitting/tests/test-cases/startup/src/main.rs
+++ b/crates/livesplit-auto-splitting/tests/test-cases/startup/src/main.rs
@@ -1,0 +1,50 @@
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    safe fn runtime_set_tick_rate(ticks_per_second: f64);
+    fn runtime_print_message(text_ptr: *const u8, text_len: usize);
+    fn user_settings_add_bool(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        default_value: u32,
+    ) -> u32;
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn update() {}
+
+fn main() {
+    let key = "enabled";
+    let description = "Enabled";
+    let enabled = unsafe {
+        user_settings_add_bool(
+            key.as_ptr(),
+            key.len(),
+            description.as_ptr(),
+            description.len(),
+            0,
+        )
+    };
+    runtime_set_tick_rate(if enabled != 0 { 42.0 } else { 24.0 });
+
+    let hang_key = "hang";
+    let hang_description = "Hang during startup";
+    let hang = unsafe {
+        user_settings_add_bool(
+            hang_key.as_ptr(),
+            hang_key.len(),
+            hang_description.as_ptr(),
+            hang_description.len(),
+            0,
+        )
+    };
+    if hang != 0 {
+        loop {
+            std::hint::spin_loop();
+        }
+    }
+
+    let message = "startup completed";
+    unsafe { runtime_print_message(message.as_ptr(), message.len()) };
+}


### PR DESCRIPTION
WebAssembly start functions currently run during instantiation, before callers can obtain an interrupt handle, so a hanging initializer can block the runtime indefinitely. Defer initialization until the first update so startup code is covered by the normal interruption mechanism.