### PR TITLE
Support Global Hotkeys on Wayland

### DIFF
--- a/crates/livesplit-hotkey/Cargo.toml
+++ b/crates/livesplit-hotkey/Cargo.toml
@@ -28,6 +28,10 @@ mio = { version = "1.0.2", default-features = false, features = [
 ], optional = true }
 nix = { version = "0.31.3", features = ["user"], optional = true }
 promising-future = { version = "0.2.4", optional = true }
+wayland-backend = { version = "0.3.17", optional = true }
+wayland-client = { version = "0.31.14", optional = true }
+wayland-scanner = { version = "0.31.10", optional = true }
+xkbcommon-dl = { version = "0.4.2", optional = true }
 x11-dl = { version = "2.20.0", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
@@ -56,7 +60,11 @@ std = [
     "nix",
     "promising-future",
     "serde/std",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-scanner",
     "windows-sys",
+    "xkbcommon-dl",
     "x11-dl",
 ]
 wasm-web = ["wasm-bindgen", "web-sys", "js-sys"]

--- a/crates/livesplit-hotkey/protocols/xx-hotkey-v1.xml
+++ b/crates/livesplit-hotkey/protocols/xx-hotkey-v1.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xx_hotkey_v1">
+  <copyright>
+    Copyright © 2026 Aurelien Brabant
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="client-managed global hotkeys">
+    This protocol lets a client bind, and freely reconfigure, its own global
+    hotkeys: it describes a trigger and the compositor accepts it or rejects it
+    with a reason. A hotkey fires regardless of which surface holds keyboard
+    focus. The compositor remains the arbiter and may deny a commit or revoke a
+    binding at any time, but the client chooses the trigger.
+
+    The key words "must", "must not", "required", "shall", "shall not",
+    "should", "should not", "recommended", "may", and "optional" in this
+    document are to be interpreted as described in IETF RFC 2119.
+
+    A bound hotkey always has exactly the trigger the client committed; the
+    compositor never substitutes one of its own.
+
+    A binding lives only as long as its xx_hotkey_v1 object and the client
+    connection; nothing is persisted by the protocol.
+
+    Whether a trigger is exclusive is compositor policy. A compositor may treat
+    triggers as exclusive and reject a clashing commit with "already_bound", or
+    may grant the same trigger to several bindings, in which case each bound
+    hotkey receives the events. Clients must cope with either.
+
+    Security considerations:
+
+    A global hotkey lets an unfocused client observe that a specific trigger
+    fired. Compositors are the security boundary and should apply policy when
+    deciding whether to accept a commit. As a default, we suggest the following
+    pseudo-code. This is not a wire requirement: every compositor is free to apply
+    a different policy and can expose settings to allow the user to configure it.
+
+    fn acceptable(trigger) {
+      if trigger.modifiers contains any of {ctrl, alt, super}:
+        return true   # modified triggers are always acceptable
+      match trigger:
+        button(code):
+          return code is an auxiliary button
+                        # side, extra, forward, back, task
+        key(keysym):
+          if keysym is a modifier keysym:
+            return true   # a lone modifier, see set_key_trigger
+          if keysym is a keypad key:
+            return true   # commonly a dedicated macro cluster
+          if keysym is a dead key:
+            return false  # no character mapping, but composes text
+          if keysym has a character mapping:
+            return false  # letters, digits, punctuation, space, Enter, Tab, ...
+          return true     # purely functional: function, media, navigation keys
+    }
+
+    The protocol's one hard guarantee is containment: a compositor must not
+    deliver events for a trigger the client did not successfully bind, and never
+    forwards the raw input stream.
+
+    Warning! The protocol described in this file is currently in the
+    experimental phase. Backwards incompatible major versions of the protocol
+    are to be expected. Exposing this protocol without an opt-in mechanism is
+    discouraged.
+  </description>
+
+  <interface name="xx_hotkey_manager_v1" version="1">
+    <description summary="global hotkey factory">
+      Identifies the application and creates global hotkeys.
+    </description>
+
+    <enum name="error">
+      <description summary="illegal request sequences">
+        Fatal protocol errors.
+      </description>
+      <entry name="invalid_app_id" value="0"
+             summary="the app id was empty, set more than once, or set after a hotkey was committed"/>
+    </enum>
+
+    <enum name="modifiers" bitfield="true">
+      <description summary="modifier keys required by a trigger">
+        A bitmask of the modifiers that must be held for the trigger to fire.
+        The match is exact: a trigger does not fire while a modifier outside
+        its mask is held, so Super+Space does not fire on Super+Shift+Space.
+        Bits outside this enum raise the "invalid_trigger" error.
+
+        These are fixed, keymap-independent semantic bits. A compositor matches
+        each bit against the corresponding modifier in its keyboard state as the
+        keymap defines it; for the xkb_v1 keymap format that is shift ->
+        XKB_MOD_NAME_SHIFT, ctrl -> XKB_MOD_NAME_CTRL, alt -> XKB_MOD_NAME_ALT
+        ("Mod1"), super -> XKB_MOD_NAME_LOGO ("Mod4").
+
+        A client needs neither a wl_keyboard nor a keymap to describe a trigger.
+
+        Lock modifiers (Caps Lock, Num Lock, Scroll Lock) are never part of a
+        binding and are ignored when matching.
+      </description>
+      <entry name="shift" value="1" summary="the Shift modifier"/>
+      <entry name="ctrl" value="2" summary="the Control modifier"/>
+      <entry name="alt" value="4" summary="the Alt modifier"/>
+      <entry name="super" value="8" summary="the Super/Logo modifier"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. Hotkey objects created through this manager
+        are unaffected and remain valid.
+      </description>
+    </request>
+
+    <request name="set_app_id">
+      <description summary="set the application identifier">
+        Identify the application, for use in compositor policy and user-facing
+        audit interfaces. It applies to every hotkey created by this manager.
+
+        Optional; if sent, it must not be empty, must be sent at most once, and
+        must be sent before the first commit, so that every policy decision
+        sees the same identity.
+
+        Where the application has a desktop entry, app_id should be its desktop
+        file ID as defined by the freedesktop.org Desktop Entry specification,
+        matching the convention used by xdg_toplevel.set_app_id.
+
+        It is advisory and may be spoofed; a compositor that needs a trustworthy
+        identity should obtain it through the security-context mechanism.
+      </description>
+      <arg name="app_id" type="string"
+           summary="advisory application identifier (should be the desktop file ID)"/>
+    </request>
+
+    <request name="create_hotkey">
+      <description summary="create a hotkey">
+        Create a new hotkey object. No binding exists and no input events are
+        sent before the first successful commit.
+      </description>
+      <arg name="id" type="new_id" interface="xx_hotkey_v1"
+           summary="the new hotkey object"/>
+    </request>
+  </interface>
+
+  <interface name="xx_hotkey_v1" version="1">
+    <description summary="a single global hotkey">
+      Represents one global hotkey. The object is built up with set_* requests
+      and applied with commit; a trigger is required, everything else is
+      optional. Requests have no effect on the binding until commit is sent.
+
+      Exactly one "bound" or "denied" event is sent per commit, in the order the
+      commits were issued. While the hotkey is bound, "triggered" and "released"
+      are sent as the trigger is activated. The compositor may send "revoked" at
+      any time to withdraw the binding.
+    </description>
+
+    <enum name="error">
+      <description summary="illegal request sequences">
+        Fatal protocol errors. A trigger that is merely unacceptable to the
+        compositor is reported through "denied" and is not an error.
+      </description>
+      <entry name="invalid_trigger" value="0"
+             summary="a null keysym, or unknown modifier bits"/>
+      <entry name="no_trigger" value="1"
+             summary="commit was sent before any trigger was described"/>
+    </enum>
+
+    <enum name="deny_reason">
+      <description summary="why a commit was rejected">
+        A reason code describing why the commit got denied. The object remains
+        valid, any previously established binding is unaffected, and the client
+        may describe a different trigger and commit again.
+
+        A compositor is not obliged to distinguish "already_bound" from
+        "not_permitted" and may report the latter for both.
+      </description>
+      <entry name="already_bound" value="0"
+             summary="held by another hotkey the compositor treats as exclusive"/>
+      <entry name="not_permitted" value="1"
+             summary="the trigger is disallowed by compositor policy"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the hotkey">
+        Release the binding and destroy the object.
+        Destroying the object with a commit still in flight cancels it.
+      </description>
+    </request>
+
+    <request name="set_description">
+      <description summary="set the human-readable description">
+        Set a human-readable, localized description of what the hotkey does
+        (e.g. "Toggle the launcher"), for display in compositor user interface.
+        Optional.
+      </description>
+      <arg name="description" type="string" summary="localized action description"/>
+    </request>
+
+    <request name="set_seat">
+      <description summary="restrict the hotkey to one seat">
+        Restrict the hotkey to the given seat, or pass null for all of the
+        client's seats, virtual ones included. Optional; the default is null.
+        If the given seat is removed, the compositor sends "revoked".
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"
+           summary="target seat, or null for all of the client's seats"/>
+    </request>
+
+    <request name="set_key_trigger">
+      <description summary="trigger on a key">
+        Describe the trigger as a key pressed while the given modifiers are
+        held. Replaces any trigger previously described. Takes effect on the
+        next commit.
+
+        The keysym uses the numbering shared with the keymap delivered over
+        wl_keyboard (for the xkb_v1 keymap format, an XKB_KEY_* value), in its
+        unshifted form (XKB_KEY_b, not XKB_KEY_B). The compositor matches it
+        against the keysym each key produces at its first shift level in any of
+        the user's layout groups, ignoring the effect Shift has on the key, so
+        that Shift is handled through the modifier mask like every other
+        modifier and a binding keeps firing after a layout group switch. A
+        binding whose keysym no group of the current keymap produces stays
+        bound and simply does not fire until the keymap changes again.
+
+        The trigger fires on key press; the compositor does not wait to see
+        whether another key follows. The press and the matching release are
+        consumed and must not be delivered to the focused surface.
+
+        The keysym may be one that contributes to modifier state, such as
+        XKB_KEY_Super_L; whether it does is decided by the seat's keymap. Such a
+        trigger is a tap: it fires when the key is released, and only if no
+        other key, button or axis event occurred while it was held. A
+        compositor may additionally require that it was held no longer than
+        some interval. The modifier mask is evaluated as the state before the
+        key was pressed, so a lone left Super key is (XKB_KEY_Super_L, 0) and
+        (XKB_KEY_Shift_L, ctrl) is a tap on Shift while Control is held.
+
+        A tap is never consumed: the key must still update modifier state and
+        reach the focused surface, so binding it does not stop it composing
+        other shortcuts. "triggered" and "released" are sent together on
+        release, so a tap cannot drive press-and-hold.
+
+        A null keysym raises the "invalid_trigger" error.
+      </description>
+      <arg name="keysym" type="uint" summary="keysym of the trigger key"/>
+      <arg name="modifiers" type="uint" enum="xx_hotkey_manager_v1.modifiers"
+           summary="bitmask of required modifiers"/>
+    </request>
+
+    <request name="set_button_trigger">
+      <description summary="trigger on a pointer button">
+        Describe the trigger as a pointer button pressed while the given
+        modifiers are held. Replaces any trigger previously described. Takes
+        effect on the next commit.
+
+        The button is a button code in the same space as wl_pointer.button.
+
+        The press and the matching release are consumed and must not be
+        delivered to the surface under the pointer.
+      </description>
+      <arg name="button" type="uint" summary="button code, as in wl_pointer.button"/>
+      <arg name="modifiers" type="uint" enum="xx_hotkey_manager_v1.modifiers"
+           summary="bitmask of required modifiers"/>
+    </request>
+
+    <request name="commit">
+      <description summary="apply the hotkey">
+        Apply the state built up on this object. The compositor replies with
+        exactly one "bound" or "denied" event per commit, in order.
+
+        Sending commit before a trigger has been described raises the
+        "no_trigger" error.
+
+        Commit may be sent again to apply a changed trigger, description or
+        seat, keeping the binding's identity. Values set with set_* requests are
+        retained across commits, accepted or denied, and each commit applies
+        all of them; committing with nothing changed is accepted with "bound".
+        An established binding survives a rejected commit: the previous state
+        stays active, so a denied reconfiguration never leaves the user with no
+        hotkey.
+      </description>
+    </request>
+
+    <event name="bound">
+      <description summary="the hotkey is now active">
+        The commit was accepted and the binding is active with the trigger that
+        was committed. "triggered" and "released" events may follow.
+      </description>
+    </event>
+
+    <event name="denied">
+      <description summary="the commit was rejected">
+        The committed trigger was not bound. Any previously established binding
+        remains active with its previous trigger.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display. It may be empty.
+        Clients must not parse it; all programmatic behavior keys off reason.
+      </description>
+      <arg name="reason" type="uint" enum="deny_reason" summary="why it was rejected"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="revoked">
+      <description summary="a previously active hotkey was withdrawn">
+        A binding that was previously "bound" is no longer active. No further
+        input events will be sent for it. The client should destroy this object
+        and must not silently commit the same trigger again; whether to retry
+        is the user's decision.
+
+        message has the same meaning as in the "denied" event.
+      </description>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="triggered">
+      <description summary="the hotkey fired">
+        The bound trigger fired. This event is sent once each time it fires; the
+        compositor does not auto-repeat the hotkey.
+
+        serial is an input serial that counts as a recent user interaction. A
+        client may pass it to xdg_activation_token_v1.set_serial to raise or
+        focus a surface, and a compositor should honor activation carried by it.
+
+        time is the event timestamp, on the same millisecond clock as
+        wl_pointer and wl_keyboard input events.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+
+    <event name="released">
+      <description summary="the hotkey was released">
+        The key or button of a previously triggered hotkey was released,
+        regardless of modifier state. This enables press-and-hold uses such as
+        push-to-talk; clients that only act on the initial firing may ignore
+        it.
+
+        serial and time have the same meaning as in the "triggered" event.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+  </interface>
+</protocol>

--- a/crates/livesplit-hotkey/src/linux/mod.rs
+++ b/crates/livesplit-hotkey/src/linux/mod.rs
@@ -7,6 +7,7 @@ use nix::unistd::{Group, getgroups};
 use promising_future::{Promise, future_promise};
 
 mod evdev_impl;
+mod wayland_impl;
 mod x11_impl;
 
 #[derive(Debug, Copy, Clone)]
@@ -16,6 +17,11 @@ pub enum Error {
     EPoll,
     NoXLib,
     OpenXServerConnection,
+    NoWaylandConnection,
+    Wayland,
+    WaylandHotkeyProtocolUnavailable,
+    WaylandHotkeyDenied,
+    WaylandKeymapUnavailable,
     ThreadStopped,
 }
 
@@ -32,6 +38,13 @@ impl fmt::Display for Error {
             Self::EPoll => "Failed polling the event file descriptors.",
             Self::NoXLib => "Failed dynamically linking to X11.",
             Self::OpenXServerConnection => "Failed opening a connection to the X11 server.",
+            Self::NoWaylandConnection => "Failed opening a connection to the Wayland compositor.",
+            Self::Wayland => "The Wayland connection failed.",
+            Self::WaylandHotkeyProtocolUnavailable => {
+                "The Wayland compositor does not support the global hotkey protocol."
+            }
+            Self::WaylandHotkeyDenied => "The Wayland compositor denied the global hotkey.",
+            Self::WaylandKeymapUnavailable => "Failed obtaining the Wayland keyboard map.",
             Self::ThreadStopped => "The background thread stopped unexpectedly.",
         })
     }
