### PR TITLE
Partial support for legacy server protocol commands

### DIFF
--- a/src/networking/server_protocol.rs
+++ b/src/networking/server_protocol.rs
@@ -59,6 +59,41 @@ use crate::{
     timing::formatter::{self, ASCII_MINUS, TimeFormatter},
 };
 
+/// Handles commands from a subset of the original LiveSplit's IPC/TCP/WebSocket server protocol
+pub fn convert_old_command(command: &str) -> Option<Command> {
+    let mut words = command.split(" ");
+    Some(match words.next().unwrap_or_default() {
+        "start" | "startimer" => Command::Start,
+        "split" => Command::Split,
+        "startorsplit" => Command::SplitOrStart,
+        "reset" => Command::Reset { save_attempt : None },
+        "unsplit" | "undosplit" => Command::UndoSplit,
+        "skipsplit" => Command::SkipSplit,
+        "pause" => Command::Pause,
+        "resume" => Command::Resume,
+        "undoallpauses" => Command::UndoAllPauses,
+        "setcomparison" => Command::SetCurrentComparison { comparison: Cow::from(words.collect::<Vec<&str>>().join(" ")) },
+        "switchto" => Command::SetCurrentTimingMethod { timing_method: match words.next() {
+            Some("gametime") => TimingMethod::GameTime,
+            Some("realtime") => TimingMethod::RealTime,
+            _ => {return None;}
+        } },
+		//apparently initgametime wasn't a real command but I know of some clients that attempt to use it
+        "initgametime" => Command::InitializeGameTime, 
+        "setgametime" => Command::SetGameTime { time: match TimeSpan::parse(words.next().unwrap_or_default(), Lang::English) {
+            Ok(time) => time,
+            Err(_) => {return None;}
+        } },
+        "pausegametime" => Command::PauseGameTime,
+        "unpausegametime" => Command::ResumeGameTime,
+        "setloadingtimes" => Command::SetLoadingTimes { time: match TimeSpan::parse(words.next().unwrap_or_default(), Lang::English) {
+            Ok(time) => time,
+            Err(_) => {return None;}
+        } },
+        _ => {return None;}
+    })
+}
+
 /// Handles an incoming command and returns the response to be sent.
 pub async fn handle_command<S: event::CommandSink + event::TimerQuery>(
     command: &str,
@@ -66,9 +101,12 @@ pub async fn handle_command<S: event::CommandSink + event::TimerQuery>(
 ) -> String {
     let response = match serde_json::from_str::<Command>(command) {
         Ok(command) => command.handle(command_sink).await.into(),
-        Err(e) => CommandResult::Error(Error::InvalidCommand {
-            message: e.to_string(),
-        }),
+        Err(e) => match convert_old_command(command) {
+            Some(command) => command.handle(command_sink).await.into(),
+            None => CommandResult::Error(Error::InvalidCommand {
+                message: e.to_string(),
+            }),
+        } 
     };
 
     serde_json::to_string(&response).unwrap()

--- a/src/networking/server_protocol.rs
+++ b/src/networking/server_protocol.rs
@@ -78,7 +78,6 @@ pub fn convert_old_command(command: &str) -> Option<Command> {
             Some("realtime") => TimingMethod::RealTime,
             _ => {return None;}
         } },
-		//apparently initgametime wasn't a real command but I know of some clients that attempt to use it
         "initgametime" => Command::InitializeGameTime, 
         "setgametime" => Command::SetGameTime { time: match TimeSpan::parse(words.next().unwrap_or_default(), Lang::English) {
             Ok(time) => time,


### PR DESCRIPTION
Adds support for the following commands from the legacy LiveSplit server protocol:
```
start/starttimer
split
startorsplit
reset
unsplit/undosplit
skipsplit
pause
resume
undoallpauses
setcomparison NAME
switchto realtime/gametime
initgametime (doesn't seem to have been a real command in the legacy protocol but I'm familiar with some clients that try it)
setgametime TIME
pausegametime
unpausegametime
setloadingtimes TIME
```
This does NOT currently cover all commands that exist in both protocols. In particular, none of the commands that expect a response from LiveSplit are supported as they would require using a different response format when responding to their legacy-protocol versions, and support for setcustomvariable is not yet included.