### PR TITLE
Add support for buttons in autosplitter settings

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -21,6 +21,18 @@ splitter.
 In addition the WebAssembly module is expected to export a memory called
 `memory`.
 
+They may also optionally provide an `on_settings_button` function with the
+following signature:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn on_settings_button() {}
+```
+
+This function is called when the user clicks a settings button. The auto
+splitter can retrieve the key of the button that was clicked by calling
+`user_settings_get_button_key`.
+
 ## API exposed to the Auto Splitters
 
 The following functions are provided to the auto splitters in the module
@@ -281,6 +293,18 @@ unsafe extern "C" {
         description_len: usize,
         heading_level: u32,
     );
+    /// Adds a new button to the user settings. This is used to trigger an
+    /// action in the auto splitter. The key needs to be unique across all
+    /// types of settings and is not persisted in the settings map. The
+    /// pointers need to point to valid UTF-8 encoded text with the respective
+    /// given length. When the user clicks the button, the auto splitter's
+    /// `on_settings_button` export is called.
+    pub fn user_settings_add_button(
+        key_ptr: *const u8,
+        key_len: usize,
+        description_ptr: *const u8,
+        description_len: usize,
+    );
     /// Adds a new choice setting that the user can modify. This allows the user
     /// to choose between various options. The key is used to store the setting
     /// in the settings map and needs to be unique across all types of settings.
@@ -370,6 +394,15 @@ unsafe extern "C" {
         tooltip_ptr: *const u8,
         tooltip_len: usize,
     );
+    /// Stores the key of the settings button that is currently being invoked
+    /// in the buffer given. Returns `false` if the buffer is too small or if
+    /// no settings button is currently being invoked. After this call, no
+    /// matter whether it was successful or not, the `buf_len_ptr` will be set
+    /// to the required buffer size. If `false` is returned and the
+    /// `buf_len_ptr` got set to 0, no settings button is currently being
+    /// invoked. The key is guaranteed to be valid UTF-8 and is not
+    /// nul-terminated.
+    pub fn user_settings_get_button_key(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
     /// Creates a new settings map. You own the settings map and are responsible
     /// for freeing it.

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -19,6 +19,18 @@
 //! In addition the WebAssembly module is expected to export a memory called
 //! `memory`.
 //!
+//! They may also optionally provide an `on_settings_button` function with the
+//! following signature:
+//!
+//! ```rust
+//! #[unsafe(no_mangle)]
+//! pub extern "C" fn on_settings_button() {}
+//! ```
+//!
+//! This function is called when the user clicks a settings button. The auto
+//! splitter can retrieve the key of the button that was clicked by calling
+//! `user_settings_get_button_key`.
+//!
 //! # API exposed to the Auto Splitters
 //!
 //! The following functions are provided to the auto splitters in the module
@@ -281,6 +293,18 @@
 //!         description_len: usize,
 //!         heading_level: u32,
 //!     );
+//!     /// Adds a new button to the user settings. This is used to trigger an
+//!     /// action in the auto splitter. The key needs to be unique across all
+//!     /// types of settings and is not persisted in the settings map. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length. When the user clicks the button, the auto splitter's
+//!     /// `on_settings_button` export is called.
+//!     pub fn user_settings_add_button(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!     );
 //!     /// Adds a new choice setting that the user can modify. This allows the user
 //!     /// to choose between various options. The key is used to store the setting
 //!     /// in the settings map and needs to be unique across all types of settings.
@@ -370,6 +394,15 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Stores the key of the settings button that is currently being invoked
+//!     /// in the buffer given. Returns `false` if the buffer is too small or if
+//!     /// no settings button is currently being invoked. After this call, no
+//!     /// matter whether it was successful or not, the `buf_len_ptr` will be set
+//!     /// to the required buffer size. If `false` is returned and the
+//!     /// `buf_len_ptr` got set to 0, no settings button is currently being
+//!     /// invoked. The key is guaranteed to be valid UTF-8 and is not
+//!     /// nul-terminated.
+//!     pub fn user_settings_get_button_key(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
 //!     /// Creates a new settings map. You own the settings map and are responsible
 //!     /// for freeing it.

--- a/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/user_settings.rs
@@ -4,7 +4,7 @@ use wasmtime::{Caller, Error, Linker};
 
 use crate::{CreationError, Timer, runtime::Context, settings};
 
