### PR TITLE
Support LibreSplit Game Time

### DIFF
--- a/src/run/parser/libresplit.rs
+++ b/src/run/parser/libresplit.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::result::Result as StdResult;
+use serde::{Deserialize as DeserializeTrait, Deserializer};
 use serde_derive::Deserialize;
 use serde_json::Error as JsonError;
 
@@ -27,14 +28,73 @@ pub enum Error {
 /// The Result type for the LibreSplit Parser.
 pub type Result<T> = StdResult<T, Error>;
 
+/// A LibreSplit time can either be a legacy timestamp string or an object
+/// containing separate real-time and game-time timestamps.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TimePayload {
+    Legacy(TimeValue),
+    Separate {
+        #[serde(default)]
+        real_time: Option<TimeValue>,
+        #[serde(default)]
+        game_time: Option<TimeValue>,
+    },
+}
+
+/// A timestamp in a LibreSplit time value. LibreSplit uses `-` for a missing
+/// value when the other timing method is present.
+struct TimeValue(Option<TimeSpan>);
+
+impl<'de> DeserializeTrait<'de> for TimeValue {
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <&str>::deserialize(deserializer)?;
+        if value == "-" {
+            return Ok(Self(None));
+        }
+
+        TimeSpan::parse(value, Lang::English)
+            .map(Some)
+            .map(Self)
+            .map_err(|_| serde::de::Error::custom("invalid LibreSplit time"))
+    }
+}
+
+impl TimePayload {
+    fn into_time(self) -> Time {
+        fn nonzero(value: Option<TimeValue>) -> Option<TimeSpan> {
+            // Legacy files use zero for an empty time. New files use `-` for
+            // the same purpose when only one timing method has a value.
+            value
+                .and_then(|value| value.0)
+                .filter(|value| *value != TimeSpan::zero())
+        }
+
+        match self {
+            Self::Legacy(value) => Time::new().with_real_time(nonzero(Some(value))),
+            Self::Separate {
+                real_time,
+                game_time,
+            } => Time::new()
+                .with_real_time(nonzero(real_time))
+                .with_game_time(nonzero(game_time)),
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct Splits<'a> {
     #[serde(borrow)]
     title: Option<Cow<'a, str>>,
     attempt_count: Option<u32>,
     start_delay: Option<TimeSpan>,
-    world_record: Option<TimeSpan>,
+    world_record: Option<TimePayload>,
     splits: Option<Vec<Split<'a>>>,
+    // TODO: Parse LibreSplit's `comparison_method` once Run can represent the
+    // authoritative timing method. Serde intentionally ignores it for now.
 }
 
 #[derive(Deserialize)]
@@ -46,20 +106,9 @@ struct Split<'a> {
     #[cfg(feature = "std")]
     #[serde(borrow)]
     icon: Option<Cow<'a, str>>,
-    time: Option<TimeSpan>,
-    best_time: Option<TimeSpan>,
-    best_segment: Option<TimeSpan>,
-}
-
-fn parse_time(real_time: TimeSpan) -> Time {
-    // Empty Time is stored as zero
-    let real_time = if real_time != TimeSpan::zero() {
-        Some(real_time)
-    } else {
-        None
-    };
-
-    Time::new().with_real_time(real_time)
+    time: Option<TimePayload>,
+    best_time: Option<TimePayload>,
+    best_segment: Option<TimePayload>,
 }
 
 /// Attempts to parse an LibreSplit (formerly Urn) splits file. In addition to
@@ -87,7 +136,9 @@ pub fn parse(source: &str, #[allow(unused)] load_files_path: Option<&Path>) -> R
     if let Some(start_delay) = splits.start_delay {
         run.set_offset(-start_delay);
     }
-    if let Some(world_record) = splits.world_record {
+    if let Some(world_record) = splits.world_record.map(TimePayload::into_time)
+        && let Some(world_record) = world_record.real_time.or(world_record.game_time)
+    {
         run.metadata_mut()
             .custom_variable_mut(world_record::NAME)
             .permanent()
@@ -110,15 +161,15 @@ pub fn parse(source: &str, #[allow(unused)] load_files_path: Option<&Path>) -> R
         for split in splits {
             let mut segment = Segment::new(split.title.unwrap_or_default());
             if let Some(time) = split.time {
-                segment.set_personal_best_split_time(parse_time(time));
+                segment.set_personal_best_split_time(time.into_time());
             }
             if let Some(best_segment) = split.best_segment {
-                segment.set_best_segment_time(parse_time(best_segment));
+                segment.set_best_segment_time(best_segment.into_time());
             }
 
             if let Some(best_time) = split.best_time {
-                let best_split_time = parse_time(best_time);
-                if best_split_time.real_time.is_some() {
+                let best_split_time = best_time.into_time();
+                if best_split_time.real_time.is_some() || best_split_time.game_time.is_some() {
                     run.add_attempt_with_index(
                         Time::default(),
                         attempt_history_index,

--- a/tests/run_files/libresplit_game_time.json
+++ b/tests/run_files/libresplit_game_time.json
@@ -1,0 +1,62 @@
+{
+    "title": "SotN Any% NSC",
+    "attempt_count": 70,
+    "comparison_method": 1,
+    "start_delay": "2.800000",
+    "world_record": {
+        "real_time": "23:42.151789",
+        "game_time": "22:00.000000"
+    },
+    "splits": [
+        {
+            "title": "Mist",
+            "icon": "mist.png",
+            "time": {
+                "real_time": "11:41.299585",
+                "game_time": "11:30.000000"
+            },
+            "best_time": {
+                "real_time": "11:32.100735",
+                "game_time": "11:20.000000"
+            },
+            "best_segment": {
+                "real_time": "11:32.100735",
+                "game_time": "11:20.000000"
+            }
+        },
+        {
+            "title": "Bat",
+            "icon": "bat.png",
+            "time": {
+                "real_time": "14:36.934210",
+                "game_time": "14:00.000000"
+            },
+            "best_time": {
+                "real_time": "14:16.933388",
+                "game_time": "13:45.000000"
+            },
+            "best_segment": {
+                "real_time": "2:35.819681",
+                "game_time": "2:25.000000"
+            }
+        },
+        {
+            "title": "Reverse",
+            "icon": "reverse.png",
+            "time": {
+                "real_time": "17:51.600311",
+                "game_time": "17:00.000000"
+            },
+            "best_time": {
+                "real_time": "-",
+                "game_time": "16:30.000000"
+            },
+            "best_segment": {
+                "real_time": "-",
+                "game_time": "2:30.000000"
+            }
+        }
+    ],
+    "width": 320,
+    "height": 300
+}

--- a/tests/run_files/mod.rs
+++ b/tests/run_files/mod.rs
@@ -26,5 +26,6 @@ pub const SPLITTERZ: &str = include_str!("splitterz");
 pub const TIME_SPLIT_TRACKER_WITHOUT_ATTEMPT_COUNT: &str = include_str!("1734.timesplittracker");
 pub const TIME_SPLIT_TRACKER: &str = include_str!("timesplittracker.txt");
 pub const LIBRESPLIT: &str = include_str!("libresplit.json");
+pub const LIBRESPLIT_GAME_TIME: &str = include_str!("libresplit_game_time.json");
 pub const WSPLIT: &str = include_str!("wsplit");
 pub const CLEAN_SUM_OF_BEST: &str = include_str!("clean_sum_of_best.lss");

--- a/tests/split_parsing.rs
+++ b/tests/split_parsing.rs
@@ -8,7 +8,7 @@ mod run_files;
 mod parse {
     use crate::run_files;
     use livesplit_core::{
-        Run, TimeSpan,
+        Lang, Run, Time, TimeSpan,
         analysis::total_playtime,
         run::parser::{
             TimerKind, composite, flitter, libresplit, livesplit, llanfair, llanfair_gered,
@@ -240,6 +240,30 @@ mod parse {
     #[test]
     fn libresplit() {
         libresplit::parse(run_files::LIBRESPLIT, None).unwrap();
+    }
+
+    fn libresplit_time(real_time: Option<&str>, game_time: Option<&str>) -> Time {
+        Time::new()
+            .with_real_time(real_time.map(|time| TimeSpan::parse(time, Lang::English).unwrap()))
+            .with_game_time(game_time.map(|time| TimeSpan::parse(time, Lang::English).unwrap()))
+    }
+
+    #[test]
+    fn libresplit_game_time() {
+        let run = libresplit::parse(run_files::LIBRESPLIT_GAME_TIME, None).unwrap();
+
+        assert_eq!(
+            run.segment(0).personal_best_split_time(),
+            libresplit_time(Some("11:41.299585"), Some("11:30.000000"))
+        );
+        assert_eq!(
+            run.segment(0).best_segment_time(),
+            libresplit_time(Some("11:32.100735"), Some("11:20.000000"))
+        );
+        assert_eq!(
+            run.segment(2).best_segment_time(),
+            libresplit_time(None, Some("2:30.000000"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
LibreSplit now stores `time`, `best_time`, and `best_segment` as objects containing separate `real_time` and `game_time` values, while older files keep those fields as timestamp strings. Parse both representations into LiveSplit Core's existing `Time` type so files produced before and after [LibreSplit PR #399](https://github.com/LibreSplit/LibreSplit/pull/399) remain readable while exposing game-time data to callers.

The parser also accepts LibreSplit's `-` marker and continues treating zero values as missing. `comparison_method` remains intentionally ignored because the current `Run` model has no LibreSplit-specific authoritative comparison setting, with a TODO documenting where that support can be added later.

Add a game-time fixture alongside the existing legacy file and cover real-time, game-time, and game-time-only values in the parser tests.