### PR TITLE
Add splits path getter for autosplitters

### DIFF
--- a/crates/livesplit-auto-splitting/README.md
+++ b/crates/livesplit-auto-splitting/README.md
@@ -249,6 +249,13 @@ unsafe extern "C" {
     /// guaranteed to be valid UTF-8 and is not nul-terminated.
     /// Example values: `windows`, `linux`, `macos`
     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+    /// Stores the WASI path of the currently loaded splits file in the buffer
+    /// given. Returns `false` if there is no splits path or the buffer is too
+    /// small. After this call, no matter whether it was successful or not, the
+    /// `buf_len_ptr` will be set to the required buffer size, or `0` if there
+    /// is no splits path. The path is guaranteed to be valid UTF-8 and is not
+    /// nul-terminated.
+    pub fn runtime_get_splits_path(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
     /// Stores the name of the architecture that the runtime is running on
     /// in the buffer given. Returns `false` if the buffer is too small.
     /// After this call, no matter whether it was successful or not, the

--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -249,6 +249,13 @@
 //!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
 //!     /// Example values: `windows`, `linux`, `macos`
 //!     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+//!     /// Stores the WASI path of the currently loaded splits file in the buffer
+//!     /// given. Returns `false` if there is no splits path or the buffer is too
+//!     /// small. After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size, or `0` if there
+//!     /// is no splits path. The path is guaranteed to be valid UTF-8 and is not
+//!     /// nul-terminated.
+//!     pub fn runtime_get_splits_path(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!     /// Stores the name of the architecture that the runtime is running on
 //!     /// in the buffer given. Returns `false` if the buffer is too small.
 //!     /// After this call, no matter whether it was successful or not, the

--- a/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/runtime.rs
@@ -73,6 +73,38 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
             source,
             name: "runtime_get_os",
         })?
+        .func_wrap("env", "runtime_get_splits_path", {
+            |mut caller: Caller<Context<T>>, ptr: u32, len_ptr: u32| {
+                let path = caller
+                    .data()
+                    .timer
+                    .splits_path()
+                    .and_then(|path| crate::wasi_path::from_native(&path));
+
+                let (memory, _) = memory_and_context(&mut caller);
+                let len_bytes = get_arr_mut(memory, len_ptr)?;
+
+                let Some(path) = path else {
+                    *len_bytes = 0u32.to_le_bytes();
+                    return Ok(0u32);
+                };
+
+                let needed = path.len();
+                let len = u32::from_le_bytes(*len_bytes) as usize;
+                *len_bytes = (needed as u32).to_le_bytes();
+
+                if len < needed {
+                    return Ok(0u32);
+                }
+                let buf = get_slice_mut(memory, ptr, needed as _)?;
+                buf.copy_from_slice(path.as_bytes());
+                Ok(1u32)
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "runtime_get_splits_path",
+        })?
         .func_wrap("env", "runtime_get_arch", {
             |mut caller: Caller<Context<T>>, ptr: u32, len_ptr: u32| {
                 let (memory, _) = memory_and_context(&mut caller);

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -73,4 +73,8 @@ pub trait Timer: Send + 'static {
     fn log_auto_splitter(&mut self, message: fmt::Arguments);
     /// Logs a message from the runtime.
     fn log_runtime(&mut self, message: fmt::Arguments, log_level: LogLevel);
+    /// The path of the currently loaded splits file, if any.
+    fn splits_path(&self) -> Option<std::path::PathBuf> {
+        None
+    }
 }

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -249,6 +249,13 @@
 //!     /// guaranteed to be valid UTF-8 and is not nul-terminated.
 //!     /// Example values: `windows`, `linux`, `macos`
 //!     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+//!     /// Stores the WASI path of the currently loaded splits file in the buffer
+//!     /// given. Returns `false` if there is no splits path or the buffer is too
+//!     /// small. After this call, no matter whether it was successful or not, the
+//!     /// `buf_len_ptr` will be set to the required buffer size, or `0` if there
+//!     /// is no splits path. The path is guaranteed to be valid UTF-8 and is not
+//!     /// nul-terminated.
+//!     pub fn runtime_get_splits_path(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 //!     /// Stores the name of the architecture that the runtime is running on
 //!     /// in the buffer given. Returns `false` if the buffer is too small.
 //!     /// After this call, no matter whether it was successful or not, the


### PR DESCRIPTION
Allows autosplitters to access the WASI filesystem path of the current splits file (if one is loaded).

Related PRs:
- https://github.com/LiveSplit/asr/pull/138
- https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/28