-use super::{get_str, memory_and_context};
+use super::{get_arr_mut, get_slice_mut, get_str, memory_and_context};
 
 pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationError> {
     linker
@@ -58,6 +58,28 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "user_settings_add_title",
+        })?
+        .func_wrap("env", "user_settings_add_button", {
+            |mut caller: Caller<Context<T>>,
+             key_ptr: u32,
+             key_len: u32,
+             description_ptr: u32,
+             description_len: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = get_str(memory, key_ptr, key_len)?.into();
+                let description = get_str(memory, description_ptr, description_len)?.into();
+                Arc::make_mut(&mut context.settings_widgets).push(settings::Widget {
+                    key,
+                    description,
+                    tooltip: None,
+                    kind: settings::WidgetKind::Button,
+                });
+                Ok(())
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_add_button",
         })?
         .func_wrap("env", "user_settings_add_choice", {
             |mut caller: Caller<Context<T>>,
@@ -227,6 +249,32 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "user_settings_set_tooltip",
+        })?
+        .func_wrap("env", "user_settings_get_button_key", {
+            |mut caller: Caller<Context<T>>, ptr: u32, len_ptr: u32| {
+                let (memory, context) = memory_and_context(&mut caller);
+                let key = context.pending_button_key.clone();
+
+                let len_bytes = get_arr_mut(memory, len_ptr)?;
+                let Some(key) = key else {
+                    *len_bytes = 0u32.to_le_bytes();
+                    return Ok(0u32);
+                };
+
+                let len = u32::from_le_bytes(*len_bytes) as usize;
+                *len_bytes = (key.len() as u32).to_le_bytes();
+
+                if len < key.len() {
+                    return Ok(0u32);
+                }
+                let buf = get_slice_mut(memory, ptr, key.len() as _)?;
+                buf.copy_from_slice(key.as_bytes());
+                Ok(1u32)
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "user_settings_get_button_key",
         })?;
     Ok(())
 }

--- a/crates/livesplit-auto-splitting/src/runtime/mod.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/mod.rs
@@ -91,6 +91,7 @@ pub struct Context<T> {
     process_list: ProcessList,
     wasi: WasiP1Ctx,
     stderr: StdErr,
+    pending_button_key: Option<Arc<str>>,
 }
 
 /// A thread-safe handle used to interrupt the execution of the script.
@@ -218,6 +219,7 @@ struct ExclusiveData<T: 'static> {
     store: Store<Context<T>>,
     initialize: Option<TypedFunc<(), ()>>,
     update: TypedFunc<(), ()>,
+    on_settings_button: Option<TypedFunc<(), ()>>,
 }
 
 /// An instantiated auto splitter that is ready to be executed. You generally
@@ -260,6 +262,45 @@ impl<T: Timer> ExecutionGuard<'_, T> {
         } else {
             data.update.call(&mut data.store, ())
         };
