### PR TITLE
Add text input widget

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -361,6 +361,20 @@ unsafe extern "C" {
         mime_type_ptr: *const u8,
         mime_type_len: usize,
     );
+    /// Adds a new text input setting that the user can modify. This allows the
+    /// user to enter a free-form string. The key is used to store the value in
+    /// the settings map and needs to be unique across all types of settings.
+    /// The description is what's shown to the user. The default value is used
+    /// if the key is not yet present in the settings map. The pointers need to
+    /// point to valid UTF-8 encoded text with the respective given length.
+    pub fn user_settings_add_text_input(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+        default_value_ptr: *const u8,
+        default_value_len: usize,
+    );
     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
     /// explaining the purpose of a setting to the user. The pointers need to
     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -361,6 +361,20 @@
 //!         mime_type_ptr: *const u8,
 //!         mime_type_len: usize,
 //!     );
+//!     /// Adds a new text input setting that the user can modify. This allows the
+//!     /// user to enter a free-form string. The key is used to store the value in
+//!     /// the settings map and needs to be unique across all types of settings.
+//!     /// The description is what's shown to the user. The default value is used
+//!     /// if the key is not yet present in the settings map. The pointers need to
+//!     /// point to valid UTF-8 encoded text with the respective given length.
+//!     pub fn user_settings_add_text_input(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         default_value_ptr: *const u8,
+//!         default_value_len: usize,
+//!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -207,6 +207,32 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "user_settings_add_file_select_mime_filter",
         })?
+        .func_wrap("env", "user_settings_add_text_input", {
+            |mut caller: Caller<Context<T>>,
+             key_ptr: u32,
+             key_len: u32,
+             description_ptr: u32,
+             description_len: u32,
+             default_value_ptr: u32,
+             default_value_len: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = get_str(memory, key_ptr, key_len)?.into();
+                let description = get_str(memory, description_ptr, description_len)?.into();
+                let default_value =
+                    get_str(memory, default_value_ptr, default_value_len)?.into();
+                Arc::make_mut(&mut context.settings_widgets).push(settings::Widget {
+                    key,
+                    description,
+                    tooltip: None,
+                    kind: settings::WidgetKind::TextInput { default_value },
+                });
+                Ok(())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_add_text_input",
+        })?
         .func_wrap("env", "user_settings_set_tooltip", {
             |mut caller: Caller<Context<T>>,
              key_ptr: u32,

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -48,6 +48,12 @@ pub enum WidgetKind {
         /// The filters that are used to filter the files that can be selected.
         filters: Arc<Vec<FileFilter>>,
     },
+    /// A free-form text input setting.
+    TextInput {
+        /// The default value of the setting, if it's not available in the
+        /// settings [`Map`](super::Map) yet.
+        default_value: Arc<str>,
+    },
 }
 
 /// A filter for a file selection setting.

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -361,6 +361,20 @@
 //!         mime_type_ptr: *const u8,
 //!         mime_type_len: usize,
 //!     );
+//!     /// Adds a new text input setting that the user can modify. This allows the
+//!     /// user to enter a free-form string. The key is used to store the value in
+//!     /// the settings map and needs to be unique across all types of settings.
+//!     /// The description is what's shown to the user. The default value is used
+//!     /// if the key is not yet present in the settings map. The pointers need to
+//!     /// point to valid UTF-8 encoded text with the respective given length.
+//!     pub fn user_settings_add_text_input(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!         default_value_ptr: *const u8,
+//!         default_value_len: usize,
+//!     );
 //!     /// Adds a tooltip to a setting based on its key. A tooltip is useful for
 //!     /// explaining the purpose of a setting to the user. The pointers need to
 //!     /// point to valid UTF-8 encoded text with the respective given length.


### PR DESCRIPTION
Adds a widget allowing text input from the user.

Related PRs to enable this functionality across the ecosystem:
- https://github.com/LiveSplit/asr/pull/136
- https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/26
- https://github.com/LiveSplit/asr-debugger/pull/27