### PR TITLE
Only store ScriptPath if fixed_script_path false

### DIFF
--- a/src/auto_splitting/mod.rs
+++ b/src/auto_splitting/mod.rs
@@ -570,6 +570,7 @@ use crate::{
     timing::TimerPhase,
 };
 use arc_swap::ArcSwapOption;
+use core::cell::Cell;
 use livesplit_auto_splitting::{
     AutoSplitter, Config, CreationError, LogLevel, Timer as AutoSplitTimer, TimerState,
 };
@@ -620,6 +621,7 @@ pub struct Runtime<T: event::CommandSink + TimerQuery + Send + Sync + 'static> {
     shared_state: Arc<SharedState<T>>,
     changed_sender: Sender<()>,
     runtime: livesplit_auto_splitting::Runtime,
+    fixed_script_path: Cell<bool>,
     loaded_path: ArcSwapOption<PathBuf>,
     timer: ArcSwapOption<T>,
 }
@@ -696,6 +698,7 @@ impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Runtime<T> {
             changed_sender,
             // TODO: unwrap?
             runtime: livesplit_auto_splitting::Runtime::new(Config::default()).unwrap(),
+            fixed_script_path: Cell::from(false),
             loaded_path: ArcSwapOption::from(None),
             timer: ArcSwapOption::from(None),
         }
@@ -710,6 +713,7 @@ impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Runtime<T> {
     /// When a path is stored, it needs to match `path` so settings from a
     /// previously selected auto splitter are not applied to a different one.
     pub fn load_from_path(&self, timer: T, path: PathBuf) -> Result<(), Error> {
+        self.fixed_script_path.set(true);
         let timer = Arc::new(timer);
         self.timer.store(Some(timer.clone()));
         self.unload()?;
@@ -731,6 +735,7 @@ impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Runtime<T> {
     /// splits file, as it keeps parsing, unloading, and instantiation entirely
     /// within livesplit-core.
     pub fn load(&self, timer: T) -> Result<Option<PathBuf>, Error> {
+        self.fixed_script_path.set(false);
         let timer = Arc::new(timer);
         self.timer.store(Some(timer.clone()));
         self.unload()?;
@@ -815,10 +820,12 @@ impl<T: event::CommandSink + TimerQuery + Send + Sync + 'static> Runtime<T> {
         };
 
         let mut stored_settings = StoredAutoSplitterSettings::new();
-        stored_settings.set_script_path(
-            self.loaded_path()
-                .map(|path| path.to_string_lossy().into_owned()),
-        );
+        if !self.fixed_script_path.get() {
+            stored_settings.set_script_path(
+                self.loaded_path()
+                    .map(|path| path.to_string_lossy().into_owned()),
+            );
+        }
 
         if let Some(settings_map) = self.settings_map().filter(|map| !map.is_empty()) {
             stored_settings.set_settings_map(settings_map);


### PR DESCRIPTION
Adds a new `fixed_script_path` field similar to the `fixedScriptPath` field of the `LiveSplit.AutoSplittingRuntime` component.

When a timer program is using an externally fixed auto splitter, such as one from `LiveSplit.AutoSplitters.xml` matching the Game Name, it should call `load_from_path` with the path of that fixed auto splitter, which will set `fixed_script_path` to `true`. Then a later call to `store_settings` will _not_ store the `ScriptPath`, consistent with LiveSplit's behavior for this case with settings stored in the splits.

When a timer program is using a local auto splitter, it should use the `ScriptPath` in the run's stored settings and call `load`, which will set `fixed_script_path` to `false`. Then a later call to `store_settings` will store the `ScriptPath`, consistent with `LiveSplit.AutoSplittingRuntime`'s behavior when used as a Layout component instead of in the splits.