### PR TITLE
Detailed Timer timing method override fix to apply to segment timer

### DIFF
--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -72,12 +72,10 @@ pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
                 "Comparison" => comparison_override(reader, |v| settings.comparison1 = v),
                 "Comparison2" => comparison_override(reader, |v| settings.comparison2 = v),
                 "HideComparison" => parse_bool(reader, |b| settings.hide_second_comparison = b),
-                "TimingMethod" => {
-                    timing_method_override(reader, |v| {
-                        settings.timer.timing_method = v;
-                        settings.segment_timer.timing_method = v;
-                    })
-                }
+                "TimingMethod" => timing_method_override(reader, |v| {
+                    settings.timer.timing_method = v;
+                    settings.segment_timer.timing_method = v;
+                }),
                 _ => {
                     // FIXME:
                     // Width

--- a/src/layout/parser/detailed_timer.rs
+++ b/src/layout/parser/detailed_timer.rs
@@ -73,7 +73,10 @@ pub fn settings(reader: &mut Reader, component: &mut Component) -> Result<()> {
                 "Comparison2" => comparison_override(reader, |v| settings.comparison2 = v),
                 "HideComparison" => parse_bool(reader, |b| settings.hide_second_comparison = b),
                 "TimingMethod" => {
-                    timing_method_override(reader, |v| settings.timer.timing_method = v)
+                    timing_method_override(reader, |v| {
+                        settings.timer.timing_method = v;
+                        settings.segment_timer.timing_method = v;
+                    })
                 }
                 _ => {
                     // FIXME:

--- a/tests/layout_files/DetailedTimerGameTime.lsl
+++ b/tests/layout_files/DetailedTimerGameTime.lsl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Layout version="1.6.1">
+  <Mode>Vertical</Mode>
+  <Components>
+    <Component>
+      <Path>LiveSplit.DetailedTimer.dll</Path>
+      <Settings>
+        <Version>1.5</Version>
+        <Height>75</Height>
+        <SegmentTimerSizeRatio>40</SegmentTimerSizeRatio>
+        <TimingMethod>Game Time</TimingMethod>
+      </Settings>
+    </Component>
+  </Components>
+</Layout>

--- a/tests/layout_files/mod.rs
+++ b/tests/layout_files/mod.rs
@@ -6,6 +6,7 @@ pub const SUBSPLITS: &str = include_str!("subsplits.lsl");
 pub const WSPLIT: &str = include_str!("WSplit.lsl");
 pub const WITH_TIMER_DELTA_BACKGROUND: &str = include_str!("WithTimerDeltaBackground.lsl");
 pub const WITH_BACKGROUND_IMAGE: &str = include_str!("WithBackgroundImage.lsl");
+pub const DETAILED_TIMER_GAME_TIME: &str = include_str!("DetailedTimerGameTime.lsl");
 pub const TEXT_SHADOW: &str = include_str!("TextShadow.ls1l");
 pub const CUSTOM_VARIABLE_SPLITS: &str = include_str!("custom_variable_splits.lsl");
 pub const CUSTOM_VARIABLE_SUBSPLITS: &str = include_str!("custom_variable_subsplits.lsl");

--- a/tests/layout_parsing.rs
+++ b/tests/layout_parsing.rs
@@ -3,7 +3,7 @@ mod layout_files;
 mod parse {
     use crate::layout_files;
     use livesplit_core::{
-        Component, Lang,
+        Component, Lang, TimingMethod,
         component::{splits, text},
         layout::{Layout, parser::parse},
     };
@@ -104,6 +104,20 @@ mod parse {
     #[test]
     fn with_timer_delta_background() {
         livesplit(layout_files::WITH_TIMER_DELTA_BACKGROUND);
+    }
+
+    #[test]
+    fn detailed_timer_timing_method_applies_to_segment_timer() {
+        let l = livesplit(layout_files::DETAILED_TIMER_GAME_TIME);
+        let Some(detailed_timer) = l.components.iter().find_map(|c| match c {
+            Component::DetailedTimer(d) => Some(d),
+            _ => None,
+        }) else {
+            panic!("Detailed Timer component not found");
+        };
+        let settings = detailed_timer.settings();
+        assert_eq!(settings.timer.timing_method, Some(TimingMethod::GameTime));
+        assert_eq!(settings.segment_timer.timing_method,Some(TimingMethod::GameTime));
     }
 
     #[test]


### PR DESCRIPTION
I override my timing method to always be Game Time but found that the override was not being applied to the segment timer but it was being applied to the main timer.

Fix just has the override apply to the segment timer as well.

Included a test if you're into that.