### PR TITLE
Allow The i686 GNU Rust Toolchain In CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,6 +274,7 @@ jobs:
                     - label: Windows i686 gnu
                       target: i686-pc-windows-gnu
                       toolchain: stable-i686-pc-windows-gnu
+                      toolchain_args: --force-non-host
                       os: windows-latest
                       cross: skip
                       auto_splitting: skip
@@ -554,8 +555,8 @@ jobs:
               if: matrix.toolchain != '' && matrix.toolchain != 'stable'
               shell: bash
               run: |
-                  rustup toolchain install "${{ matrix.toolchain }}"
-                  rustup default "${{ matrix.toolchain }}"
+                  rustup toolchain install "${{ matrix.toolchain }}" ${{ matrix.toolchain_args }}
+                  rustup default "${{ matrix.toolchain }}" ${{ matrix.toolchain_args }}
 
             - name: Install Target
               if: matrix.install_target != ''


### PR DESCRIPTION
Rustup 1.29 rejects installing `stable-i686-pc-windows-gnu` because it does not match the runner's detected x86_64 MSVC host. This makes the Windows i686 GNU job fail before the build starts.

The i686 GNU host toolchain is intentional because, unlike `rustup target add`, it includes the `rust-mingw` component with the linker needed to build the shared library. Pass `--force-non-host` only for this matrix entry while leaving the native and x86_64 GNU toolchains unchanged.

Rustup introduced the host compatibility check in 1.28 and the Windows runner now ships 1.29. The shell is not involved in detecting the host: Git Bash still invokes the native Windows Rustup binary, which sees the runner's x86_64 MSVC default host.

Using only the preinstalled MSVC toolchain with an added i686 GNU target initially looked preferable and does compile the static library. Testing that approach in this PR showed that `rustup target add` installs `rust-std` but not the host-bound `rust-mingw` component, so the shared-library build then fails because `i686-w64-mingw32-gcc` is unavailable. Installing the requested GNU host toolchain remains the small, self-contained way to supply that linker; `--force-non-host` is Rustup's explicit opt-in for doing so.

The workflow already uses the runner-provided stable Rust for its native MSVC jobs and direct Rustup commands for additional toolchains. This change therefore does not add another setup action or reinstall Rust for those jobs.