@@ -72,21 +85,35 @@ fn can_use_evdev() -> Option<()> {
 
 impl Hook {
     pub fn new(consume: ConsumePreference) -> Result<Self> {
-        if matches!(consume, ConsumePreference::PreferConsume)
-            && let Ok(x11) = x11_impl::new()
-        {
-            return Ok(x11);
-        }
-
-        if !matches!(consume, ConsumePreference::MustConsume) && can_use_evdev().is_some() {
-            evdev_impl::new()
-        } else if !matches!(
-            consume,
-            ConsumePreference::MustNotConsume | ConsumePreference::PreferConsume
-        ) {
-            x11_impl::new()
-        } else {
-            Err(crate::Error::UnmatchedPreference)
+        match consume {
+            ConsumePreference::NoPreference => {
+                if can_use_evdev().is_some() {
+                    evdev_impl::new()
+                } else if let Ok(wayland) = wayland_impl::new() {
+                    Ok(wayland)
+                } else {
+                    x11_impl::new()
+                }
+            }
+            ConsumePreference::PreferConsume => {
+                if let Ok(wayland) = wayland_impl::new() {
+                    Ok(wayland)
+                } else if let Ok(x11) = x11_impl::new() {
+                    Ok(x11)
+                } else if can_use_evdev().is_some() {
+                    evdev_impl::new()
+                } else {
+                    Err(crate::Error::UnmatchedPreference)
+                }
+            }
+            ConsumePreference::MustConsume => wayland_impl::new().or_else(|_| x11_impl::new()),
+            ConsumePreference::PreferNoConsume | ConsumePreference::MustNotConsume => {
+                if can_use_evdev().is_some() {
+                    evdev_impl::new()
+                } else {
+                    Err(crate::Error::UnmatchedPreference)
+                }
+            }
         }
     }
 

--- a/crates/livesplit-hotkey/src/linux/wayland_impl.rs
+++ b/crates/livesplit-hotkey/src/linux/wayland_impl.rs
@@ -1,0 +1,455 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::Read,
+    os::fd::{AsFd, AsRawFd},
+    thread,
+};
+
+use mio::{Events, Interest, Poll, Token, Waker, unix::SourceFd};
+use promising_future::Promise;
+use wayland_client::{
+    Connection, Dispatch, QueueHandle, WEnum,
+    globals::{GlobalListContents, registry_queue_init},
+    protocol::{wl_keyboard, wl_registry, wl_seat},
+};
+use xkbcommon_dl::{
+    XkbCommon, xkb_context, xkb_context_flags, xkb_keymap, xkb_keymap_compile_flags,
+    xkb_keymap_format,
+};
+
+use super::{Error, Hook, Message, evdev_impl};
+use crate::{Hotkey, KeyCode, Modifiers, Result};
+
+mod protocol {
+    #[allow(clippy::single_component_path_imports)]
+    use wayland_client;
+    use wayland_client::protocol::*;
+
+    pub mod __interfaces {
+        use wayland_client::protocol::__interfaces::*;
+
+        wayland_scanner::generate_interfaces!("protocols/xx-hotkey-v1.xml");
+    }
+
+    use self::__interfaces::*;
+    wayland_scanner::generate_client_code!("protocols/xx-hotkey-v1.xml");
+}
+
+use self::protocol::{
+    xx_hotkey_manager_v1::{Modifiers as ProtocolModifiers, XxHotkeyManagerV1},
+    xx_hotkey_v1::{self, XxHotkeyV1},
+};
+
+const WAYLAND_TOKEN: Token = Token(0);
+const PING_TOKEN: Token = Token(1);
+
+struct KeyboardMap {
+    lib: &'static XkbCommon,
+    context: *mut xkb_context,
+    keymap: *mut xkb_keymap,
+}
+
+// The xkb objects are only ever used by the Wayland hotkey thread.
+unsafe impl Send for KeyboardMap {}
+
+impl KeyboardMap {
+    fn from_keymap(mut fd: File, size: u32) -> Option<Self> {
+        let lib = xkbcommon_dl::xkbcommon_option()?;
+        let mut bytes = Vec::with_capacity(size as usize);
+        fd.by_ref().take(size as u64).read_to_end(&mut bytes).ok()?;
+
+        let context = unsafe { (lib.xkb_context_new)(xkb_context_flags::XKB_CONTEXT_NO_FLAGS) };
+        if context.is_null() {
+            return None;
+        }
+
+        let keymap = unsafe {
+            (lib.xkb_keymap_new_from_buffer)(
+                context,
+                bytes.as_ptr().cast(),
+                bytes.len(),
+                xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V1,
+                xkb_keymap_compile_flags::XKB_KEYMAP_COMPILE_NO_FLAGS,
+            )
+        };
+        if keymap.is_null() {
+            unsafe { (lib.xkb_context_unref)(context) };
+            return None;
+        }
+
+        Some(Self {
+            lib,
+            context,
+            keymap,
+        })
+    }
+
+    fn keysym_for(&self, key_code: KeyCode) -> Option<u32> {
+        // XKB keycodes use the X11 numbering, which is evdev + 8.
+        let keycode = evdev_impl::code_for(key_code)?.0 as u32 + 8;
+        let mut syms = std::ptr::null();
+        let count = unsafe {
+            (self.lib.xkb_keymap_key_get_syms_by_level)(self.keymap, keycode, 0, 0, &mut syms)
+        };
+        if count <= 0 || syms.is_null() {
+            return None;
+        }
+        Some(unsafe { *syms })
+    }
+
+    fn resolve(&self, key_code: KeyCode) -> Option<char> {
+        let keysym = self.keysym_for(key_code)?;
+        let code_point = unsafe { (self.lib.xkb_keysym_to_utf32)(keysym) };
+        char::from_u32(code_point)
+    }
+}
+
+impl Drop for KeyboardMap {
+    fn drop(&mut self) {
+        unsafe {
+            (self.lib.xkb_keymap_unref)(self.keymap);
+            (self.lib.xkb_context_unref)(self.context);
+        }
+    }
+}
+
+struct Binding {
+    proxy: XxHotkeyV1,
+    callback: Box<dyn FnMut() + Send + 'static>,
+    pending: Option<Promise<Result<()>>>,
+    keysym: u32,
+}
+
+struct State {
+    manager: XxHotkeyManagerV1,
+    _seat: Option<wl_seat::WlSeat>,
+    keyboard: Option<wl_keyboard::WlKeyboard>,
+    keymap: Option<KeyboardMap>,
+    bindings: HashMap<Hotkey, Binding>,
+}
+
+impl State {
+    fn register(
+        &mut self,
+        qh: &QueueHandle<Self>,
+        hotkey: Hotkey,
+        callback: Box<dyn FnMut() + Send + 'static>,
+        promise: Promise<Result<()>>,
+    ) {
+        if self.bindings.contains_key(&hotkey) {
+            promise.set(Err(crate::Error::AlreadyRegistered));
+            return;
+        }
+
+        let Some(keysym) = self
+            .keymap
+            .as_ref()
+            .and_then(|keymap| keymap.keysym_for(hotkey.key_code))
+        else {
+            // Keep the behavior of the existing Linux backends for keys that
+            // cannot be represented by the platform implementation.
+            promise.set(Ok(()));
+            return;
+        };
+
+        let proxy = self.manager.create_hotkey(qh, hotkey);
+        proxy.set_description(hotkey.to_string());
+        proxy.set_key_trigger(keysym, protocol_modifiers(hotkey.modifiers));
+        proxy.commit();
+
+        self.bindings.insert(
+            hotkey,
+            Binding {
+                proxy,
+                callback,
+                pending: Some(promise),
+                keysym,
+            },
+        );
+    }
+
+    fn unregister(&mut self, hotkey: Hotkey, promise: Promise<Result<()>>) {
+        promise.set(match self.bindings.remove(&hotkey) {
+            Some(binding) => {
+                binding.proxy.destroy();
+                Ok(())
+            }
+            None => Err(crate::Error::NotRegistered),
+        });
+    }
+
+    fn update_keymap(&mut self, keymap: KeyboardMap) {
+        self.keymap = Some(keymap);
+        let updates: Vec<_> = self
+            .bindings
+            .keys()
+            .filter_map(|&hotkey| {
+                let keysym = self.keymap.as_ref()?.keysym_for(hotkey.key_code)?;
+                Some((hotkey, keysym))
+            })
+            .collect();
+
+        for (hotkey, keysym) in updates {
+            let binding = self.bindings.get_mut(&hotkey).unwrap();
+            if binding.keysym != keysym {
+                binding.keysym = keysym;
+                binding
+                    .proxy
+                    .set_key_trigger(keysym, protocol_modifiers(hotkey.modifiers));
+                binding.proxy.commit();
+            }
+        }
+    }
+}
+
+fn protocol_modifiers(modifiers: Modifiers) -> ProtocolModifiers {
+    let mut result = ProtocolModifiers::empty();
+    if modifiers.contains(Modifiers::SHIFT) {
+        result.insert(ProtocolModifiers::Shift);
+    }
+    if modifiers.contains(Modifiers::CONTROL) {
+        result.insert(ProtocolModifiers::Ctrl);
+    }
+    if modifiers.contains(Modifiers::ALT) {
+        result.insert(ProtocolModifiers::Alt);
+    }
+    if modifiers.contains(Modifiers::META) {
+        result.insert(ProtocolModifiers::Super);
+    }
+    result
+}
+
+impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
+    fn event(
+        _: &mut Self,
+        _: &wl_registry::WlRegistry,
+        _: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, ()> for State {
+    fn event(
+        state: &mut Self,
+        seat: &wl_seat::WlSeat,
+        event: wl_seat::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_seat::Event::Capabilities {
+            capabilities: WEnum::Value(capabilities),
+        } = event
+            && capabilities.contains(wl_seat::Capability::Keyboard)
+            && state.keyboard.is_none()
+        {
+            state.keyboard = Some(seat.get_keyboard(qh, ()));
+        }
+    }
+}
+
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &wl_keyboard::WlKeyboard,
+        event: wl_keyboard::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_keyboard::Event::Keymap {
+            format: WEnum::Value(wl_keyboard::KeymapFormat::XkbV1),
+            fd,
+            size,
+        } = event
+            && let Some(keymap) = KeyboardMap::from_keymap(fd.into(), size)
+        {
+            state.update_keymap(keymap);
+        }
+    }
+}
+
+impl Dispatch<XxHotkeyManagerV1, ()> for State {
+    fn event(
+        _: &mut Self,
+        _: &XxHotkeyManagerV1,
+        _: <XxHotkeyManagerV1 as wayland_client::Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<XxHotkeyV1, Hotkey> for State {
+    fn event(
+        state: &mut Self,
+        proxy: &XxHotkeyV1,
+        event: xx_hotkey_v1::Event,
+        hotkey: &Hotkey,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            xx_hotkey_v1::Event::Bound => {
+                if let Some(promise) = state
+                    .bindings
+                    .get_mut(hotkey)
+                    .and_then(|binding| binding.pending.take())
+                {
+                    promise.set(Ok(()));
+                }
+            }
+            xx_hotkey_v1::Event::Denied { .. } => {
+                let is_initial_commit = state
+                    .bindings
+                    .get(hotkey)
+                    .is_some_and(|binding| binding.pending.is_some());
+                if is_initial_commit && let Some(mut binding) = state.bindings.remove(hotkey) {
+                    proxy.destroy();
+                    binding
+                        .pending
+                        .take()
+                        .unwrap()
+                        .set(Err(Error::WaylandHotkeyDenied.into()));
+                }
+            }
+            xx_hotkey_v1::Event::Revoked { .. } => {
+                state.bindings.remove(hotkey);
+                proxy.destroy();
+            }
+            xx_hotkey_v1::Event::Triggered { .. } => {
+                if let Some(binding) = state.bindings.get_mut(hotkey) {
+                    (binding.callback)();
+                }
+            }
+            xx_hotkey_v1::Event::Released { .. } => {}
+        }
+    }
+}
+
+pub fn new() -> Result<Hook> {
+    let connection = Connection::connect_to_env().map_err(|_| Error::NoWaylandConnection)?;
+    let (globals, mut event_queue) =
+        registry_queue_init::<State>(&connection).map_err(|_| Error::Wayland)?;
+    let qh = event_queue.handle();
+    let manager = globals
+        .bind::<XxHotkeyManagerV1, _, _>(&qh, 1..=1, ())
+        .map_err(|_| Error::WaylandHotkeyProtocolUnavailable)?;
+    let seat = globals
+        .bind::<wl_seat::WlSeat, _, _>(&qh, 1..=1, ())
+        .map_err(|_| Error::WaylandKeymapUnavailable)?;
+    let mut state = State {
+        manager,
+        _seat: Some(seat),
+        keyboard: None,
+        keymap: None,
+        bindings: HashMap::new(),
+    };
+
+    // The first trip receives seat capabilities and requests the keyboard;
+    // the second receives its initial keymap.
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|_| Error::Wayland)?;
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|_| Error::Wayland)?;
+    if state.keymap.is_none() {
+        return Err(Error::WaylandKeymapUnavailable.into());
+    }
+
+    let (sender, receiver) = crossbeam_channel::unbounded();
+    let mut poll = Poll::new().map_err(|_| Error::EPoll)?;
+    let fd = event_queue.as_fd().as_raw_fd();
+    poll.registry()
+        .register(&mut SourceFd(&fd), WAYLAND_TOKEN, Interest::READABLE)
+        .map_err(|_| Error::EPoll)?;
+    let waker = Waker::new(poll.registry(), PING_TOKEN).map_err(|_| Error::EPoll)?;
+    let thread_qh = qh;
+
+    let join_handle = thread::spawn(move || -> Result<()> {
+        let mut events = Events::with_capacity(16);
+
+        'event_loop: loop {
+            event_queue
+                .dispatch_pending(&mut state)
+                .map_err(|_| Error::Wayland)?;
+            event_queue.flush().map_err(|_| Error::Wayland)?;
+
+            let read_guard = loop {
+                if let Some(read_guard) = event_queue.prepare_read() {
+                    break read_guard;
+                }
+                event_queue
+                    .dispatch_pending(&mut state)
+                    .map_err(|_| Error::Wayland)?;
+            };
+
+            poll.poll(&mut events, None).map_err(|_| Error::EPoll)?;
+            let wayland_ready = events
+                .iter()
+                .any(|event| event.token() == WAYLAND_TOKEN && event.is_readable());
+            let messages_ready = events.iter().any(|event| event.token() == PING_TOKEN);
+
+            if wayland_ready {
+                read_guard.read().map_err(|_| Error::Wayland)?;
+                event_queue
+                    .dispatch_pending(&mut state)
+                    .map_err(|_| Error::Wayland)?;
+            } else {
+                drop(read_guard);
+            }
+
+            if messages_ready {
+                for message in receiver.try_iter() {
+                    match message {
+                        Message::Register(hotkey, callback, promise) => {
+                            state.register(&thread_qh, hotkey, callback, promise);
+                        }
+                        Message::Unregister(hotkey, promise) => {
+                            state.unregister(hotkey, promise);
+                        }
+                        Message::Resolve(key_code, promise) => {
+                            promise.set(
+                                state
+                                    .keymap
+                                    .as_ref()
+                                    .and_then(|keymap| keymap.resolve(key_code)),
+                            );
+                        }
+                        Message::End => break 'event_loop,
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    });
+
+    Ok(Hook {
+        sender,
+        waker,
+        join_handle: Some(join_handle),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_modifiers() {
+        let modifiers = protocol_modifiers(
+            Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::META,
+        );
+        assert!(modifiers.contains(ProtocolModifiers::Shift));
+        assert!(modifiers.contains(ProtocolModifiers::Ctrl));
+        assert!(modifiers.contains(ProtocolModifiers::Alt));
+        assert!(modifiers.contains(ProtocolModifiers::Super));
+    }
+}


### PR DESCRIPTION
Wayland currently has no stable protocol for applications to register global hotkeys. This implements the recently merged experimental xx-hotkey-v1 protocol and vendors its XML description.

The backend converts physical key codes through the compositor-provided XKB keymap, updates bindings when the keymap changes, and handles bindings being denied or revoked. The Linux backend selection prefers Wayland over X11 when consuming hotkeys is requested, while retaining evdev and X11 fallbacks for unsupported compositors.

This allows global hotkeys to work without direct input device access or XWayland once compositor support becomes available.

## Protocol Status

As of September 12, 2026, [xx-hotkey-v1](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/525) has been merged into the official wayland-protocols repository under `experimental/xx-hotkey`. It is therefore an accepted upstream experiment, but it is not yet a staging or stable protocol. The [protocol specification](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/experimental/xx-hotkey/xx-hotkey-v1.xml) explicitly warns that backwards-incompatible major versions are expected and discourages exposing it without an opt-in mechanism.

The latest released wayland-protocols version is still [1.49 from June 7, 2026](https://www.mail-archive.com/wayland-devel%40lists.freedesktop.org/msg44296.html), which predates the merge. This implementation therefore vendors the current upstream XML and does not depend on the distribution packaging it. The vendored XML is identical to the current upstream version.

## Compositor Support

| Compositor | Status | Protocol |
| --- | --- | --- |
| Hyprland | [Implemented and shipped](https://github.com/hyprwm/Hyprland/pull/15010), including in 0.56 | The older vendor-specific `vicinae-hotkey-v1` |
| niri | [Open, unmerged implementation](https://github.com/niri-wm/niri/pull/4145) | The older vendor-specific `vicinae-hotkey-v1` |
| Mutter / GNOME | No implementation found | None |
| KWin | No implementation found | None |
| Sway | No implementation found | None |
| COSMIC | No implementation found | None |

Hyprland's current implementation advertises `vicinae_hotkey_manager_v1`, while the official experimental protocol advertises `xx_hotkey_manager_v1`. These interface names are not wire-compatible, so this implementation cannot use Hyprland's existing support.

## Client Support

| Client | Status | Protocol |
| --- | --- | --- |
| Vicinae | Supports both variants on its current main branch | `xx-hotkey-v1` and `vicinae-hotkey-v1` |
| Ghostty | [Merged support](https://github.com/ghostty-org/ghostty/pull/13464) | The older vendor-specific `vicinae-hotkey-v1` |
| OBS Studio | [Open pull request](https://github.com/obsproject/obs-studio/pull/13661) | The official experimental `xx-hotkey-v1` |
| LiveSplit Core | This pull request | The official experimental `xx-hotkey-v1` |

## Why This Is a Draft

I could not find a released compositor that advertises the exact official `xx_hotkey_manager_v1` interface yet, so the implementation has only been tested for compilation and its internal key and modifier conversion, not end to end against a matching compositor.

Additionally, the protocol deliberately leaves trigger exclusivity to compositor policy. Before this is ready, we should decide how that maps to `ConsumePreference`, particularly `MustConsume`, and whether temporarily supporting the older `vicinae-hotkey-v1` interface is worthwhile for compatibility with Hyprland.