+
+        if result.is_ok() {
+            self.settings_widgets
+                .store(data.store.data().settings_widgets.clone());
+        } else {
+            data.trapped = true;
+        }
+
+        let data = data.store.data_mut();
+        data.stderr.print_lines(&mut data.timer);
+
+        result
+    }
+
+    /// Runs the exported `on_settings_button` function of the WebAssembly
+    /// module for the given settings button key. The auto splitter can then
+    /// retrieve the key by calling `user_settings_get_button_key`. If the auto
+    /// splitter does not export `on_settings_button`, this logs a debug message
+    /// and returns successfully. The pending key is cleared after the call,
+    /// including when the auto splitter traps.
+    pub fn invoke_settings_button(&mut self, key: &str) -> Result<()> {
+        let data = &mut *self.data;
+        if data.trapped {
+            return Ok(());
+        }
+
+        let Some(on_settings_button) = data.on_settings_button.as_ref() else {
+            data.store.data_mut().timer.log_runtime(
+                format_args!(
+                    "Settings button `{key}` was clicked, but the auto splitter does not export `on_settings_button`."
+                ),
+                LogLevel::Debug,
+            );
+            return Ok(());
+        };
+
+        data.store.data_mut().pending_button_key = Some(Arc::from(key));
+        let result = on_settings_button.call(&mut data.store, ());
+        data.store.data_mut().pending_button_key = None;
 
         if result.is_ok() {
             self.settings_widgets
@@ -405,6 +446,7 @@ impl CompiledAutoSplitter {
                 process_list: ProcessList::new(),
                 wasi,
                 stderr,
+                pending_button_key: None,
             },
         );
 
@@ -455,12 +497,17 @@ impl CompiledAutoSplitter {
             .get_typed_func(&mut store, "update")
             .map_err(|source| CreationError::MissingUpdateFunction { source })?;
 
+        let on_settings_button = instance
+            .get_typed_func::<(), ()>(&mut store, "on_settings_button")
+            .ok();
+
         Ok(AutoSplitter {
             exclusive_data: Mutex::new(ExclusiveData {
                 trapped: false,
                 store,
                 initialize,
                 update,
+                on_settings_button,
             }),
             engine: engine.clone(),
             settings_widgets: ArcSwap::new(settings_widgets),
@@ -551,5 +598,12 @@ impl<T: Timer> AutoSplitter<T> {
     /// applied to the settings map and stored back.
     pub fn settings_widgets(&self) -> Arc<Vec<settings::Widget>> {
         self.settings_widgets.load_full()
+    }
+
+    /// Invokes the auto splitter's `on_settings_button` export for the given
+    /// settings button key. This locks the auto splitter, so it may block if
+    /// another thread is currently executing it.
+    pub fn invoke_settings_button(&self, key: &str) -> Result<()> {
+        self.lock().invoke_settings_button(key)
     }
 }

--- a/crates/livesplit-auto-splitting/src/settings/gui.rs
+++ b/crates/livesplit-auto-splitting/src/settings/gui.rs
@@ -29,6 +29,10 @@ pub enum WidgetKind {
         /// The top level titles use a heading level of 0.
         heading_level: u32,
     },
+    /// A button that is shown to the user. It doesn't by itself store a value
+    /// and is not persisted in the settings [`Map`](super::Map). Clicking it
+    /// invokes the auto splitter's `on_settings_button` export.
+    Button,
     /// A boolean setting. This could be shown as a checkbox or a toggle.
     Bool {
         /// The default value of the setting, if it's not available in the

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -19,6 +19,18 @@
 //! In addition the WebAssembly module is expected to export a memory called
 //! `memory`.
 //!
+//! They may also optionally provide an `on_settings_button` function with the
+//! following signature:
+//!
+//! ```rust
+//! #[unsafe(no_mangle)]
+//! pub extern "C" fn on_settings_button() {}
+//! ```
+//!
+//! This function is called when the user clicks a settings button. The auto
+//! splitter can retrieve the key of the button that was clicked by calling
+//! `user_settings_get_button_key`.
+//!
 //! # API exposed to the Auto Splitters
 //!
 //! The following functions are provided to the auto splitters in the module
@@ -281,6 +293,18 @@
 //!         description_len: usize,
 //!         heading_level: u32,
 //!     );
+//!     /// Adds a new button to the user settings. This is used to trigger an
+//!     /// action in the auto splitter. The key needs to be unique across all
+//!     /// types of settings and is not persisted in the settings map. The
+//!     /// pointers need to point to valid UTF-8 encoded text with the respective
+//!     /// given length. When the user clicks the button, the auto splitter's
+//!     /// `on_settings_button` export is called.
+//!     pub fn user_settings_add_button(
+//!         key_ptr: *const u8,
+//!         key_len: usize,
+//!         description_ptr: *const u8,
+//!         description_len: usize,
+//!     );
 //!     /// Adds a new choice setting that the user can modify. This allows the user
 //!     /// to choose between various options. The key is used to store the setting
 //!     /// in the settings map and needs to be unique across all types of settings.
@@ -370,6 +394,15 @@
 //!         tooltip_ptr: *const u8,
 //!         tooltip_len: usize,
 //!     );
+//!     /// Stores the key of the settings button that is currently being invoked
+//!     /// in the buffer given. Returns `false` if the buffer is too small or if
+//!     /// no settings button is currently being invoked. After this call, no
+//!     /// matter whether it was successful or not, the `buf_len_ptr` will be set
+//!     /// to the required buffer size. If `false` is returned and the
+//!     /// `buf_len_ptr` got set to 0, no settings button is currently being
+//!     /// invoked. The key is guaranteed to be valid UTF-8 and is not
+//!     /// nul-terminated.
+//!     pub fn user_settings_get_button_key(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!
 //!     /// Creates a new settings map. You own the settings map and are responsible
 //!     /// for freeing it.
@@ -782,6 +815,20 @@ impl<T: event::CommandSink + TimerQuery + Send + 'static> Runtime<T> {
                 .as_ref()?
                 .settings_widgets(),
         )
+    }
+
+    /// Invokes the auto splitter's `on_settings_button` export for the given
+    /// settings button key. Returns [`None`] if there is no auto splitter
+    /// loaded. If the auto splitter traps, it is unloaded.
+    pub fn invoke_settings_button(&self, key: &str) -> Option<()> {
+        let auto_splitter = self.shared_state.auto_splitter.load();
+        let auto_splitter = auto_splitter.as_ref()?;
+        if let Err(e) = auto_splitter.invoke_settings_button(key) {
+            self.shared_state.auto_splitter.store(None);
+            log::error!(target: "Auto Splitter", "Unloaded, because the script trapped: {:?}", e);
+            let _ = self.changed_sender.send(());
+        }
+        Some(())
     }
 }
 


### PR DESCRIPTION
Adds a `WidgetKind::Button` and `user_settings_add_button` so autosplitters can have action buttons in the settings UI.

Hosts invoke clicks with `invoke_settings_button(key)`. 

The optional no-arg `on_settings_button` export should pull the key to match to a button via `user_settings_get_button_key` - this was intended to be the same buffer protocol as other implementations in this repo (like `runtime_get_os`). The alternative was for the host to write directly into guest memory to provide the key, but this added a fair amount of complexity that didn't align with existing patterns so I decided against it.

Related PRs to enable this functionality across the ecosystem:
- https://github.com/LiveSplit/asr/pull/137
- https://github.com/LiveSplit/asr-debugger/pull/28
- https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/27