### PR TITLE
Allow autosplitters to set timer's timing method

### DIFF
--- a/crates/livesplit-auto-splitting/src/lib.rs
+++ b/crates/livesplit-auto-splitting/src/lib.rs
@@ -140,6 +140,8 @@
 //!     /// Resumes the game time. This does not resume the timer, only the
 //!     /// automatic flow of time for the game time.
 //!     pub safe fn timer_resume_game_time();
+//!     /// Sets whether the timer compares against real time or game time.
+//!     pub safe fn timer_set_timing_method(method: u32);
 //!
 //!     /// Attaches to a process based on its name. The pointer needs to point to
 //!     /// valid UTF-8 encoded text with the given length. If multiple processes
@@ -586,7 +588,7 @@ pub use runtime::{
     Runtime,
 };
 pub use time;
-pub use timer::{LogLevel, Timer, TimerState};
+pub use timer::{LogLevel, Timer, TimerState, TimingMethod};
 
 const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}

--- a/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
+++ b/crates/livesplit-auto-splitting/src/runtime/api/timer.rs
@@ -124,6 +124,20 @@ pub fn bind<T: Timer>(linker: &mut Linker<Context<T>>) -> Result<(), CreationErr
         .map_err(|source| CreationError::LinkFunction {
             source,
             name: "timer_resume_game_time",
+        })?
+        .func_wrap("env", "timer_set_timing_method", {
+            |mut caller: Caller<Context<T>>, method: u32| {
+                let method = match method {
+                    0 => crate::TimingMethod::RealTime,
+                    1 => crate::TimingMethod::GameTime,
+                    _ => return,
+                };
+                caller.data_mut().timer.set_timing_method(method);
+            }
+        })
+        .map_err(|source| CreationError::LinkFunction {
+            source,
+            name: "timer_set_timing_method",
         })?;
     Ok(())
 }

--- a/crates/livesplit-auto-splitting/src/timer.rs
+++ b/crates/livesplit-auto-splitting/src/timer.rs
@@ -16,6 +16,16 @@ pub enum TimerState {
     Ended = 3,
 }
 
+/// Whether the timer compares against real time or game time.
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TimingMethod {
+    /// Compare against real time.
+    RealTime = 0,
+    /// Compare against game time.
+    GameTime = 1,
+}
+
 /// The level of criticalness of a log message.
 pub enum LogLevel {
     /// A trace message. This is the least critical and most verbose message.
@@ -66,6 +76,8 @@ pub trait Timer: Send + 'static {
     /// Resumes the game time. This does not resume the timer, only the
     /// automatic flow of time for the game time.
     fn resume_game_time(&mut self);
+    /// Sets whether the timer compares against real time or game time.
+    fn set_timing_method(&mut self, _method: TimingMethod) {}
     /// Sets a custom key value pair. This may be arbitrary information that the
     /// auto splitter wants to provide for visualization.
     fn set_variable(&mut self, key: &str, value: &str);

--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -140,6 +140,8 @@
 //!     /// Resumes the game time. This does not resume the timer, only the
 //!     /// automatic flow of time for the game time.
 //!     pub safe fn timer_resume_game_time();
+//!     /// Sets whether the timer compares against real time or game time.
+//!     pub safe fn timer_set_timing_method(method: u32);
 //!
 //!     /// Attaches to a process based on its name. The pointer needs to point to
 //!     /// valid UTF-8 encoded text with the given length. If multiple processes
@@ -848,6 +850,14 @@ impl<E: event::CommandSink + TimerQuery + Send + 'static> AutoSplitTimer for Tim
 
     fn resume_game_time(&mut self) {
         drop(self.0.resume_game_time());
+    }
+
+    fn set_timing_method(&mut self, method: livesplit_auto_splitting::TimingMethod) {
+        let method = match method {
+            livesplit_auto_splitting::TimingMethod::RealTime => crate::TimingMethod::RealTime,
+            livesplit_auto_splitting::TimingMethod::GameTime => crate::TimingMethod::GameTime,
+        };
+        drop(self.0.set_current_timing_method(method));
     }
 
     fn set_variable(&mut self, name: &str, value: &str) {


### PR DESCRIPTION
Related PRs:
- https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/29
- https://github.com/LiveSplit/asr/pull/139